### PR TITLE
feat: overlay icon, issue templates, friction modal brand harmonization (v0.4.20)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**Steps to reproduce**
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots.
+
+**Environment**
+- OS: [e.g. Windows 11, macOS 15]
+- Browser: [e.g. Chrome 124, Firefox 128]
+- Extension version: [e.g. v0.4.14]
+
+**Additional context**
+Any other details.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+**Describe the feature**
+A clear description of what you'd like.
+
+**Use case**
+Why is this needed? What problem does it solve?
+
+**Alternatives considered**
+Any other approaches you've thought about.
+
+**Additional context**
+Any other details, mockups, or references.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ HypeControl/
 ## Known Issues
 
 - **Bits Combo module** — The animated Bits Combo (timer/counter) that Twitch displays during cheering cannot currently be intercepted. Hype Control can intercept the "Get Bits" button in the top navigation bar, but the Combo module uses a non-standard rendering path that doesn't expose a clickable element Hype Control can hook.
+- **Emoji input (Windows)** — The Windows emoji picker (Win + .) allows inserting non-emoji characters (Latin symbols, special characters) into the emoji field. GIF selection is not supported. For best results, stick to standard emoji from the Smileys or Symbols categories.
+- **Emoji input (macOS)** — The macOS Character Viewer works as expected for standard emoji. GIF insertion is not supported.
 
 ## Contributing
 

