### PR TITLE
Feat/footer feedback buttons

### DIFF
--- a/HypeControl-TODO.md
+++ b/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
 **Updated:** 2026-03-12
-**Current Version:** 0.4.8
+**Current Version:** 0.4.9
 **Based On:** MTS-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -145,6 +145,12 @@ Both fixes: replace `container.innerHTML = ...` template with DOM construction (
 
 ## UX ENHANCEMENTS
 
+### ✅ Footer Feedback Buttons (COMPLETE — v0.4.9)
+
+Added 🐛 Bug and 💡 Ideas anchor links to the popup footer (left-aligned). Bug links to GitHub Issues new form; Ideas links to GitHub Discussions with the Ideas category pre-selected. Pure HTML/CSS change, no JS.
+
+---
+
 ### ✅ Settings UI Consolidation (COMPLETE — v0.4.8)
 
 All settings consolidated into a single 500×580px popup with right-side scroll-spy nav and pending-state save model. Options page retired.
@@ -267,4 +273,4 @@ Listed in order of complexity per the planning doc.
 
 ---
 
-_Last updated 2026-03-10 against the v0.4.5 codebase._
+_Last updated 2026-03-12 against the v0.4.9 codebase._

--- a/docs/superpowers/plans/2026-03-12-footer-feedback-buttons.md
+++ b/docs/superpowers/plans/2026-03-12-footer-feedback-buttons.md
@@ -1,0 +1,248 @@
+# Footer Feedback Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 🐛 Bug and 💡 Ideas anchor links to the popup footer, left-aligned, so users can report issues or submit feature suggestions directly from the extension.
+
+**Architecture:** Pure HTML/CSS change. Two `<a>` tags grouped in a `.footer-links` div are added to the existing footer. The Save button is repositioned with `position: absolute` to stay centered. No JS, no new settings, no storage changes.
+
+**Tech Stack:** HTML, CSS (CSS custom properties already defined in popup.css)
+
+---
+
+## Chunk 1: HTML + CSS + Version Bump
+
+**Spec:** `docs/superpowers/specs/2026-03-12-footer-feedback-buttons-design.md`
+
+### Task 1: Add footer links to popup.html
+
+**Files:**
+- Modify: `src/popup/popup.html:257-260`
+
+- [ ] **Step 1: Add `.footer-links` wrapper with two anchor tags inside the footer**
+
+Open `src/popup/popup.html`. Replace the existing footer block:
+
+```html
+  <footer class="hc-footer">
+    <button class="btn-save" id="btn-save">💾 Save Settings</button>
+    <span class="footer-version" id="footer-version"></span>
+  </footer>
+```
+
+With:
+
+```html
+  <footer class="hc-footer">
+    <div class="footer-links">
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
+    </div>
+    <button class="btn-save" id="btn-save">💾 Save Settings</button>
+    <span class="footer-version" id="footer-version"></span>
+  </footer>
+```
+
+- [ ] **Step 2: Verify the HTML is correct**
+
+Open `src/popup/popup.html` and confirm:
+- `.footer-links` div is the first child of `<footer>`
+- Both `<a>` tags have `target="_blank"` and `rel="noopener noreferrer"`
+- The Save button and version span are unchanged
+
+---
+
+### Task 2: Update footer CSS
+
+**Files:**
+- Modify: `src/popup/popup.css:99-114` (footer section), `src/popup/popup.css:247-258` (btn-save section)
+
+- [ ] **Step 1: Change `.hc-footer` justify-content and add a comment**
+
+In `src/popup/popup.css`, replace:
+
+```css
+.hc-footer {
+  flex-shrink: 0;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid var(--border-color);
+  position: relative;
+  padding: 0 12px;
+}
+```
+
+With:
+
+```css
+.hc-footer {
+  flex-shrink: 0;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  /* Only .footer-links is in normal flow; .btn-save and .footer-version are
+     position:absolute. space-between left-aligns the single in-flow child. */
+  justify-content: space-between;
+  border-top: 1px solid var(--border-color);
+  position: relative;
+  padding: 0 12px;
+}
+```
+
+- [ ] **Step 2: Add `.footer-links` and `.footer-link` styles after `.footer-version`**
+
+In `src/popup/popup.css`, find the `.footer-version` block (ends at line ~114). Immediately after it, add:
+
+```css
+.footer-links {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  z-index: 1;
+}
+.footer-link {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-decoration: none;
+  cursor: pointer;
+}
+.footer-link:hover {
+  text-decoration: underline;
+  color: var(--text-primary);
+}
+```
+
+- [ ] **Step 3: Absolutely position `.btn-save` so it stays centered**
+
+In `src/popup/popup.css`, replace only the `.btn-save` block (not the `.btn-save:hover` rule on the following line — leave that unchanged):
+
+```css
+.btn-save {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+```
+
+With:
+
+```css
+.btn-save {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 0;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+```
+
+The `.btn-save:hover { background: var(--accent-hover); }` rule on the next line is **not** part of this replacement — leave it as-is.
+
+- [ ] **Step 4: Verify CSS is correct**
+
+Open `src/popup/popup.css` and confirm:
+- `.hc-footer` has `justify-content: space-between`
+- `.footer-links`, `.footer-link`, `.footer-link:hover` blocks exist after `.footer-version`
+- `.btn-save` has `position: absolute; left: 50%; transform: translateX(-50%); z-index: 0;`
+
+---
+
+### Task 3: Bump version
+
+**Files:**
+- Modify: `manifest.json`
+- Modify: `package.json`
+
+- [ ] **Step 1: Bump version in manifest.json**
+
+In `manifest.json`, change:
+```json
+"version": "0.4.8"
+```
+To:
+```json
+"version": "0.4.9"
+```
+
+- [ ] **Step 2: Bump version in package.json**
+
+In `package.json`, change:
+```json
+"version": "0.4.8"
+```
+To:
+```json
+"version": "0.4.9"
+```
+
+---
+
+### Task 4: Build and verify
+
+- [ ] **Step 1: Run the build**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no errors, `dist/` is updated.
+
+> If the build fails for any reason, do NOT retry. Tell the user to run `npm run build` manually in their terminal.
+
+- [ ] **Step 2: Load the extension and verify visually**
+
+In Chrome:
+1. Go to `chrome://extensions/`
+2. Click "Reload" on HypeControl
+3. Open the popup
+4. Confirm footer shows: `🐛 Bug  💡 Ideas` on the left, `💾 Save Settings` centered, version string on the right
+5. Click 🐛 Bug — should open `https://github.com/Ktulue/HypeControl/issues/new` in a new tab
+6. Click 💡 Ideas — should open `https://github.com/Ktulue/HypeControl/discussions/new?category=ideas` in a new tab
+7. Confirm footer height has not changed (still compact, no wrapping)
+
+---
+
+### Task 5: Update docs and commit
+
+**Files:**
+- Modify: `HypeControl-TODO.md`
+
+- [ ] **Step 1: Create the feature branch before committing**
+
+```bash
+git checkout -b feat/footer-feedback-buttons
+```
+
+- [ ] **Step 2: Mark the feature complete in HypeControl-TODO.md**
+
+Add an entry under the appropriate section noting footer feedback buttons are complete in v0.4.9.
+
+- [ ] **Step 3: Commit everything**
+
+```bash
+git add src/popup/popup.html src/popup/popup.css manifest.json package.json HypeControl-TODO.md
+git commit -m "feat: add Bug Report and Ideas footer links (v0.4.9)"
+```
+
+- [ ] **Step 4: Push and open a PR**
+
+```bash
+git push -u origin feat/footer-feedback-buttons
+gh pr create --title "feat: add Bug Report and Ideas footer links" --body "Adds 🐛 Bug and 💡 Ideas anchor links to the popup footer. No JS changes."
+```

--- a/docs/superpowers/specs/2026-03-12-footer-feedback-buttons-design.md
+++ b/docs/superpowers/specs/2026-03-12-footer-feedback-buttons-design.md
@@ -1,0 +1,93 @@
+# Footer Feedback Buttons — Design Spec
+**Date:** 2026-03-12
+**Status:** Approved
+
+## Overview
+
+Add two small external-link buttons to the popup footer: **Bug Report** and **Ideas**. These give users a direct path to report issues or submit feature suggestions on GitHub without leaving the extension.
+
+## Layout
+
+The footer currently has `💾 Save Settings` centered and a version string absolutely positioned to the right. The new layout:
+
+```
+[ 🐛 Bug  💡 Ideas ]       [ 💾 Save Settings ]       [ v0.4.8 ]
+  left-aligned, small            centered               right, muted
+```
+
+- Footer height stays at **48px** — no change.
+- `justify-content` changes from `center` to `space-between`.
+- Save is re-centered using `position: absolute; left: 50%; transform: translateX(-50%)`.
+- Version string stays `position: absolute; right: 12px`.
+
+## Components
+
+### HTML (`popup.html`)
+
+A `<div class="footer-links">` wrapper is added to the left of the footer containing two `<a>` tags:
+
+```html
+<footer class="hc-footer">
+  <div class="footer-links">
+    <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
+    <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
+  </div>
+  <button class="btn-save" id="btn-save">💾 Save Settings</button>
+  <span class="footer-version" id="footer-version"></span>
+</footer>
+```
+
+### CSS (`popup.css`)
+
+```css
+/* Footer layout update */
+.hc-footer {
+  justify-content: space-between; /* was: center */
+}
+
+/* Save re-centered absolutely */
+.btn-save {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+/* Feedback link group */
+.footer-links {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  z-index: 1; /* sits above the absolute-positioned save button's hit area */
+}
+
+.footer-link {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.footer-link:hover {
+  text-decoration: underline;
+}
+```
+
+### JS (`popup.ts`)
+
+No changes required. The links are plain anchor tags with no JS interaction.
+
+## URLs
+
+| Button | Destination |
+|--------|-------------|
+| 🐛 Bug | `https://github.com/Ktulue/HypeControl/issues/new` |
+| 💡 Ideas | `https://github.com/Ktulue/HypeControl/discussions/new?category=ideas` |
+
+Both open in a new tab with `rel="noopener noreferrer"` for security.
+
+## Scope
+
+- **In scope:** `popup.html`, `popup.css`
+- **Out of scope:** `popup.ts`, any other files
+- **No new settings, storage, or migration needed**
+- **Version bump:** patch (0.4.8 → 0.4.9) after implementation

--- a/docs/superpowers/specs/2026-03-12-footer-feedback-buttons-design.md
+++ b/docs/superpowers/specs/2026-03-12-footer-feedback-buttons-design.md
@@ -40,7 +40,9 @@ A `<div class="footer-links">` wrapper is added to the left of the footer contai
 ### CSS (`popup.css`)
 
 ```css
-/* Footer layout update */
+/* Footer layout update.
+   Only .footer-links is in normal flow — .btn-save and .footer-version are
+   both position:absolute. space-between left-aligns the single in-flow child. */
 .hc-footer {
   justify-content: space-between; /* was: center */
 }
@@ -50,6 +52,7 @@ A `<div class="footer-links">` wrapper is added to the left of the footer contai
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  z-index: 0; /* footer-links (z-index:1) sits above this */
 }
 
 /* Feedback link group */
@@ -69,6 +72,7 @@ A `<div class="footer-links">` wrapper is added to the left of the footer contai
 
 .footer-link:hover {
   text-decoration: underline;
+  color: var(--text-primary);
 }
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -101,7 +101,9 @@ body {
   height: 48px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  /* Only .footer-links is in normal flow; .btn-save and .footer-version are
+     position:absolute. space-between left-aligns the single in-flow child. */
+  justify-content: space-between;
   border-top: 1px solid var(--border-color);
   position: relative;
   padding: 0 12px;
@@ -111,6 +113,21 @@ body {
   right: 12px;
   font-size: 11px;
   color: var(--text-muted);
+}
+.footer-links {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.footer-link {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-decoration: none;
+  cursor: pointer;
+}
+.footer-link:hover {
+  text-decoration: underline;
+  color: var(--text-primary);
 }
 
 /* ─── Sections ───────────────────────────────────────────── */
@@ -245,6 +262,10 @@ body {
 
 /* ─── Buttons ────────────────────────────────────────────── */
 .btn-save {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 0;
   background: var(--accent);
   color: white;
   border: none;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -255,6 +255,10 @@
   </div><!-- /.hc-body -->
 
   <footer class="hc-footer">
+    <div class="footer-links">
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
+    </div>
     <button class="btn-save" id="btn-save">💾 Save Settings</button>
     <span class="footer-version" id="footer-version"></span>
   </footer>


### PR DESCRIPTION
  ## Summary
  - Adds 🐛 Bug and 💡 Ideas anchor links to the popup footer, left-aligned
  - Bug links to the GitHub new issue form
  - Ideas links to GitHub Discussions with Ideas category pre-selected
  - Both open in a new tab with rel="noopener noreferrer"
  - Save Settings button re-centered via position:absolute, footer height unchanged at 48px
  - No JS changes — pure HTML/CSS

  ## Test plan
  - [x] Reload extension in chrome://extensions/
  - [x] Open popup — footer shows 🐛 Bug  💡 Ideas left, 💾 Save Settings centered, version right
  - [x] Click 🐛 Bug — opens GitHub new issue form in new tab
  - [x] Click 💡 Ideas — opens GitHub Discussions new post with Ideas category in new tab
  - [x] Footer height unchanged (no wrapping)