--- a/docs/superpowers/plans/2026-03-13-friction-modal-brand-harmonization.md
+++ b/docs/superpowers/plans/2026-03-13-friction-modal-brand-harmonization.md
@@ -1,0 +1,268 @@
+# Friction Modal Brand Harmonization Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the friction overlay modals (content script) visually cohesive with the popup and logs page — same font (Space Grotesk), same border radius/color tokens, flat header, aligned button sizing, no rogue monospace.
+
+**Architecture:** All changes are in two files: `manifest.json` (expose font assets to content script context) and `src/content/styles.css` (font declarations + token/style fixes). No TypeScript logic changes. No new tests.
+
+**Tech Stack:** Chrome MV3, TypeScript, webpack, CSS custom properties
+
+**Spec:** `docs/superpowers/specs/2026-03-13-friction-modal-brand-harmonization-design.md`
+
+---
+
+## Pre-flight
+
+Before starting, confirm you are on branch `feat/overlay-icon-issue-templates`:
+```bash
+git branch --show-current
+```
+Expected: `feat/overlay-icon-issue-templates`
+
+Note: The popup header icon change (spec Section 6) is **already implemented** in the working tree — `popup.html` and `popup.css` are modified. Do NOT undo those changes.
+
+---
+
+## Chunk 1: Manifest + Font Loading
+
+### Task 1: Extend `web_accessible_resources` with font files
+
+**Files:**
+- Modify: `manifest.json`
+
+The existing `web_accessible_resources` array has one entry with `HC_icon_48px.png`. Add the four Space Grotesk woff2 filenames to that same entry's `resources` array. Do NOT create a second entry.
+
+- [ ] **Step 1: Edit manifest.json**
+
+Find the `web_accessible_resources` block (currently):
+```json
+"web_accessible_resources": [
+  {
+    "resources": ["assets/icons/ChromeWebStore/HC_icon_48px.png"],
+    "matches": ["https://*.twitch.tv/*"]
+  }
+],
+```
+
+Replace with:
+```json
+"web_accessible_resources": [
+  {
+    "resources": [
+      "assets/icons/ChromeWebStore/HC_icon_48px.png",
+      "assets/fonts/SpaceGrotesk-Regular.woff2",
+      "assets/fonts/SpaceGrotesk-Medium.woff2",
+      "assets/fonts/SpaceGrotesk-SemiBold.woff2",
+      "assets/fonts/SpaceGrotesk-Bold.woff2"
+    ],
+    "matches": ["https://*.twitch.tv/*"]
+  }
+],
+```
+
+- [ ] **Step 2: Verify font files exist in source**
+
+```bash
+ls assets/fonts/
+```
+Expected output includes all four: `SpaceGrotesk-Regular.woff2`, `SpaceGrotesk-Medium.woff2`, `SpaceGrotesk-SemiBold.woff2`, `SpaceGrotesk-Bold.woff2`
+
+- [ ] **Step 3: Verify webpack copies fonts to dist**
+
+```bash
+ls dist/assets/fonts/
+```
+Expected: same four files. If the directory doesn't exist or files are missing, check `webpack.config.js` for a `CopyPlugin` entry covering `assets/fonts/`. The fonts must be in `dist/` at runtime or `web_accessible_resources` declarations will point to nothing.
+
+---
+
+### Task 2: Add `@font-face` declarations to `styles.css`
+
+**Files:**
+- Modify: `src/content/styles.css`
+
+**Critical:** Content script CSS `url()` paths resolve against the **page origin** (twitch.tv), not the extension root. You MUST use the `chrome-extension://__MSG_@@extension_id__/` prefix. Chrome substitutes the real extension ID at injection time for CSS files declared in `content_scripts[].css`.
+
+- [ ] **Step 1: Add @font-face blocks at the very top of styles.css** (before the `:root` block)
+
+```css
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-SemiBold.woff2') format('woff2');
+  font-weight: 600;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-display: swap;
+}
+```
+
+- [ ] **Step 2: Build and verify no errors**
+
+```bash
+npm run build
+```
+Expected: `webpack compiled successfully` — zero TypeScript errors, zero warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add manifest.json src/content/styles.css
+git commit -m "feat: load Space Grotesk in content script via web_accessible_resources"
+```
+
+---
+
+## Chunk 2: Token + Style Alignment
+
+### Task 3: Align CSS tokens
+
+**Files:**
+- Modify: `src/content/styles.css` — `:root` block
+
+- [ ] **Step 1: Update --hc-radius and --hc-border in :root**
+
+Find in the `:root` block:
+```css
+--hc-radius: 8px;
+```
+Change to:
+```css
+--hc-radius: 6px;
+```
+
+Find:
+```css
+--hc-border: #3d3d42;
+```
+Change to:
+```css
+--hc-border: #2d2d35;
+```
+
+---
+
+### Task 4: Flatten the modal header
+
+**Files:**
+- Modify: `src/content/styles.css` — `.hc-header`, `.hc-title`
+
+- [ ] **Step 1: Update .hc-header**
+
+Find:
+```css
+.hc-header {
+  background: linear-gradient(135deg, var(--hc-primary) 0%, var(--hc-primary-dark) 100%);
+```
+Replace the `background` line with:
+```css
+  background: var(--hc-bg-card);
+  border-bottom: 1px solid var(--hc-border);
+```
+Leave all other `.hc-header` properties (padding, display, flex, gap) unchanged.
+
+- [ ] **Step 2: Update .hc-title**
+
+Find the `.hc-title` rule. Remove these two properties:
+```css
+  text-transform: uppercase;
+  letter-spacing: 1px;
+```
+Change `color: white` to:
+```css
+  color: var(--hc-text);
+```
+Change `font-size: 18px` to:
+```css
+  font-size: 15px;
+```
+
+---
+
+### Task 5: Align button sizing
+
+**Files:**
+- Modify: `src/content/styles.css` — `.hc-btn`
+
+- [ ] **Step 1: Update .hc-btn**
+
+Find the `.hc-btn` base rule. Make these changes:
+- `padding: 12px 20px` → `padding: 8px 14px`
+- `font-size: 14px` → `font-size: 12px`
+- Remove `text-transform: uppercase`
+- Remove `letter-spacing: 0.5px`
+
+Leave `font-weight`, `border-radius`, `cursor`, `transition`, and all other properties unchanged.
+
+---
+
+### Task 6: Fix type-to-confirm phrase font
+
+**Files:**
+- Modify: `src/content/styles.css` — `.hc-confirm-phrase`
+
+- [ ] **Step 1: Update .hc-confirm-phrase**
+
+Find the `.hc-confirm-phrase` rule. Make these changes:
+- `font-family: 'Courier New', Courier, monospace` → `font-family: var(--hc-font)`
+- Remove `letter-spacing: 0.5px`
+
+Note: `.hc-confirm-input` (the actual text input below the phrase) uses `font-family: inherit` — leave it unchanged.
+
+---
+
+### Task 7: Build, version bump, commit
+
+- [ ] **Step 1: Build**
+
+```bash
+npm run build
+```
+Expected: `webpack compiled successfully`
+
+- [ ] **Step 2: Bump patch version**
+
+In `manifest.json`: `"version": "0.4.16"` → `"0.4.17"`
+In `package.json`: `"version": "0.4.16"` → `"0.4.17"`
+
+- [ ] **Step 3: Build again with new version**
+
+```bash
+npm run build
+```
+Expected: `webpack compiled successfully`
+
+- [ ] **Step 4: Commit everything**
+
+```bash
+git add manifest.json package.json package-lock.json src/content/styles.css
+git commit -m "feat: harmonize friction modal brand — Space Grotesk, flat header, aligned tokens (v0.4.17)"
+```
+
+---
+
+## Validation (manual — after reload in Chrome)
+
+- [ ] Reload the extension in `chrome://extensions`
+- [ ] Open a Twitch page and trigger a friction modal (use `window.HC.testOverlay()` in DevTools console if available)
+- [ ] Verify Space Grotesk renders in the modal (not system sans-serif — check DevTools Computed tab, `font-family` on `.hc-modal`)
+- [ ] Verify modal header is flat (no gradient), normal-case title, same dark background as the modal body
+- [ ] Verify buttons are compact (matching popup size), no uppercase text
+- [ ] Trigger the type-to-confirm step — verify the phrase display uses Space Grotesk, not Courier New
+- [ ] Toggle Settings → Theme → Light — verify modal uses `#7c3aed` accent in light mode

--- a/docs/superpowers/specs/2026-03-13-friction-modal-brand-harmonization-design.md
+++ b/docs/superpowers/specs/2026-03-13-friction-modal-brand-harmonization-design.md
@@ -1,0 +1,191 @@
+# Friction Modal Brand Harmonization — Design Spec
+**Date:** 2026-03-13
+**Branch:** `feat/overlay-icon-issue-templates` (extend existing branch)
+**Version target:** 0.4.16
+**Status:** Approved
+
+---
+
+## Overview
+
+The friction modal overlays (rendered by the content script) were not fully updated during the UI polish & rebrand pass. The Impeccable audit spec explicitly deferred Space Grotesk font loading in the content script due to `web_accessible_resources` complexity. That blocker is now removed — the manifest already has a `web_accessible_resources` entry (added for the logo icon). This pass completes the brand harmonization so the friction modals are visually cohesive with the popup and logs page.
+
+**Purple accent values (already in styles.css, for reference):**
+- Dark: `--hc-primary: #9147ff`, `--hc-primary-dark: #772ce8`, `--hc-primary-rgb: 145, 71, 255`
+- Light: `--hc-primary: #7c3aed`, `--hc-primary-dark: #6d28d9`, `--hc-primary-rgb: 124, 58, 237`
+
+---
+
+## Changes
+
+### 1. Space Grotesk font loading (`manifest.json` + `styles.css`)
+
+**`manifest.json`** — Add font filenames to the **existing** `web_accessible_resources` entry's `resources` array (do not append a new entry):
+
+```json
+{
+  "resources": [
+    "assets/icons/ChromeWebStore/HC_icon_48px.png",
+    "assets/fonts/SpaceGrotesk-Regular.woff2",
+    "assets/fonts/SpaceGrotesk-Medium.woff2",
+    "assets/fonts/SpaceGrotesk-SemiBold.woff2",
+    "assets/fonts/SpaceGrotesk-Bold.woff2"
+  ],
+  "matches": ["https://*.twitch.tv/*"]
+}
+```
+
+**`styles.css`** — Add `@font-face` declarations at the top of the file.
+
+**Critical path note:** Content script CSS `url()` paths are resolved relative to the **page origin** (e.g. `https://www.twitch.tv/`), not the extension root. The relative paths used in `popup.css` (`url('assets/fonts/...')`) work there because popup pages are served from `chrome-extension://<id>/`. They will silently fail in `styles.css`. The correct form for content script CSS is the absolute extension URL using Chrome's built-in `__MSG_@@extension_id__` substitution token, which Chrome replaces at injection time:
+
+```css
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-SemiBold.woff2') format('woff2');
+  font-weight: 600;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-display: swap;
+}
+```
+
+---
+
+### 2. Token alignment (`styles.css`)
+
+Two minor fixes to match popup.css values:
+
+| Token | Current | Target |
+|-------|---------|--------|
+| `--hc-radius` | `8px` | `6px` |
+| `--hc-border` | `#3d3d42` | `#2d2d35` |
+
+---
+
+### 3. Header flattening (`styles.css`)
+
+**Current:**
+```css
+.hc-header {
+  background: linear-gradient(135deg, var(--hc-primary) 0%, var(--hc-primary-dark) 100%);
+  padding: 16px 20px;
+}
+.hc-title {
+  color: white;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+```
+
+**Target:**
+```css
+.hc-header {
+  background: var(--hc-bg-card);
+  border-bottom: 1px solid var(--hc-border);
+  padding: 16px 20px;
+}
+.hc-title {
+  color: var(--hc-text);
+  font-size: 15px;
+  font-weight: 700;
+}
+```
+
+Removes gradient, uppercase, and letter-spacing. Matches popup header's flat, quiet style. The header's visual identity is anchored by the HC logo PNG (32px, injected via `chrome.runtime.getURL()`) which is already in place.
+
+---
+
+### 4. Button alignment (`styles.css`)
+
+**Current:**
+```css
+.hc-btn {
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+```
+
+**Target:**
+```css
+.hc-btn {
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 600;
+}
+```
+
+Removes uppercase and letter-spacing. Aligns size with popup button conventions.
+
+---
+
+### 5. Type-to-confirm phrase display (`styles.css`)
+
+The `.hc-confirm-phrase` selector (the badge that displays the phrase to type) has `font-family: 'Courier New', Courier, monospace` and `letter-spacing: 0.5px`. With Space Grotesk now loaded, both should be updated:
+
+- `font-family: 'Courier New', Courier, monospace` → `font-family: var(--hc-font)`
+- Remove `letter-spacing: 0.5px` (was compensating for monospace character spacing)
+
+Note: `.hc-confirm-input` (the actual text input) already uses `font-family: inherit` — no change needed there.
+
+---
+
+### 6. Popup header icon (`popup.html` + `popup.css`)
+
+Add the HC logo to the popup header alongside "Hype Control" — matching the logs page pattern.
+
+**`popup.html`** — Add `<img>` to `.hc-title`:
+```html
+<h1 class="hc-title">
+  <img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="20" height="20" alt="">
+  Hype Control
+</h1>
+```
+
+**`popup.css`** — Add flex layout to `.hc-title` so icon and text align:
+```css
+.hc-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+```
+
+This change is already implemented. No `web_accessible_resources` changes needed — popup pages resolve asset URLs relative to the extension root natively.
+
+---
+
+## Out of Scope
+
+- Merging `--hc-*` and `--*` CSS variable namespaces — they are semantically aligned; a structural merge is unnecessary
+- Any changes to modal behavior, copy, or friction logic
+- New tests
+
+---
+
+## Validation
+
+- `npm run build` — zero errors
+- Reload extension in Chrome, trigger a friction modal on Twitch — verify Space Grotesk renders (not system sans-serif), header is flat with the HC logo PNG visible at top, buttons are correctly sized without uppercase
+- Verify light mode by toggling theme in Settings — modal should use `#7c3aed` accent throughout

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",
@@ -25,6 +25,18 @@
       "js": ["content.js"],
       "css": ["content.css"],
       "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "assets/icons/ChromeWebStore/HC_icon_48px.png",
+        "assets/fonts/SpaceGrotesk-Regular.woff2",
+        "assets/fonts/SpaceGrotesk-Medium.woff2",
+        "assets/fonts/SpaceGrotesk-SemiBold.woff2",
+        "assets/fonts/SpaceGrotesk-Bold.woff2"
+      ],
+      "matches": ["https://*.twitch.tv/*"]
     }
   ],
   "action": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.15",
+  "version": "0.4.17",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -538,7 +538,7 @@ async function showComparisonStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">${item.emoji}</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">STEP ${stepNumber} OF ${totalSteps}</h2>
       </div>
       <div class="hc-content">
@@ -593,8 +593,8 @@ function showCooldownBlock(remainingMs: number): void {
   overlay.setAttribute('aria-describedby', 'hc-overlay-desc');
   overlay.innerHTML = `
     <div class="hc-modal hc-cooldown-modal">
-      <div class="hc-header" style="background: linear-gradient(135deg, var(--hc-danger), var(--hc-danger-dark));">
-        <span class="hc-icon">\u231B</span>
+      <div class="hc-header">
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">COOLDOWN ACTIVE</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -668,7 +668,7 @@ async function showDelayTimerStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">⏱️</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">Last Chance to Reconsider</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -774,7 +774,7 @@ async function showReasonSelectionStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">🤔</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">Why are you buying this?</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc">
@@ -882,7 +882,7 @@ async function showFrictionCooldownStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">⏳</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">Take a moment to reflect...</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -985,7 +985,7 @@ async function showTypeToConfirmStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">⌨️</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">Type to confirm</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -1131,7 +1131,7 @@ async function showMathChallengeStep(
   const renderContent = () => `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">🧮</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title" id="hc-overlay-heading">Solve to proceed</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -472,7 +472,7 @@ async function showMainOverlay(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <span class="hc-icon">\u{1F6E1}\uFE0F</span>
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
         <h2 class="hc-title">Hype Control</h2>
       </div>
       <div class="hc-content">

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -538,7 +538,7 @@ async function showComparisonStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">${item.emoji}</span>
         <h2 class="hc-title" id="hc-overlay-heading">STEP ${stepNumber} OF ${totalSteps}</h2>
       </div>
       <div class="hc-content">
@@ -594,7 +594,7 @@ function showCooldownBlock(remainingMs: number): void {
   overlay.innerHTML = `
     <div class="hc-modal hc-cooldown-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">\u231B</span>
         <h2 class="hc-title" id="hc-overlay-heading">COOLDOWN ACTIVE</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -668,7 +668,7 @@ async function showDelayTimerStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">⏱️</span>
         <h2 class="hc-title" id="hc-overlay-heading">Last Chance to Reconsider</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -774,7 +774,7 @@ async function showReasonSelectionStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">🤔</span>
         <h2 class="hc-title" id="hc-overlay-heading">Why are you buying this?</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc">
@@ -882,7 +882,7 @@ async function showFrictionCooldownStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">⏳</span>
         <h2 class="hc-title" id="hc-overlay-heading">Take a moment to reflect...</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -985,7 +985,7 @@ async function showTypeToConfirmStep(
   overlay.innerHTML = `
     <div class="hc-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">⌨️</span>
         <h2 class="hc-title" id="hc-overlay-heading">Type to confirm</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
@@ -1131,7 +1131,7 @@ async function showMathChallengeStep(
   const renderContent = () => `
     <div class="hc-modal">
       <div class="hc-header">
-        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <span class="hc-icon">🧮</span>
         <h2 class="hc-title" id="hc-overlay-heading">Solve to proceed</h2>
       </div>
       <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -42,10 +42,10 @@
   --hc-bg-card: #1f1f23;
   --hc-text: #efeff1;
   --hc-text-muted: #adadb8;
-  --hc-border: #3d3d42;
+  --hc-border: #2d2d35;
   --hc-overlay-bg: rgba(0, 0, 0, 0.85);
   --hc-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-  --hc-radius: 8px;
+  --hc-radius: 6px;
   --hc-font: 'Space Grotesk', sans-serif;
   --hc-primary-rgb: 145, 71, 255;
   --hc-danger-rgb: 233, 25, 22;
@@ -131,7 +131,8 @@
 
 /* Header section */
 .hc-header {
-  background: linear-gradient(135deg, var(--hc-primary) 0%, var(--hc-primary-dark) 100%);
+  background: var(--hc-bg-card);
+  border-bottom: 1px solid var(--hc-border);
   padding: 16px 20px;
   display: flex;
   align-items: center;
@@ -146,12 +147,10 @@
 }
 
 .hc-title {
-  color: white;
-  font-size: 18px;
+  color: var(--hc-text);
+  font-size: 15px;
   font-weight: 700;
   margin: 0;
-  letter-spacing: 1px;
-  text-transform: uppercase;
 }
 
 /* Content section */
@@ -324,15 +323,13 @@
 
 .hc-btn {
   flex: 1;
-  padding: 12px 20px;
-  font-size: 14px;
+  padding: 8px 14px;
+  font-size: 12px;
   font-weight: 600;
   border: none;
   border-radius: var(--hc-radius);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
 .hc-btn:focus {
@@ -677,7 +674,7 @@
 /* Type-to-confirm step */
 .hc-confirm-phrase {
   display: inline-block;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--hc-font);
   font-size: 16px;
   font-weight: 700;
   color: var(--hc-primary);
@@ -686,7 +683,6 @@
   border-radius: 4px;
   padding: 6px 14px;
   margin: 12px 0 16px;
-  letter-spacing: 0.5px;
   user-select: all;
 }
 

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -5,6 +5,32 @@
  * Designed to be visible and intentional, not easily dismissed
  */
 
+/* Font Loading */
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-SemiBold.woff2') format('woff2');
+  font-weight: 600;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('chrome-extension://__MSG_@@extension_id__/assets/fonts/SpaceGrotesk-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-display: swap;
+}
+
 /* CSS Variables */
 :root {
   --hc-primary: #9147ff;
@@ -116,6 +142,7 @@
 .hc-icon {
   font-size: 28px;
   line-height: 1;
+  display: block;
 }
 
 .hc-title {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -116,6 +116,8 @@
   margin: 20px;
   animation: hc-slideIn 0.3s ease-out;
   overflow: hidden;
+  font-family: var(--hc-font);
+  font-size: 13px;
 }
 
 @keyframes hc-slideIn {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -54,6 +54,7 @@
   --hc-warning-rgb: 249, 115, 22;
   --hc-primary-light: rgba(145, 71, 255, 0.12);
   --hc-progress-bg: #2a2a2e;
+  --hc-primary-text: #bf94ff;
 }
 
 /* Light mode overrides */
@@ -71,6 +72,7 @@
   --hc-success: #16A34A;
   --hc-warning: #EA580C;
   --hc-primary-light: rgba(124, 58, 237, 0.12);
+  --hc-primary-text: #7c3aed;
 }
 
 .hc-light .hc-whitelist-note {
@@ -220,7 +222,7 @@
 .hc-cost-hours {
   margin-top: 8px;
   font-size: 15px;
-  color: var(--hc-primary);
+  color: var(--hc-primary-text);
 }
 
 .hc-cost-hours strong {
@@ -246,7 +248,7 @@
 
 .hc-comparison-label {
   font-size: 18px;
-  color: var(--hc-primary);
+  color: var(--hc-primary-text);
   margin: 4px 0 0 0;
   font-weight: 600;
   text-transform: lowercase;
@@ -383,7 +385,7 @@
 }
 
 .hc-nudge-comparison {
-  color: var(--hc-primary);
+  color: var(--hc-primary-text);
   font-size: 14px;
   margin: 0 0 16px 0;
 }
@@ -498,7 +500,7 @@
   background: rgba(var(--hc-primary-rgb), 0.15);
   border: 1px solid rgba(var(--hc-primary-rgb), 0.3);
   border-radius: 6px;
-  color: var(--hc-primary);
+  color: var(--hc-primary-text);
   font-size: 13px;
   padding: 8px 12px;
   margin-bottom: 16px;
@@ -679,7 +681,7 @@
   font-family: var(--hc-font);
   font-size: 16px;
   font-weight: 700;
-  color: var(--hc-primary);
+  color: var(--hc-primary-text);
   background: rgba(var(--hc-primary-rgb), 0.12);
   border: 1px solid rgba(var(--hc-primary-rgb), 0.3);
   border-radius: 4px;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -90,6 +90,9 @@ body {
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: 0.02em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* ─── Body row (content + nav) ───────────────────────────── */
@@ -472,6 +475,13 @@ body {
   color: var(--text-muted);
   margin-top: 2px;
   margin-bottom: 4px;
+}
+.hint-link {
+  color: var(--text-muted);
+  text-decoration: underline;
+}
+.hint-link:hover {
+  color: var(--accent);
 }
 .hc-hint kbd {
   font-family: var(--font);

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -42,6 +42,7 @@
   --success-rgb: 34, 197, 94;
   --radius: 6px;
   --font: 'Space Grotesk', sans-serif;
+  --accent-text: #bf94ff;
 }
 
 /* ─── Light mode overrides ───────────────────────────────── */
@@ -55,6 +56,7 @@
   --text-muted:    #71717a;
   --accent: #7c3aed;
   --accent-hover: #6d28d9;
+  --accent-text: #7c3aed;
   --success: #16A34A;
   --accent-rgb: 124, 58, 237;
   --success-rgb: 22, 163, 74;
@@ -138,7 +140,7 @@ body {
 }
 .nav-label:hover { background: var(--bg-secondary); color: var(--text-secondary); }
 .nav-label.active {
-  color: var(--accent);
+  color: var(--accent-text);
   background: rgba(var(--accent-rgb), 0.1);
   font-weight: 600;
 }
@@ -395,7 +397,7 @@ body {
 }
 .stat-tile--saved .stat-value  { color: var(--success); }
 .stat-tile--rate  .stat-value  { color: #f59e0b; }
-.stat-tile--step  .stat-value  { color: var(--accent); }
+.stat-tile--step  .stat-value  { color: var(--accent-text); }
 /* stat-tile--blocked intentionally has no override — inherits var(--text-primary) from .stat-value default */
 
 /* ─── Override status ────────────────────────────────────── */
@@ -481,7 +483,7 @@ body {
   text-decoration: underline;
 }
 .hint-link:hover {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 .hc-hint kbd {
   font-family: var(--font);
@@ -603,7 +605,7 @@ body {
 }
 .credits-link {
   font-size: 12px;
-  color: var(--accent);
+  color: var(--accent-text);
   text-decoration: none;
 }
 .credits-link:hover {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <header class="hc-header">
-    <h1 class="hc-title">Hype Control</h1>
+    <h1 class="hc-title"><img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="20" height="20" alt=""> Hype Control</h1>
   </header>
 
   <div class="hc-body">
@@ -129,6 +129,7 @@
             <input type="text" id="sp-emoji" maxlength="4" class="hc-input hc-input--sm" placeholder="🛒" />
           </div>
           <p class="hc-hint">Windows: <kbd>Win + .</kbd>&nbsp;&nbsp;Mac: <kbd>Ctrl + ⌘ + Space</kbd></p>
+          <p class="hc-hint hc-hint--issues">⚠️ Some emoji features vary by OS — <a href="https://github.com/Ktulue/HypeControl#known-issues" target="_blank" rel="noopener" class="hint-link">known issues</a></p>
           <div class="hc-row">
             <label class="hc-label" for="sp-name">Name</label>
             <input type="text" id="sp-name" class="hc-input" />


### PR DESCRIPTION
## Summary

- **HC logo in overlay header** — replaced emoji with HC icon PNG in the main friction modal header; all friction step modals retain their semantic emoji (⏱️ 🤔 ⏳ ⌨️ 🧮)
- **GitHub issue templates** — added bug report and feature request templates; added emoji input known issues note to README
- **Friction modal brand harmonization** — loaded Space Grotesk via \`web_accessible_resources\` + \`__MSG_@@extension_id__\` URLs; aligned all CSS tokens (radius, border, colors) with popup; flattened modal header (no gradient); aligned button sizing; fixed confirm-phrase font (Courier New → Space Grotesk); added \`font-family\` base to \`.hc-modal\` so Space Grotesk cascades to all modal text
- **Dark mode accent text fix** — added \`--accent-text: #bf94ff\` / \`--hc-primary-text: #bf94ff\` so accent color used as text renders legibly on dark backgrounds (same hex reads too dim as text vs. filled button); light mode unaffected

## Test Plan

- [ ] Reload extension + hard-refresh Twitch tab
- [ ] Trigger friction modal — verify HC logo PNG appears in header, Space Grotesk renders (check DevTools Computed → font-family on \`.hc-modal\`)
- [ ] Step through all friction steps — verify each has its emoji icon, flat header, compact buttons, no uppercase
- [ ] Type-to-confirm step — verify phrase uses Space Grotesk, not Courier New
- [ ] Toggle dark/light mode — verify accent text is legible in both; purple fill buttons match popup
- [ ] Verify popup Credits section, nav active state, and hint links all render with lighter purple text in dark mode
- [ ] Check GitHub issue templates appear at github.com/Ktulue/HypeControl/issues/new/choose

🤖 Generated with [Claude Code](https://claude.com/claude-code)