### PR TITLE
feat: interactive onboarding tour (v0.4.21)

### DIFF
--- a/HypeControl-TODO.md
+++ b/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-03-13
-**Current Version:** 0.4.14
+**Updated:** 2026-03-14
+**Current Version:** 0.4.21
 **Based On:** MTS-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -22,7 +22,7 @@
 | Add-on 4 — Custom Comparison Items       | ✅ Complete       |
 | Add-on 2 — Spending History View         | 🔲 Not Started    |
 | Add-on 3 — Weekly/Monthly Limits         | 🔲 Not Started    |
-| Interactive Onboarding Tour              | 🔲 Not Started    |
+| Interactive Onboarding Tour              | ✅ Complete        |
 | Firefox AMO Port                         | 🔲 Not Started    |
 | Add-ons 6–12 — Future Enhancements       | ⏸️ Deferred       |
 
@@ -293,4 +293,4 @@ Firefox supports MV3 (since Firefox 109), so this is an adaptation rather than a
 
 ---
 
-_Last updated 2026-03-13 against the v0.4.14 codebase. UI polish/rebrand branch complete. Logs page fully rebranded with ARIA tab pattern and extracted CSS._
+_Last updated 2026-03-14 against the v0.4.21 codebase. Interactive onboarding tour complete — Phase 1 popup wizard and Phase 2 Twitch-side live demo panel._

--- a/docs/superpowers/plans/2026-03-14-interactive-onboarding-tour.md
+++ b/docs/superpowers/plans/2026-03-14-interactive-onboarding-tour.md
@@ -1,0 +1,1484 @@
+# Interactive Onboarding Tour Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a two-phase onboarding tour — a popup wizard on first open (Phase 1) and a Twitch-side live demo on first Twitch visit (Phase 2) — that gets new users configured and experiencing the real overlay in under 2 minutes.
+
+**Architecture:** Phase 1 fires on first user-initiated popup open (detected via `hcOnboardingWizardPending` in `chrome.storage.local`). Phase 2 fires on first Twitch page load (detected via `hcOnboardingPhase2Pending`). Both phases are independently dismissable and replayable. The Phase 2 demo uses `triggerDemoOverlay()`, a stable export that calls the real `runFrictionFlow()` with a mock purchase and a clean tracker — no storage writes.
+
+**Tech Stack:** TypeScript, Chrome Extension MV3, webpack, `chrome.storage.local`, DOM injection (same pattern as interceptor.ts overlay)
+
+**Branch:** `feat/interactive-onboarding-tour`
+
+**Do NOT bump versions** during implementation. Version bump happens in the final task.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/shared/types.ts` | Modify | Add `isDemoMode?` to `PurchaseAttempt`; add `ONBOARDING_KEYS` constants |
+| `src/content/interceptor.ts` | Modify | Add `triggerDemoOverlay()` export; add demo badge to `showMainOverlay`; update `HC.testOverlay()` delegation in `index.ts` |
+| `src/content/index.ts` | Modify | Refactor `HC.testOverlay()` to call `triggerDemoOverlay()`; add Phase 2 pending check + DOM readiness + `initTourPanel()` call |
+| `src/background/serviceWorker.ts` | Modify | Add `onInstalled` handler to set both pending flags |
+| `src/popup/popup.html` | Modify | Add wizard markup (`#hc-wizard`); add `↺ Tour` footer link |
+| `src/popup/popup.css` | Modify | Add wizard styles |
+| `src/popup/popup.ts` | Modify | Add wizard state check at init; skip logic; continue logic; in-place replay re-render; replay trigger |
+| `src/popup/sections/settings-section.ts` | Modify | Add `↺ Replay setup tour` button + handler |
+| `src/popup/sections/settings-section.html` (inline) | Modify | Add replay button to Settings section HTML in popup.html |
+| `src/content/tourPanel.ts` | Create | Slide-out tour panel: DOM injection, step 1 highlights, step 2 demo, collapse/expand, completion |
+| `src/content/styles.css` | Modify | Highlight ring styles, tour panel styles |
+| `manifest.json` + `package.json` | Modify | Patch version bump (final task only) |
+
+---
+
+## Chunk 1: Foundation
+
+> Types + demo overlay + service worker trigger
+
+---
+
+### Task 1: Add onboarding types and constants
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+- [ ] **Step 1: Add `isDemoMode` to `PurchaseAttempt` and `ONBOARDING_KEYS` constants**
+
+Open `src/shared/types.ts`. Make two changes:
+
+**Change 1** — add `isDemoMode?` to `PurchaseAttempt` (after the `element` field):
+
+```typescript
+/** Information about a detected purchase attempt */
+export interface PurchaseAttempt {
+  type: PurchaseType;
+  rawPrice: string | null;
+  priceValue: number | null;
+  channel: string;
+  timestamp: Date;
+  element: HTMLElement;
+  isDemoMode?: boolean;  // true when fired from triggerDemoOverlay() — skips storage writes
+}
+```
+
+**Change 2** — add `ONBOARDING_KEYS` constants at the bottom of the file (before the closing):
+
+```typescript
+/** Storage keys for onboarding state — all stored in chrome.storage.local */
+export const ONBOARDING_KEYS = {
+  wizardPending: 'hcOnboardingWizardPending',
+  phase2Pending: 'hcOnboardingPhase2Pending',
+  complete: 'hcOnboardingComplete',
+} as const;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles cleanly**
+
+Run: `npm run build`
+
+Expected: Build succeeds with no TypeScript errors. (If build fails for any reason, stop and report to the user — do not retry.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat: add isDemoMode to PurchaseAttempt and ONBOARDING_KEYS constants"
+```
+
+---
+
+### Task 2: Add `triggerDemoOverlay()` and demo badge
+
+**Files:**
+- Modify: `src/content/interceptor.ts`
+
+- [ ] **Step 1: Add demo badge to `showMainOverlay`**
+
+In `src/content/interceptor.ts`, find the `showMainOverlay` function (around line 438). Find the line that renders `${whitelistNote ? ... : ''}` inside `hc-content`. Add a demo badge **above** that line:
+
+```typescript
+  overlay.innerHTML = `
+    <div class="hc-modal">
+      <div class="hc-header">
+        <img class="hc-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="32" height="32" alt="Hype Control">
+        <h2 class="hc-title">Hype Control</h2>
+      </div>
+      <div class="hc-content">
+        ${attempt.isDemoMode ? '<div class="hc-demo-badge">Demo mode — no real purchase will be made</div>' : ''}
+        ${whitelistNote ? `<div class="hc-whitelist-note">${whitelistNote}</div>` : ''}
+```
+
+(Only this one line addition — do not change anything else in `showMainOverlay`.)
+
+- [ ] **Step 2: Add `triggerDemoOverlay()` export**
+
+At the bottom of `src/content/interceptor.ts`, before the final closing, add:
+
+```typescript
+/**
+ * Fires the real friction overlay with mock purchase data.
+ * Used by the onboarding tour (Phase 2) and by HC.testOverlay().
+ * Does NOT write to storage — no spend tracking, no event log.
+ */
+export async function triggerDemoOverlay(): Promise<void> {
+  const settings = await loadSettings();
+  const mockAttempt: PurchaseAttempt = {
+    type: 'Subscribe',
+    rawPrice: '$4.99',
+    priceValue: 4.99,
+    channel: getCurrentChannel() || 'example_channel',
+    timestamp: new Date(),
+    element: document.body,
+    isDemoMode: true,
+  };
+  // Use a fresh tracker so demo never affects daily totals or cooldown
+  const freshTracker = { ...DEFAULT_SPENDING_TRACKER };
+  await runFrictionFlow(mockAttempt, settings, freshTracker);
+  // Intentionally no recordPurchase or writeInterceptEvent — demo mode
+}
+```
+
+You'll need to add the `getCurrentChannel` import. Check the imports at the top of interceptor.ts — it imports from `./detector`. Add `getCurrentChannel` to that import:
+
+```typescript
+import { isPurchaseButton, createPurchaseAttempt, getCurrentChannel } from './detector';
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "feat: add triggerDemoOverlay() export and demo badge to main overlay"
+```
+
+---
+
+### Task 3: Refactor `HC.testOverlay()` to delegate to `triggerDemoOverlay()`
+
+**Files:**
+- Modify: `src/content/index.ts`
+
+- [ ] **Step 1: Import `triggerDemoOverlay`, update `testOverlay`, remove unused import**
+
+In `src/content/index.ts`, make three changes:
+
+**Change 1** — update the import from `./interceptor`:
+```typescript
+import { setupInterceptor, triggerDemoOverlay } from './interceptor';
+```
+
+**Change 2** — update the import from `./themeManager`. After the refactor, `applyThemeToOverlay` is only used inside `testOverlay()` (line 264). Once `testOverlay` no longer builds its own overlay HTML, `applyThemeToOverlay` becomes unused. Remove it from the import:
+```typescript
+import { initThemeManager } from './themeManager';
+```
+
+**Change 3** — find the `testOverlay()` function (around line 214). Replace the entire function body — approximately 55 lines of inline overlay HTML — with a single delegation call:
+```typescript
+function testOverlay(): void {
+  log('Testing overlay display via triggerDemoOverlay()...');
+  triggerDemoOverlay().catch((e) => log('testOverlay error:', e));
+}
+```
+
+The `window.HC.testOverlay` assignment at the bottom stays unchanged — only the function body changes.
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+
+Expected: Build succeeds. Load extension in Chrome, open Twitch, run `HC.testOverlay()` in console — the real friction overlay should appear with a "Demo mode" badge.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/index.ts
+git commit -m "refactor: HC.testOverlay() delegates to triggerDemoOverlay()"
+```
+
+---
+
+### Task 4: Service worker `onInstalled` handler
+
+**Files:**
+- Modify: `src/background/serviceWorker.ts`
+
+Current state: The file has a single comment and is otherwise empty.
+
+- [ ] **Step 1: Add `onInstalled` handler**
+
+Replace the entire file content with:
+
+```typescript
+import { ONBOARDING_KEYS } from '../shared/types';
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    chrome.storage.local.set({
+      [ONBOARDING_KEYS.wizardPending]: true,
+      [ONBOARDING_KEYS.phase2Pending]: true,
+      [ONBOARDING_KEYS.complete]: false,
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+
+Expected: Build succeeds. To verify manually: remove the extension from Chrome, reload it unpacked, then check `chrome.storage.local` via the extension's service worker DevTools — `hcOnboardingWizardPending` and `hcOnboardingPhase2Pending` should both be `true`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/background/serviceWorker.ts
+git commit -m "feat: set onboarding pending flags on first install"
+```
+
+---
+
+## Chunk 2: Popup Wizard (Phase 1)
+
+> HTML markup + CSS + popup.ts logic for the first-open wizard
+
+---
+
+### Task 5: Wizard markup in popup.html
+
+**Files:**
+- Modify: `src/popup/popup.html`
+
+- [ ] **Step 1: Add wizard container to popup.html**
+
+In `src/popup/popup.html`, find the `<div class="hc-body">` opening tag. Add the wizard panel **immediately after** `<div class="hc-body">` and **before** `<div class="hc-content"`:
+
+```html
+  <!-- Onboarding Wizard (Phase 1) — shown on first popup open -->
+  <div id="hc-wizard" class="hc-wizard" hidden>
+    <div class="hc-wizard-header">
+      <img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="28" height="28" alt="">
+      <h2 class="hc-wizard-title">Welcome to Hype Control</h2>
+    </div>
+
+    <a class="hc-wizard-skip" id="wizard-skip" href="#">Skip setup, I'll configure it myself →</a>
+
+    <!-- Skip confirmation (shown after skip click) -->
+    <div id="wizard-skip-confirm" class="hc-wizard-skip-confirm" hidden>
+      <p class="hc-wizard-defaults-msg">You're all set with defaults: <strong>$20/hr wage · 7% sales tax · Medium friction · Preset comparison items enabled.</strong> Update these in Settings anytime.</p>
+      <button class="btn-primary" id="wizard-got-it">Got it →</button>
+    </div>
+
+    <!-- Main wizard form -->
+    <div id="wizard-form" class="hc-wizard-form">
+      <div class="hc-wizard-field">
+        <label class="hc-wizard-label" for="wizard-hourly-rate">Hourly Rate (take-home)</label>
+        <div class="hc-wizard-input-row">
+          <span class="hc-wizard-prefix">$</span>
+          <input type="number" id="wizard-hourly-rate" class="hc-wizard-input" value="20" min="1" max="999" step="0.01">
+        </div>
+        <p class="hc-wizard-hint">$20/hr is our default — update this for accurate results</p>
+        <a class="hc-wizard-calc-toggle" id="wizard-calc-toggle" href="#">Calculate from salary →</a>
+        <div id="wizard-salary-calc" class="hc-wizard-salary-calc" hidden>
+          <div class="hc-wizard-input-row">
+            <span class="hc-wizard-prefix">$</span>
+            <input type="number" id="wizard-annual-salary" class="hc-wizard-input" placeholder="Annual salary" min="1">
+          </div>
+          <div class="hc-wizard-input-row">
+            <input type="number" id="wizard-hours-per-week" class="hc-wizard-input" placeholder="Hours/week" value="40" min="1" max="168">
+            <span class="hc-wizard-suffix">hrs/wk</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="hc-wizard-field">
+        <label class="hc-wizard-label" for="wizard-tax-rate">Sales Tax Rate</label>
+        <div class="hc-wizard-input-row">
+          <input type="number" id="wizard-tax-rate" class="hc-wizard-input" value="7" min="0" max="20" step="0.1">
+          <span class="hc-wizard-suffix">%</span>
+        </div>
+      </div>
+
+      <div class="hc-wizard-field">
+        <span class="hc-wizard-label">Friction Level</span>
+        <div class="hc-wizard-seg" id="wizard-friction-seg" role="group" aria-label="Friction level">
+          <button class="hc-wizard-seg-btn" data-value="low">Low</button>
+          <button class="hc-wizard-seg-btn active" data-value="medium">Medium</button>
+          <button class="hc-wizard-seg-btn" data-value="high">High</button>
+          <button class="hc-wizard-seg-btn" data-value="extreme">Extreme</button>
+        </div>
+        <p class="hc-wizard-friction-desc" id="wizard-friction-desc">Overlay + reason selection</p>
+      </div>
+
+      <div class="hc-wizard-field">
+        <span class="hc-wizard-label">Comparison Items</span>
+        <div class="hc-wizard-chips" id="wizard-chips">
+          <!-- Populated by popup.ts from PRESET_COMPARISON_ITEMS -->
+        </div>
+        <p class="hc-wizard-hint">These are your default comparisons. <a href="#" id="wizard-customize-link">Customize in Settings →</a></p>
+      </div>
+
+      <button class="btn-primary hc-wizard-continue" id="wizard-continue">Continue →</button>
+    </div>
+  </div><!-- /#hc-wizard -->
+```
+
+- [ ] **Step 2: Add `↺ Tour` link to footer**
+
+Find the footer in popup.html:
+
+```html
+  <footer class="hc-footer">
+    <div class="footer-links">
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
+    </div>
+```
+
+Add the tour replay link inside `.footer-links`:
+
+```html
+    <div class="footer-links">
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
+      <a class="footer-link" href="#" id="footer-replay-tour">↺ Tour</a>
+    </div>
+```
+
+- [ ] **Step 3: Add replay button to Settings section**
+
+Find `section id="section-settings"` in popup.html. Add a replay button at the bottom of that section, just before its closing `</section>`:
+
+```html
+      <div class="hc-row hc-row--replay">
+        <button class="btn-secondary btn-replay-tour" id="btn-replay-tour">↺ Replay setup tour</button>
+      </div>
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/popup/popup.html
+git commit -m "feat: add wizard markup, tour footer link, and replay button to popup.html"
+```
+
+---
+
+### Task 6: Wizard CSS
+
+**Files:**
+- Modify: `src/popup/popup.css`
+
+- [ ] **Step 1: Add wizard styles**
+
+Append the following to the end of `src/popup/popup.css`:
+
+```css
+/* ── Onboarding Wizard ─────────────────────────────────────────────── */
+
+.hc-wizard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.hc-wizard[hidden] { display: none; }
+
+.hc-wizard-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--hc-border);
+}
+
+.hc-wizard-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--hc-text-primary);
+  margin: 0;
+}
+
+.hc-wizard-skip {
+  font-size: 11px;
+  color: var(--hc-text-muted);
+  text-decoration: none;
+  align-self: flex-start;
+}
+.hc-wizard-skip:hover { color: var(--hc-text-primary); text-decoration: underline; }
+
+.hc-wizard-skip-confirm {
+  background: var(--hc-surface-2);
+  border-radius: 6px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.hc-wizard-skip-confirm[hidden] { display: none; }
+
+.hc-wizard-defaults-msg {
+  font-size: 12px;
+  color: var(--hc-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.hc-wizard-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.hc-wizard-form[hidden] { display: none; }
+
+.hc-wizard-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hc-wizard-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--hc-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hc-wizard-input-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.hc-wizard-prefix,
+.hc-wizard-suffix {
+  font-size: 13px;
+  color: var(--hc-text-muted);
+  flex-shrink: 0;
+}
+
+.hc-wizard-input {
+  background: var(--hc-surface-2);
+  border: 1px solid var(--hc-border);
+  border-radius: 4px;
+  color: var(--hc-text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  padding: 6px 8px;
+  width: 100%;
+}
+.hc-wizard-input:focus {
+  outline: 2px solid var(--hc-accent);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.hc-wizard-hint {
+  font-size: 11px;
+  color: var(--hc-text-muted);
+  margin: 0;
+  line-height: 1.4;
+}
+.hc-wizard-hint a {
+  color: var(--hc-accent);
+  text-decoration: none;
+}
+.hc-wizard-hint a:hover { text-decoration: underline; }
+
+.hc-wizard-calc-toggle {
+  font-size: 11px;
+  color: var(--hc-accent);
+  text-decoration: none;
+  align-self: flex-start;
+}
+.hc-wizard-calc-toggle:hover { text-decoration: underline; }
+
+.hc-wizard-salary-calc {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  background: var(--hc-surface-2);
+  border-radius: 4px;
+  border: 1px solid var(--hc-border);
+}
+.hc-wizard-salary-calc[hidden] { display: none; }
+
+/* Friction segmented control */
+.hc-wizard-seg {
+  display: flex;
+  gap: 2px;
+  background: var(--hc-surface-2);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.hc-wizard-seg-btn {
+  flex: 1;
+  padding: 5px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+  color: var(--hc-text-muted);
+  transition: background 0.15s, color 0.15s;
+}
+.hc-wizard-seg-btn.active {
+  background: var(--hc-accent);
+  color: #fff;
+}
+.hc-wizard-seg-btn:hover:not(.active) {
+  background: var(--hc-surface-3, rgba(255,255,255,0.08));
+  color: var(--hc-text-primary);
+}
+
+.hc-wizard-friction-desc {
+  font-size: 11px;
+  color: var(--hc-text-muted);
+  margin: 0;
+  min-height: 16px;
+}
+
+/* Comparison chips */
+.hc-wizard-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hc-wizard-chip {
+  background: var(--hc-surface-2);
+  border: 1px solid var(--hc-border);
+  border-radius: 20px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--hc-text-secondary);
+}
+
+.hc-wizard-continue {
+  margin-top: 4px;
+  width: 100%;
+}
+
+/* Replay button in settings section */
+.hc-row--replay {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--hc-border);
+}
+
+.btn-replay-tour {
+  font-size: 12px;
+}
+
+/* NOTE: .hc-demo-badge is intentionally NOT defined here.
+   It is used in overlay HTML rendered by interceptor.ts (content script),
+   which loads src/content/styles.css — not popup.css.
+   The badge style is defined in Task 9 (styles.css). */
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/popup/popup.css
+git commit -m "feat: add wizard and demo badge CSS styles"
+```
+
+---
+
+### Task 7: Popup wizard logic
+
+**Files:**
+- Modify: `src/popup/popup.ts`
+
+- [ ] **Step 1: Import ONBOARDING_KEYS and PRESET_COMPARISON_ITEMS**
+
+At the top of `src/popup/popup.ts`, update the import from `../shared/types`:
+
+```typescript
+import { migrateSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS } from '../shared/types';
+```
+
+- [ ] **Step 2: Add `showWizard()` function**
+
+Add the following function to `popup.ts` **before** the `main()` function:
+
+```typescript
+const FRICTION_DESCRIPTIONS: Record<string, string> = {
+  low: 'Main overlay only — one click to cancel',
+  medium: 'Overlay + reason selection',
+  high: 'Overlay + reason + cooldown timer',
+  extreme: 'Everything + math challenge + type-to-confirm',
+};
+
+function showWizard(onComplete: () => void): void {
+  const wizard = document.getElementById('hc-wizard')!;
+  const form = document.getElementById('wizard-form')!;
+  const skipLink = document.getElementById('wizard-skip')!;
+  const skipConfirm = document.getElementById('wizard-skip-confirm')!;
+  const gotItBtn = document.getElementById('wizard-got-it')!;
+  const hourlyInput = document.getElementById('wizard-hourly-rate') as HTMLInputElement;
+  const taxInput = document.getElementById('wizard-tax-rate') as HTMLInputElement;
+  const calcToggle = document.getElementById('wizard-calc-toggle')!;
+  const salaryCalc = document.getElementById('wizard-salary-calc')!;
+  const salaryInput = document.getElementById('wizard-annual-salary') as HTMLInputElement;
+  const hoursInput = document.getElementById('wizard-hours-per-week') as HTMLInputElement;
+  const frictionSeg = document.getElementById('wizard-friction-seg')!;
+  const frictionDesc = document.getElementById('wizard-friction-desc')!;
+  const chips = document.getElementById('wizard-chips')!;
+  const continueBtn = document.getElementById('wizard-continue')!;
+  const customizeLink = document.getElementById('wizard-customize-link')!;
+
+  // Show wizard, hide main content
+  wizard.removeAttribute('hidden');
+  const content = document.getElementById('hc-content')!;
+  const nav = document.getElementById('hc-nav')!;
+  content.setAttribute('hidden', '');
+  nav.setAttribute('hidden', '');
+
+  // Populate comparison chips (first 4 enabled presets)
+  const previewItems = PRESET_COMPARISON_ITEMS.filter(i => i.enabled).slice(0, 4);
+  chips.innerHTML = '';
+  previewItems.forEach(item => {
+    const chip = document.createElement('span');
+    chip.className = 'hc-wizard-chip';
+    chip.textContent = `${item.emoji} ${item.name}`;
+    chips.appendChild(chip);
+  });
+
+  // Salary calculator toggle
+  calcToggle.addEventListener('click', (e) => {
+    e.preventDefault();
+    const isHidden = salaryCalc.hasAttribute('hidden');
+    if (isHidden) {
+      salaryCalc.removeAttribute('hidden');
+      calcToggle.textContent = 'Hide calculator ↑';
+    } else {
+      salaryCalc.setAttribute('hidden', '');
+      calcToggle.textContent = 'Calculate from salary →';
+    }
+  });
+
+  // Salary calculator: auto-compute hourly rate
+  function updateHourlyFromSalary(): void {
+    const salary = parseFloat(salaryInput.value);
+    const hours = parseFloat(hoursInput.value) || 40;
+    if (salary > 0 && hours > 0) {
+      hourlyInput.value = (salary / 52 / hours).toFixed(2);
+    }
+  }
+  salaryInput.addEventListener('input', updateHourlyFromSalary);
+  hoursInput.addEventListener('input', updateHourlyFromSalary);
+
+  // Friction segmented control
+  frictionSeg.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest('.hc-wizard-seg-btn') as HTMLButtonElement | null;
+    if (!btn) return;
+    frictionSeg.querySelectorAll('.hc-wizard-seg-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    frictionDesc.textContent = FRICTION_DESCRIPTIONS[btn.dataset.value ?? 'medium'] ?? '';
+  });
+
+  // Skip path
+  skipLink.addEventListener('click', async (e) => {
+    e.preventDefault();
+    // Write defaults to storage
+    await chrome.storage.sync.set({ hcSettings: DEFAULT_SETTINGS });
+    // Clear wizard pending flag; leave phase2 pending
+    await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
+    // Show skip confirmation
+    form.setAttribute('hidden', '');
+    skipLink.setAttribute('hidden', '');
+    skipConfirm.removeAttribute('hidden');
+    // Auto-close after 3s fallback
+    const autoClose = setTimeout(() => closeWizard(), 3000);
+    gotItBtn.addEventListener('click', () => {
+      clearTimeout(autoClose);
+      closeWizard();
+    });
+  });
+
+  // Customize link — close wizard and navigate to Comparisons section
+  customizeLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    closeWizard();
+    // Scroll to comparisons section
+    setTimeout(() => {
+      document.getElementById('section-comparisons')?.scrollIntoView({ behavior: 'smooth' });
+    }, 50);
+  });
+
+  // Continue button
+  continueBtn.addEventListener('click', async () => {
+    const hourlyRate = parseFloat(hourlyInput.value) || 20;
+    const taxRate = parseFloat(taxInput.value) || 7;
+    const activeBtn = frictionSeg.querySelector<HTMLButtonElement>('.hc-wizard-seg-btn.active');
+    const frictionIntensity = (activeBtn?.dataset.value ?? 'medium') as UserSettings['frictionIntensity'];
+
+    // Load current settings (handles reinstall case — prefills from existing)
+    const result = await chrome.storage.sync.get('hcSettings');
+    const current = migrateSettings(result.hcSettings ?? {});
+    const updated = { ...current, hourlyRate, taxRate, frictionIntensity };
+    await chrome.storage.sync.set({ hcSettings: updated });
+    await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
+    closeWizard();
+  });
+
+  function closeWizard(): void {
+    wizard.setAttribute('hidden', '');
+    content.removeAttribute('hidden');
+    nav.removeAttribute('hidden');
+    onComplete();
+  }
+}
+```
+
+Note: `UserSettings` needs to be imported. Update the types import to include it:
+
+```typescript
+import { migrateSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS, UserSettings } from '../shared/types';
+```
+
+- [ ] **Step 3: Add wizard check to `main()`**
+
+At the very start of the `main()` async function, **before** the `chrome.storage.sync.get` call, add the wizard check:
+
+```typescript
+async function main(): Promise<void> {
+  // Check if onboarding wizard should be shown (first open)
+  const onboardingState = await chrome.storage.local.get([
+    ONBOARDING_KEYS.wizardPending,
+  ]);
+  if (onboardingState[ONBOARDING_KEYS.wizardPending] === true) {
+    // Show wizard; when complete, re-run main() to populate normal popup state
+    showWizard(() => main());
+    return;
+  }
+
+  // --- existing main() code continues below ---
+  const result = await chrome.storage.sync.get(SETTINGS_KEY);
+  // ...
+```
+
+- [ ] **Step 4: Add replay trigger function**
+
+Add the following function to `popup.ts` (after `showWizard`):
+
+```typescript
+async function triggerReplay(): Promise<void> {
+  await chrome.storage.local.set({
+    [ONBOARDING_KEYS.wizardPending]: true,
+    [ONBOARDING_KEYS.phase2Pending]: true,
+    [ONBOARDING_KEYS.complete]: false,
+  });
+  // Re-render wizard in place.
+  // On completion, reload the popup window to avoid double-initializing
+  // section controllers and event listeners (main() already ran once).
+  showWizard(() => window.location.reload());
+}
+```
+
+- [ ] **Step 5: Wire up replay triggers in `main()`**
+
+At the end of `main()`, after all sections are initialized, wire up both replay entry points:
+
+```typescript
+  // Replay tour triggers
+  document.getElementById('footer-replay-tour')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    triggerReplay();
+  });
+  document.getElementById('btn-replay-tour')?.addEventListener('click', () => {
+    triggerReplay();
+  });
+```
+
+- [ ] **Step 6: Build**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 7: Manual smoke test**
+
+1. Load extension unpacked
+2. Open popup — wizard should NOT show (onboarding flags not set yet)
+3. Manually set `hcOnboardingWizardPending: true` via service worker console: `chrome.storage.local.set({ hcOnboardingWizardPending: true })`
+4. Close and reopen popup — wizard should appear
+5. Test skip path: click skip, confirm defaults summary shows, click "Got it →" — returns to normal popup
+6. Test continue path: adjust hourly rate, click Continue — verify settings saved in storage
+7. Test replay: click `↺ Tour` in footer — wizard reappears in place
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/popup/popup.ts
+git commit -m "feat: popup wizard Phase 1 — first-open config wizard with skip and replay"
+```
+
+---
+
+## Chunk 3: Twitch Tour Panel (Phase 2)
+
+> New `tourPanel.ts` module + styles + index.ts trigger
+
+---
+
+### Task 8: Create `tourPanel.ts`
+
+**Files:**
+- Create: `src/content/tourPanel.ts` ← lives in `src/content/`, NOT `src/popup/`. It is imported as a module by `index.ts` and bundled into the content script — it is NOT a new webpack entry point.
+
+- [ ] **Step 1: Create the tour panel module**
+
+Create `src/content/tourPanel.ts` with the following content:
+
+```typescript
+/**
+ * tourPanel.ts — Phase 2 onboarding tour
+ *
+ * Injects a non-blocking slide-out panel on Twitch pages when
+ * hcOnboardingPhase2Pending is true. Two steps:
+ *   Step 1: Highlight visible interceptable buttons
+ *   Step 2: Fire triggerDemoOverlay() so user experiences the real overlay
+ */
+
+import { ONBOARDING_KEYS } from '../shared/types';
+import { triggerDemoOverlay } from './interceptor';
+import { log } from '../shared/logger';
+
+/** Selectors used by detector.ts — kept in sync manually */
+const INTERCEPTABLE_SELECTORS = [
+  '[data-a-target="gift-button"]',
+  '[data-a-target="gift-sub-confirm-button"]',
+  'button[data-a-target="top-nav-get-bits-button"]',
+  'button[aria-label="Bits"]',
+  'button[data-a-target^="bits-purchase-button"]',
+];
+
+/** Labels for each selector type */
+const SELECTOR_LABELS: Record<string, string> = {
+  'gift-button': 'Gift Sub',
+  'gift-sub-confirm-button': 'Gift Sub',
+  'top-nav-get-bits-button': 'Get Bits',
+  'bits': 'Get Bits',
+};
+
+interface HighlightedButton {
+  el: HTMLElement;
+  ring: HTMLElement;
+  label: HTMLElement;
+}
+
+let panelEl: HTMLElement | null = null;
+let highlightedButtons: HighlightedButton[] = [];
+let completionTimeout: ReturnType<typeof setTimeout> | null = null;
+
+/** Mark onboarding as complete in storage */
+async function markComplete(): Promise<void> {
+  await chrome.storage.local.set({
+    [ONBOARDING_KEYS.phase2Pending]: false,
+    [ONBOARDING_KEYS.complete]: true,
+  });
+  log('Onboarding Phase 2 complete');
+}
+
+/** Remove all highlight rings from Twitch buttons */
+function clearHighlights(): void {
+  highlightedButtons.forEach(({ ring, label }) => {
+    ring.remove();
+    label.remove();
+  });
+  highlightedButtons = [];
+}
+
+/** Find interceptable buttons currently visible in the viewport */
+function findVisibleInterceptableButtons(): HTMLElement[] {
+  const found: HTMLElement[] = [];
+  for (const selector of INTERCEPTABLE_SELECTORS) {
+    document.querySelectorAll<HTMLElement>(selector).forEach(el => {
+      const rect = el.getBoundingClientRect();
+      const isVisible = rect.width > 0 && rect.height > 0 &&
+        rect.top >= 0 && rect.bottom <= window.innerHeight;
+      if (isVisible && !found.includes(el)) {
+        found.push(el);
+      }
+    });
+  }
+  return found;
+}
+
+/** Get a human-readable label for a highlighted button */
+function getLabelForButton(el: HTMLElement): string {
+  const dataTarget = el.getAttribute('data-a-target') || '';
+  const ariaLabel = (el.getAttribute('aria-label') || '').toLowerCase();
+
+  if (dataTarget.includes('gift')) return 'Gift Sub';
+  if (dataTarget.includes('bits') || ariaLabel === 'bits') return 'Get Bits';
+
+  // Bits purchase tier buttons
+  if (dataTarget.startsWith('bits-purchase-button')) {
+    const match = dataTarget.match(/bits-purchase-button-(\d+)/);
+    return match ? `Buy ${Number(match[1]).toLocaleString()} Bits` : 'Get Bits';
+  }
+
+  return 'Purchase Button';
+}
+
+/** Apply highlight ring and floating label to a button */
+function highlightButton(el: HTMLElement): HighlightedButton {
+  const rect = el.getBoundingClientRect();
+
+  const ring = document.createElement('div');
+  ring.className = 'hc-tour-highlight-ring';
+  ring.style.cssText = `
+    position: fixed;
+    top: ${rect.top - 4}px;
+    left: ${rect.left - 4}px;
+    width: ${rect.width + 8}px;
+    height: ${rect.height + 8}px;
+    pointer-events: none;
+    z-index: 999997;
+    border-radius: 6px;
+  `;
+
+  const label = document.createElement('div');
+  label.className = 'hc-tour-highlight-label';
+  label.textContent = getLabelForButton(el);
+  label.style.cssText = `
+    position: fixed;
+    top: ${rect.top - 28}px;
+    left: ${rect.left}px;
+    pointer-events: none;
+    z-index: 999998;
+  `;
+
+  document.body.appendChild(ring);
+  document.body.appendChild(label);
+
+  return { el, ring, label };
+}
+
+/** Render Step 2 content into the panel */
+function renderStep2(panel: HTMLElement): void {
+  const body = panel.querySelector('.hc-tour-body')!;
+  body.innerHTML = `
+    <p class="hc-tour-heading">Here's what happens when you click one</p>
+    <p class="hc-tour-sub">No real purchase will be made.</p>
+    <button class="hc-tour-btn-primary" id="hc-tour-try-btn">Try it now</button>
+  `;
+
+  panel.querySelector('#hc-tour-try-btn')?.addEventListener('click', async () => {
+    // Collapse panel to tab while overlay is active
+    panel.classList.add('hc-tour-panel--collapsed');
+
+    try {
+      await triggerDemoOverlay();
+    } finally {
+      // Re-expand after overlay is dismissed (triggerDemoOverlay resolves after user interacts)
+      panel.classList.remove('hc-tour-panel--collapsed');
+      showCompletion(panel);
+    }
+  });
+}
+
+/** Show completion message and auto-dismiss */
+function showCompletion(panel: HTMLElement): void {
+  const body = panel.querySelector('.hc-tour-body')!;
+  body.innerHTML = `<p class="hc-tour-complete">That's it. You're protected. 🛡️</p>`;
+
+  completionTimeout = setTimeout(async () => {
+    await markComplete();
+    panel.remove();
+    panelEl = null;
+  }, 3000);
+}
+
+/** Build and inject the tour panel into the page */
+function createPanel(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = 'hc-tour-panel';
+  panel.className = 'hc-tour-panel';
+  panel.setAttribute('role', 'complementary');
+  panel.setAttribute('aria-label', 'Hype Control onboarding tour');
+
+  panel.innerHTML = `
+    <div class="hc-tour-header">
+      <img class="hc-tour-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="20" height="20" alt="">
+      <span class="hc-tour-title">Hype Control</span>
+      <button class="hc-tour-close" id="hc-tour-close" aria-label="Dismiss tour">✕</button>
+    </div>
+    <div class="hc-tour-body">
+      <!-- Content injected per step -->
+    </div>
+    <!-- Collapsed tab state -->
+    <div class="hc-tour-tab">
+      <img src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="16" height="16" alt="HC">
+      <span>…</span>
+    </div>
+  `;
+
+  // Dismiss / close
+  panel.querySelector('#hc-tour-close')?.addEventListener('click', async () => {
+    if (completionTimeout) clearTimeout(completionTimeout);
+    clearHighlights();
+    await markComplete();
+    panel.remove();
+    panelEl = null;
+  });
+
+  return panel;
+}
+
+/** Run Step 1: find and highlight buttons, show panel */
+function runStep1(panel: HTMLElement): void {
+  const buttons = findVisibleInterceptableButtons();
+  const body = panel.querySelector('.hc-tour-body')!;
+
+  if (buttons.length > 0) {
+    // Highlight each visible button
+    buttons.forEach(btn => {
+      highlightedButtons.push(highlightButton(btn));
+    });
+
+    body.innerHTML = `
+      <p class="hc-tour-heading">Here's what I watch for you</p>
+      <p class="hc-tour-sub">${buttons.length} interceptable button${buttons.length !== 1 ? 's' : ''} on this page</p>
+      <button class="hc-tour-btn-primary" id="hc-tour-next-btn">Show me what happens →</button>
+    `;
+
+    panel.querySelector('#hc-tour-next-btn')?.addEventListener('click', () => {
+      clearHighlights();
+      renderStep2(panel);
+    });
+  } else {
+    // No buttons visible — skip to step 2
+    body.innerHTML = `
+      <p class="hc-tour-heading">Navigate to a channel to see what I protect</p>
+      <p class="hc-tour-sub">Or try a demo now.</p>
+      <button class="hc-tour-btn-primary" id="hc-tour-next-btn">Show me anyway →</button>
+    `;
+
+    panel.querySelector('#hc-tour-next-btn')?.addEventListener('click', () => {
+      renderStep2(panel);
+    });
+  }
+}
+
+/**
+ * Initialize the Phase 2 onboarding tour panel.
+ * Call from index.ts after DOM readiness check passes.
+ */
+export function initTourPanel(): void {
+  if (panelEl) return; // Already initialized
+
+  panelEl = createPanel();
+  document.body.appendChild(panelEl);
+  runStep1(panelEl);
+  log('Onboarding Phase 2 tour panel initialized');
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/tourPanel.ts
+git commit -m "feat: add tourPanel.ts for Phase 2 Twitch-side onboarding tour"
+```
+
+---
+
+### Task 9: Tour panel and highlight ring styles
+
+**Files:**
+- Modify: `src/content/styles.css`
+
+- [ ] **Step 1: Add tour panel styles**
+
+Append the following to the end of `src/content/styles.css`:
+
+```css
+/* ── Onboarding Tour Panel ─────────────────────────────────────────── */
+
+#hc-tour-panel {
+  position: fixed;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  width: 260px;
+  background: var(--hc-modal-bg, #1f1f23);
+  border: 1px solid var(--hc-border, rgba(255,255,255,0.1));
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  z-index: 999996;
+  font-family: 'Space Grotesk', sans-serif;
+  overflow: hidden;
+  transition: width 0.2s, opacity 0.2s;
+}
+
+/* Collapsed tab state (shown while demo overlay is active) */
+.hc-tour-panel--collapsed .hc-tour-header,
+.hc-tour-panel--collapsed .hc-tour-body {
+  display: none;
+}
+
+.hc-tour-panel--collapsed {
+  width: 44px;
+  border-radius: 8px;
+}
+
+.hc-tour-tab {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 0;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--hc-text-muted, rgba(255,255,255,0.5));
+}
+
+.hc-tour-panel--collapsed .hc-tour-tab {
+  display: flex;
+}
+
+/* Panel header */
+.hc-tour-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid var(--hc-border, rgba(255,255,255,0.08));
+}
+
+.hc-tour-icon {
+  flex-shrink: 0;
+}
+
+.hc-tour-title {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--hc-text-primary, #fff);
+}
+
+.hc-tour-close {
+  background: none;
+  border: none;
+  color: var(--hc-text-muted, rgba(255,255,255,0.4));
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 4px;
+  border-radius: 3px;
+  line-height: 1;
+}
+.hc-tour-close:hover {
+  color: var(--hc-text-primary, #fff);
+  background: rgba(255,255,255,0.08);
+}
+
+/* Panel body */
+.hc-tour-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hc-tour-heading {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--hc-text-primary, #fff);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.hc-tour-sub {
+  font-size: 12px;
+  color: var(--hc-text-muted, rgba(255,255,255,0.5));
+  margin: 0;
+  line-height: 1.4;
+}
+
+.hc-tour-complete {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--hc-success, #22C55E);
+  margin: 0;
+  text-align: center;
+  padding: 8px 0;
+}
+
+.hc-tour-btn-primary {
+  background: var(--hc-accent, #9147ff);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  width: 100%;
+  text-align: center;
+  transition: opacity 0.15s;
+}
+.hc-tour-btn-primary:hover { opacity: 0.88; }
+
+/* ── Highlight ring on Twitch buttons ──────────────────────────────── */
+
+.hc-tour-highlight-ring {
+  border: 2px solid var(--hc-accent, #9147ff);
+  box-shadow: 0 0 0 3px rgba(145, 71, 255, 0.3);
+  animation: hc-tour-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes hc-tour-pulse {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(145, 71, 255, 0.3); }
+  50%       { box-shadow: 0 0 0 6px rgba(145, 71, 255, 0.1); }
+}
+
+.hc-tour-highlight-label {
+  background: var(--hc-accent, #9147ff);
+  color: #fff;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/styles.css
+git commit -m "feat: add tour panel and highlight ring styles"
+```
+
+---
+
+### Task 10: Phase 2 trigger in `index.ts`
+
+**Files:**
+- Modify: `src/content/index.ts`
+
+- [ ] **Step 1: Import `initTourPanel` and `ONBOARDING_KEYS`**
+
+Add to the imports at the top of `src/content/index.ts`:
+
+```typescript
+import { initTourPanel } from './tourPanel';
+import { ONBOARDING_KEYS } from '../shared/types';
+```
+
+- [ ] **Step 2: Add Phase 2 check function**
+
+Add the following function to `index.ts`, before the `init()` function:
+
+```typescript
+/**
+ * Checks if the Phase 2 onboarding tour should run on this page load.
+ * Waits for a known stable Twitch selector before injecting.
+ * Times out silently after 10 seconds if selector never appears.
+ */
+async function maybeInitTourPanel(): Promise<void> {
+  try {
+    const state = await chrome.storage.local.get(ONBOARDING_KEYS.phase2Pending);
+    if (!state[ONBOARDING_KEYS.phase2Pending]) return;
+
+    // Wait for a stable Twitch selector (same strategy as detector.ts uses)
+    // NOTE: This selector targets the top-nav avatar present for logged-in users.
+    // Logged-out users will not have this element, causing the tour to silently
+    // skip on that page load and retry on the next navigation. This is acceptable —
+    // HypeControl only intercepts purchases, which require a logged-in Twitch account.
+    const STABLE_SELECTOR = '[data-a-target="top-nav-avatar"]';
+    const TIMEOUT_MS = 10_000;
+    const POLL_MS = 300;
+
+    await new Promise<void>((resolve, reject) => {
+      const start = Date.now();
+      const interval = setInterval(() => {
+        if (document.querySelector(STABLE_SELECTOR)) {
+          clearInterval(interval);
+          resolve();
+        } else if (Date.now() - start > TIMEOUT_MS) {
+          clearInterval(interval);
+          reject(new Error('Twitch selector timeout'));
+        }
+      }, POLL_MS);
+    });
+
+    initTourPanel();
+  } catch (e) {
+    // Timeout or storage error — skip silently, retry on next navigation
+    debug('Tour panel init skipped:', e);
+  }
+}
+```
+
+- [ ] **Step 3: Call `maybeInitTourPanel()` from `init()`**
+
+Inside the `init()` function, after `setupInterceptor()` is called, add:
+
+```typescript
+    // Phase 2 onboarding tour (fires on first Twitch visit after install)
+    maybeInitTourPanel();
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 5: Manual smoke test**
+
+1. Load extension, navigate to Twitch
+2. Manually set `hcOnboardingPhase2Pending: true` via service worker console
+3. Reload Twitch page — tour panel should appear after a moment
+4. Click "Show me what happens →" (Step 2)
+5. Click "Try it now" — real overlay fires with demo badge, panel collapses to tab
+6. Cancel or Proceed in overlay — panel re-expands, shows "You're protected." message
+7. Panel auto-dismisses after 3 seconds; verify `hcOnboardingComplete: true` in storage
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/content/index.ts
+git commit -m "feat: trigger Phase 2 tour panel on first Twitch visit"
+```
+
+---
+
+## Chunk 4: Version Bump + Final Build
+
+---
+
+### Task 11: Version bump and build
+
+**Files:**
+- Modify: `manifest.json`
+- Modify: `package.json`
+
+- [ ] **Step 1: Check current version**
+
+```bash
+grep '"version"' manifest.json package.json
+```
+
+Expected: Both show `"0.4.20"`.
+
+- [ ] **Step 2: Bump patch version in both files**
+
+In `manifest.json`, change:
+```json
+"version": "0.4.20"
+```
+to:
+```json
+"version": "0.4.21"
+```
+
+In `package.json`, change:
+```json
+"version": "0.4.20"
+```
+to:
+```json
+"version": "0.4.21"
+```
+
+- [ ] **Step 3: Final build**
+
+Run: `npm run build`
+
+Expected: Build succeeds. Verify `dist/` is populated.
+
+- [ ] **Step 4: Update HypeControl-TODO.md**
+
+In `HypeControl-TODO.md`:
+- Update `Current Version` in the header to `0.4.21`
+- Update the `Updated` date to today (`2026-03-14`)
+- Mark `Interactive Onboarding Tour` as `✅ Complete` in the Quick Summary table
+- Update the footer timestamp
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manifest.json package.json HypeControl-TODO.md
+git commit -m "feat: interactive onboarding tour complete (v0.4.21)"
+```
+
+---
+
+## End-to-End Test Checklist
+
+After all tasks are complete, verify the full flow:
+
+**Fresh install simulation:**
+- [ ] Remove and re-load extension unpacked
+- [ ] Verify `hcOnboardingWizardPending: true` and `hcOnboardingPhase2Pending: true` in storage
+- [ ] Open popup — wizard appears, normal popup is hidden
+- [ ] Adjust hourly rate, select friction level, click Continue
+- [ ] Verify settings saved to `chrome.storage.sync`
+- [ ] Navigate to Twitch — tour panel appears after selector is found
+- [ ] Step 1: interceptable buttons highlighted (if present)
+- [ ] Step 2: click "Try it now" — real overlay fires with "Demo mode" badge
+- [ ] Overlay shows cost breakdown with adjusted hourly rate
+- [ ] Dismiss overlay — panel re-expands, "You're protected." message
+- [ ] Panel auto-dismisses — `hcOnboardingComplete: true` in storage
+- [ ] Reopen popup — normal stats view, no wizard
+
+**Skip path:**
+- [ ] Reset flags, open popup, click "Skip setup" link
+- [ ] Default summary shows, "Got it →" button closes wizard
+- [ ] Navigate to Twitch — tour panel still appears (Phase 2 not skipped)
+
+**Replay:**
+- [ ] Click "↺ Tour" in popup footer — wizard re-renders in place
+- [ ] Click "↺ Replay setup tour" in Settings section — same behavior
+- [ ] After wizard completes, Phase 2 fires again on next Twitch visit
+
+**Advanced user (skip both phases by dismissing):**
+- [ ] X on tour panel marks `hcOnboardingComplete: true`
+- [ ] Popup no longer shows wizard on reopen

--- a/docs/superpowers/specs/2026-03-14-interactive-onboarding-tour-design.md
+++ b/docs/superpowers/specs/2026-03-14-interactive-onboarding-tour-design.md
@@ -1,0 +1,250 @@
+# Interactive Onboarding Tour — Design Spec
+
+**Date:** 2026-03-14
+**Status:** Approved
+**Version target:** Post-v0.4.20
+
+---
+
+## Overview
+
+HypeControl has no guided onboarding. New users open the popup for the first time and land in a dense stats/settings panel with no context, no defaults explanation, and no demonstration of what the extension actually does. This spec defines a two-phase onboarding tour: a popup wizard on first open, followed by a Twitch-side live demo on first Twitch visit.
+
+---
+
+## Goals
+
+- **Aha moment:** User completes config setup *and* experiences the real overlay
+- **Time to value:** Under 2 minutes for the full flow
+- **Respect advanced users:** One-click skip with a defaults summary
+- **Replayability:** Always accessible for users returning after a break
+
+---
+
+## Users
+
+Twitch viewers and streamers who installed HypeControl voluntarily. Mixed experience level — some first-time extension users, some power users who want to configure and go.
+
+---
+
+## Architecture
+
+Three storage keys tracked via `chrome.storage.local`:
+
+```
+hcOnboardingWizardPending: boolean   // set false after Phase 1 completes or is skipped
+hcOnboardingPhase2Pending: boolean   // set false when Phase 2 completes or is dismissed
+hcOnboardingComplete: boolean        // set true when Phase 2 completes or is dismissed
+```
+
+All flags are boolean values written via `chrome.storage.local.set()`. "Cleared" throughout this spec means set to `false` — keys are never deleted.
+
+Replaying resets all three flags. Phases are independently dismissable — dismissing either counts as completion of that phase.
+
+---
+
+## Phase 1 — Popup Wizard
+
+### Trigger
+
+`chrome.runtime.onInstalled` (reason: `"install"`) in `serviceWorker.ts` writes:
+```
+hcOnboardingWizardPending: true
+hcOnboardingPhase2Pending: true
+```
+
+When the user opens the popup for the first time (user-initiated click on extension icon), `popup.ts` checks `hcOnboardingWizardPending`. If `true`, popup renders wizard state instead of the normal stats view.
+
+**Why not `chrome.action.openPopup()`:** This API is restricted to user gesture contexts and is not available in `onInstalled`. Phase 1 fires on the first user-initiated popup open instead — the wizard is waiting for them when they click the icon.
+
+### Skip Path
+
+A `"Skip setup, I'll configure it myself →"` text link at the top of the wizard screen.
+
+On click:
+1. Write `DEFAULT_SETTINGS` values to `chrome.storage.sync` (ensures storage is initialized — same values already in defaults, but makes the write explicit)
+2. Display inline defaults summary:
+   > *"You're all set with defaults: $20/hr wage · 7% sales tax · Medium friction · Preset comparison items enabled. Update these in Settings anytime."*
+3. Set `hcOnboardingWizardPending` to `false`
+4. Leave `hcOnboardingPhase2Pending: true` (Phase 2 still activates on next Twitch visit)
+5. Show a `"Got it →"` button that closes to normal popup view immediately. If the user does not interact, auto-close after 3 seconds as a fallback.
+
+### Wizard Screen (single screen, beginner path)
+
+**Hourly Rate**
+- Pre-filled: `$20.00`
+- Helper note beneath: *"$20/hr is our default — update this for accurate results"*
+- Inline expander link: `"Calculate from salary →"` reveals two fields (Annual salary + Hours/week) that compute hourly rate using existing salary calculator logic. Collapses after rate is populated.
+
+**Sales Tax Rate**
+- Pre-filled: `7%`
+
+**Friction Level**
+- Segmented control: Low / Medium / High / Extreme
+- Default: Medium
+- One-line description below the control updates per selection:
+  - Low: *"Main overlay only — one click to cancel"*
+  - Medium: *"Overlay + reason selection"*
+  - High: *"Overlay + reason + cooldown timer"*
+  - Extreme: *"Everything + math challenge + type-to-confirm"*
+
+**Comparison Items Preview**
+- Read-only chip display of 3–4 representative enabled preset items (e.g., 🌮 🍕 ☕ 🌭)
+- Label: *"These are your default comparisons. [Customize in Settings →]"* — "Customize in Settings" is a link that closes the wizard and navigates to the Comparisons section
+
+**Continue →** button
+1. Saves hourly rate, tax rate, and friction level to `chrome.storage.sync`
+2. Sets `hcOnboardingWizardPending` to `false`
+3. Closes popup (user opens it again if they want to see stats)
+
+---
+
+## Phase 2 — Twitch-Side Tour
+
+### Trigger
+
+On every Twitch page load, `index.ts` checks `hcOnboardingPhase2Pending`. If `true`, injects the tour panel after DOM readiness (see below).
+
+**Why Phase 2 fires even when Phase 1 was skipped:** Skip only bypasses configuration. The Twitch-side product demo is the core aha moment and should always fire.
+
+**If the user never visits Twitch:** `hcOnboardingPhase2Pending` remains `true` indefinitely. This is acceptable — the extension serves no purpose without Twitch, so the pending flag is harmless. No timeout or expiry is needed.
+
+### DOM Readiness
+
+Instead of a fixed 500ms delay, Phase 2 injection waits for a known stable Twitch selector to exist before injecting the tour panel. Use the same selector strategy as `detector.ts`. If the selector never appears within 10 seconds, skip injection silently for that page load and retry on next navigation.
+
+### Slide-Out Panel
+
+- DOM element injected into Twitch page body (same pattern as the friction overlay in `interceptor.ts`)
+- Positioned: right side of viewport, fixed, non-blocking (does not dim or lock the page)
+- Dismissable via X button at any point
+- Dismissing sets `hcOnboardingComplete` to `true` and sets `hcOnboardingPhase2Pending` to `false`
+
+### Step 1 — Button Highlights
+
+**Panel content:**
+> *"Here's what I watch for you"*
+
+- Dynamically detects which interceptable buttons are currently visible using existing `detector.ts` selectors (Subscribe, Gift Sub, Get Bits)
+- Applies a highlight ring (CSS `outline` + subtle glow using `--hc-primary` accent color) to each visible button
+- Small floating label adjacent to each: *"Gift Sub"*, *"Subscribe"*, *"Get Bits"*
+- If no interceptable buttons currently visible:
+  > *"Navigate to a channel to see what I protect — or try a demo now."*
+  — Skip Step 1, go directly to Step 2
+- Panel CTA: `"Show me what happens →"` advances to Step 2
+- Highlight rings removed when advancing
+
+### Step 2 — Live Demo
+
+**Panel content:**
+> *"Here's what happens when you click one"*
+> *"No real purchase will be made."*
+
+- CTA: `"Try it now"` button calls `triggerDemoOverlay()` (see Demo Overlay section below)
+- Panel collapses to a small tab fixed to the right viewport edge while the overlay is active (prevents visual competition with the overlay). The tab shows only the HypeControl icon and a `"…"` label. The panel does not intercept clicks while collapsed.
+- After user clicks Cancel or Proceed in the overlay:
+  - Panel re-expands to its full width automatically
+  - Shows: *"That's it. You're protected."*
+  - Auto-dismisses after 3 seconds
+  - Sets `hcOnboardingComplete` to `true`
+  - Sets `hcOnboardingPhase2Pending` to `false`
+
+### Demo Overlay
+
+`HC.testOverlay()` is a debug-only function with no stability guarantees. Instead, define a stable entrypoint:
+
+```typescript
+// interceptor.ts
+export function triggerDemoOverlay(): void {
+  const sampleEvent: InterceptEvent = {
+    type: 'sub',
+    channel: 'example_channel',
+    priceValue: 4.99,
+    priceWithTax: 5.34,
+    hoursEquivalent: 0.27,
+    timestamp: Date.now(),
+    isDemoMode: true,
+  };
+  runFrictionFlow(sampleEvent);
+}
+```
+
+`HC.testOverlay()` can call `triggerDemoOverlay()` internally. The onboarding tour always calls `triggerDemoOverlay()` directly. This isolates onboarding from future changes to the debug helper.
+
+Add `isDemoMode?: boolean` to the `InterceptEvent` type so the overlay can display a *"Demo mode — no real purchase"* badge.
+
+**`isDemoMode` behavior in `runFrictionFlow()`:** When `isDemoMode` is `true`, the friction flow must:
+- Skip writing to `hcInterceptEvents` (no event logged to history)
+- Skip updating `dailyTotal` and `sessionTotal` in `SpendingTracker`
+- Skip cooldown timer writes
+- Still run the full friction UI (all steps, the real overlay experience)
+
+This prevents demo interactions from contaminating spending data or triggering daily cap warnings.
+
+---
+
+## Replayability
+
+### Settings entry point
+`"↺ Replay setup tour"` link in the Settings section of the popup (bottom of Settings nav).
+
+### Popup footer entry point
+`"↺ Tour"` link in the popup footer, alongside the existing Bug / Ideas links.
+
+### Replay behavior
+On click (from either entry point):
+1. Set `hcOnboardingWizardPending: true`
+2. Set `hcOnboardingPhase2Pending: true`
+3. Set `hcOnboardingComplete: false`
+4. Re-render popup to wizard state **in place** (no close/reopen required) — wizard state is driven by a local variable in `popup.ts`, not by polling storage, so it updates reactively
+5. Phase 2 will activate on their next Twitch page load
+
+---
+
+## Defaults Applied
+
+When Phase 1 is completed or skipped, these values are written to `chrome.storage.sync`:
+
+| Setting | Default Value |
+|---------|--------------|
+| `hourlyRate` | `20.00` |
+| `taxRate` | `7` |
+| `frictionIntensity` | `"medium"` |
+| Preset comparison items | All enabled (existing `DEFAULT_SETTINGS` behavior) |
+
+If settings already exist (reinstall scenario), wizard pre-fills from existing stored values instead of defaults.
+
+---
+
+## Storage Summary
+
+| Key | Store | Type | Set to `true` | Set to `false` |
+|-----|-------|------|----------------|----------------|
+| `hcOnboardingWizardPending` | `chrome.storage.local` | boolean | `onInstalled`, replay | Phase 1 complete or skipped |
+| `hcOnboardingPhase2Pending` | `chrome.storage.local` | boolean | `onInstalled`, replay | Phase 2 complete or dismissed |
+| `hcOnboardingComplete` | `chrome.storage.local` | boolean | Phase 2 complete or dismissed | Replay |
+
+---
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `src/background/serviceWorker.ts` | Add `onInstalled` handler: set `hcOnboardingWizardPending` and `hcOnboardingPhase2Pending` |
+| `src/popup/popup.ts` | Wizard state rendering, skip logic, defaults write, replay trigger, in-place re-render |
+| `src/popup/popup.html` | Wizard markup, footer replay link |
+| `src/popup/popup.css` | Wizard styles |
+| `src/content/index.ts` | Phase 2 pending check on page load, DOM readiness wait |
+| `src/content/tourPanel.ts` | New file — slide-out panel component, step logic, highlight ring injection |
+| `src/content/styles.css` | Highlight ring styles, tour panel styles |
+| `src/content/interceptor.ts` | Add `triggerDemoOverlay()` stable export; `HC.testOverlay()` delegates to it |
+| `src/shared/types.ts` | Add `isDemoMode?: boolean` to `InterceptEvent`; add `OnboardingStorageKeys` constants |
+
+---
+
+## What This Is Not
+
+- **Not a separate tutorial mode** — Phase 2 uses `triggerDemoOverlay()` which calls the real `runFrictionFlow()`. No mock UI.
+- **Not blocking** — Neither phase prevents product use. Both are independently dismissable.
+- **Not repeated** — Once complete, never shown again unless explicitly replayed.
+- **Not auto-opening** — Phase 1 fires on first user-initiated popup open, not automatically on install (MV3 does not allow programmatic popup open from service workers).

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/background/serviceWorker.ts
+++ b/src/background/serviceWorker.ts
@@ -1,1 +1,11 @@
-// No handlers needed; popup.html is declared as default_popup in manifest.json
+import { ONBOARDING_KEYS } from '../shared/types';
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    chrome.storage.local.set({
+      [ONBOARDING_KEYS.wizardPending]: true,
+      [ONBOARDING_KEYS.phase2Pending]: true,
+      [ONBOARDING_KEYS.complete]: false,
+    });
+  }
+});

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -12,8 +12,9 @@ import { setupModalObserver, getCurrentChannel } from './detector';
 import { checkAndUpdateLiveStatus } from './streamingMode';
 import { initThemeManager } from './themeManager';
 import { log, debug, error, setVersion, loadLogs } from '../shared/logger';
-import { migrateSettings, DEFAULT_SETTINGS } from '../shared/types';
+import { migrateSettings, DEFAULT_SETTINGS, ONBOARDING_KEYS } from '../shared/types';
 import './styles.css';
+import { initTourPanel } from './tourPanel';
 
 const SETTINGS_KEY = 'hcSettings';
 
@@ -127,6 +128,45 @@ function scanForButtons(): void {
   log(`=== Scan complete: ${interceptCount} interceptable button(s) found ===`);
 }
 
+/**
+ * Checks if the Phase 2 onboarding tour should run on this page load.
+ * Waits for a known stable Twitch selector before injecting.
+ * Times out silently after 10 seconds if selector never appears.
+ */
+async function maybeInitTourPanel(): Promise<void> {
+  try {
+    const state = await chrome.storage.local.get(ONBOARDING_KEYS.phase2Pending);
+    if (!state[ONBOARDING_KEYS.phase2Pending]) return;
+
+    // Wait for a stable Twitch selector (same strategy as detector.ts uses)
+    // NOTE: This selector targets the top-nav avatar present for logged-in users.
+    // Logged-out users will not have this element, causing the tour to silently
+    // skip on that page load and retry on the next navigation. This is acceptable —
+    // HypeControl only intercepts purchases, which require a logged-in Twitch account.
+    const STABLE_SELECTOR = '[data-a-target="top-nav-avatar"]';
+    const TIMEOUT_MS = 10_000;
+    const POLL_MS = 300;
+
+    await new Promise<void>((resolve, reject) => {
+      const start = Date.now();
+      const interval = setInterval(() => {
+        if (document.querySelector(STABLE_SELECTOR)) {
+          clearInterval(interval);
+          resolve();
+        } else if (Date.now() - start > TIMEOUT_MS) {
+          clearInterval(interval);
+          reject(new Error('Twitch selector timeout'));
+        }
+      }, POLL_MS);
+    });
+
+    initTourPanel();
+  } catch (e) {
+    // Timeout or storage error — skip silently, retry on next navigation
+    debug('Tour panel init skipped:', e);
+  }
+}
+
 // Extension initialization
 function init(): void {
   try {
@@ -143,6 +183,9 @@ function init(): void {
     // Set up the click interceptor
     setupInterceptor();
     log('Click interceptor active');
+
+    // Phase 2 onboarding tour (fires on first Twitch visit after install)
+    maybeInitTourPanel();
 
     // Start streaming mode polling (every 30s)
     const startStreamingPoller = async () => {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -7,10 +7,10 @@
  * 3. Overlay display for confirmation
  */
 
-import { setupInterceptor } from './interceptor';
+import { setupInterceptor, triggerDemoOverlay } from './interceptor';
 import { setupModalObserver, getCurrentChannel } from './detector';
 import { checkAndUpdateLiveStatus } from './streamingMode';
-import { initThemeManager, applyThemeToOverlay } from './themeManager';
+import { initThemeManager } from './themeManager';
 import { log, debug, error, setVersion, loadLogs } from '../shared/logger';
 import { migrateSettings, DEFAULT_SETTINGS } from '../shared/types';
 import './styles.css';
@@ -212,58 +212,8 @@ declare global {
  * Call from console: HC.testOverlay()
  */
 function testOverlay(): void {
-  log('Testing overlay display...');
-
-  const testAttempt = {
-    type: 'subscribe' as const,
-    rawPrice: '$4.99',
-    priceValue: 4.99,
-    channel: getCurrentChannel(),
-    timestamp: new Date(),
-    element: document.body,
-  };
-
-  // Create overlay directly
-  const overlay = document.createElement('div');
-  overlay.id = 'hc-overlay';
-  overlay.className = 'hc-overlay';
-  overlay.innerHTML = `
-    <div class="hc-modal">
-      <div class="hc-header">
-        <span class="hc-icon">🛡️</span>
-        <h2 class="hc-title">SPENDING GUARDIAN</h2>
-      </div>
-      <div class="hc-content">
-        <div class="hc-price-section">
-          <p class="hc-label">TEST MODE - You're about to spend:</p>
-          <p class="hc-price">${testAttempt.rawPrice}</p>
-        </div>
-        <div class="hc-info">
-          <p class="hc-channel">Channel: <strong>${testAttempt.channel}</strong></p>
-          <p class="hc-type">Type: <strong>Subscription</strong></p>
-        </div>
-        <p class="hc-message">
-          This is a TEST overlay. Click Cancel or Proceed to dismiss.
-        </p>
-      </div>
-      <div class="hc-actions">
-        <button class="hc-btn hc-btn-cancel" data-action="cancel">Cancel</button>
-        <button class="hc-btn hc-btn-proceed" data-action="proceed">Proceed Anyway</button>
-      </div>
-    </div>
-  `;
-
-  overlay.addEventListener('click', (e) => {
-    const target = e.target as HTMLElement;
-    if (target.dataset.action || e.target === overlay) {
-      overlay.remove();
-      log('Test overlay dismissed');
-    }
-  });
-
-  applyThemeToOverlay(overlay);
-  document.body.appendChild(overlay);
-  log('Test overlay displayed. Click Cancel or Proceed to dismiss.');
+  log('Testing overlay display via triggerDemoOverlay()...');
+  triggerDemoOverlay().catch((e) => log('testOverlay error:', e));
 }
 
 // Expose to window

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -409,19 +409,33 @@ function showWhitelistSelector(
     `;
   }).join('');
 
-  const selectorHTML = `
-    <div class="hc-whitelist-selector">
-      <p class="hc-whitelist-selector-title">Remember <strong>${channel}</strong> as:</p>
-      ${warningHTML}
-      <div class="hc-whitelist-options">
-        ${optionsHTML}
-      </div>
-    </div>
-  `;
+  // Build selector via DOM construction so channel name is never treated as HTML
+  const selector = document.createElement('div');
+  selector.className = 'hc-whitelist-selector';
+
+  const title = document.createElement('p');
+  title.className = 'hc-whitelist-selector-title';
+  title.append('Remember ');
+  const strong = document.createElement('strong');
+  strong.textContent = channel;
+  title.appendChild(strong);
+  title.append(' as:');
+  selector.appendChild(title);
+
+  if (warningHTML) {
+    const warningWrap = document.createElement('div');
+    warningWrap.innerHTML = warningHTML; // safe: existingEntry.behavior is a WhitelistBehavior enum
+    selector.appendChild(warningWrap.firstElementChild!);
+  }
+
+  const optionsWrap = document.createElement('div');
+  optionsWrap.className = 'hc-whitelist-options';
+  optionsWrap.innerHTML = optionsHTML; // safe: name/desc are hardcoded WHITELIST_BEHAVIOR_LABELS
+  selector.appendChild(optionsWrap);
 
   // Replace the quick-add wrap with the selector
   const wrap = overlay.querySelector('.hc-quick-add-wrap');
-  if (wrap) wrap.outerHTML = selectorHTML;
+  if (wrap) wrap.replaceWith(selector);
 
   // Wire behavior buttons
   overlay.querySelectorAll<HTMLButtonElement>('[data-behavior]').forEach(btn => {

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -9,7 +9,7 @@ import {
   FrictionLevel, SpendingTracker, DEFAULT_SPENDING_TRACKER, ComparisonItem, migrateSettings,
   WhitelistEntry, WhitelistBehavior,
 } from '../shared/types';
-import { isPurchaseButton, createPurchaseAttempt } from './detector';
+import { isPurchaseButton, createPurchaseAttempt, getCurrentChannel } from './detector';
 import { shouldBypassFriction } from './streamingMode';
 import { applyThemeToOverlay } from './themeManager';
 import { log, debug } from '../shared/logger';
@@ -476,6 +476,7 @@ async function showMainOverlay(
         <h2 class="hc-title">Hype Control</h2>
       </div>
       <div class="hc-content">
+        ${attempt.isDemoMode ? '<div class="hc-demo-badge">Demo mode — no real purchase will be made</div>' : ''}
         ${whitelistNote ? `<div class="hc-whitelist-note">${whitelistNote}</div>` : ''}
         <div class="hc-price-section" id="hc-overlay-desc">
           <p class="hc-label" id="hc-overlay-heading">You're about to spend:</p>
@@ -1688,4 +1689,26 @@ export function setupInterceptor(): void {
 export function teardownInterceptor(): void {
   document.removeEventListener('click', clickHandler, { capture: true });
   log('Interceptor removed');
+}
+
+/**
+ * Fires the real friction overlay with mock purchase data.
+ * Used by the onboarding tour (Phase 2) and by HC.testOverlay().
+ * Does NOT write to storage — no spend tracking, no event log.
+ */
+export async function triggerDemoOverlay(): Promise<void> {
+  const settings = await loadSettings();
+  const mockAttempt: PurchaseAttempt = {
+    type: 'Subscribe',
+    rawPrice: '$4.99',
+    priceValue: 4.99,
+    channel: getCurrentChannel() || 'example_channel',
+    timestamp: new Date(),
+    element: document.body,
+    isDemoMode: true,
+  };
+  // Use a fresh tracker so demo never affects daily totals or cooldown
+  const freshTracker = { ...DEFAULT_SPENDING_TRACKER };
+  await runFrictionFlow(mockAttempt, settings, freshTracker);
+  // Intentionally no recordPurchase or writeInterceptEvent — demo mode
 }

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -764,3 +764,170 @@
   font-weight: 600;
   color: var(--hc-danger);
 }
+
+/* ── Onboarding Tour Panel ─────────────────────────────────────────── */
+
+#hc-tour-panel {
+  position: fixed;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  width: 260px;
+  background: var(--hc-modal-bg, #1f1f23);
+  border: 1px solid var(--hc-border, rgba(255,255,255,0.1));
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  z-index: 999996;
+  font-family: 'Space Grotesk', sans-serif;
+  overflow: hidden;
+  transition: width 0.2s, opacity 0.2s;
+}
+
+/* Collapsed tab state (shown while demo overlay is active) */
+.hc-tour-panel--collapsed .hc-tour-header,
+.hc-tour-panel--collapsed .hc-tour-body {
+  display: none;
+}
+
+.hc-tour-panel--collapsed {
+  width: 44px;
+  border-radius: 8px;
+}
+
+.hc-tour-tab {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 0;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--hc-text-muted, rgba(255,255,255,0.5));
+}
+
+.hc-tour-panel--collapsed .hc-tour-tab {
+  display: flex;
+}
+
+/* Panel header */
+.hc-tour-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid var(--hc-border, rgba(255,255,255,0.08));
+}
+
+.hc-tour-icon {
+  flex-shrink: 0;
+}
+
+.hc-tour-title {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--hc-text-primary, #fff);
+}
+
+.hc-tour-close {
+  background: none;
+  border: none;
+  color: var(--hc-text-muted, rgba(255,255,255,0.4));
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 4px;
+  border-radius: 3px;
+  line-height: 1;
+}
+.hc-tour-close:hover {
+  color: var(--hc-text-primary, #fff);
+  background: rgba(255,255,255,0.08);
+}
+
+/* Panel body */
+.hc-tour-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hc-tour-heading {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--hc-text-primary, #fff);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.hc-tour-sub {
+  font-size: 12px;
+  color: var(--hc-text-muted, rgba(255,255,255,0.5));
+  margin: 0;
+  line-height: 1.4;
+}
+
+.hc-tour-complete {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--hc-success, #22C55E);
+  margin: 0;
+  text-align: center;
+  padding: 8px 0;
+}
+
+.hc-tour-btn-primary {
+  background: var(--hc-accent, #9147ff);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  width: 100%;
+  text-align: center;
+  transition: opacity 0.15s;
+}
+.hc-tour-btn-primary:hover { opacity: 0.88; }
+
+/* ── Highlight ring on Twitch buttons ──────────────────────────────── */
+
+.hc-tour-highlight-ring {
+  border: 2px solid var(--hc-accent, #9147ff);
+  box-shadow: 0 0 0 3px rgba(145, 71, 255, 0.3);
+  animation: hc-tour-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes hc-tour-pulse {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(145, 71, 255, 0.3); }
+  50%       { box-shadow: 0 0 0 6px rgba(145, 71, 255, 0.1); }
+}
+
+.hc-tour-highlight-label {
+  background: var(--hc-accent, #9147ff);
+  color: #fff;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* ── Demo mode badge (shown in friction overlay during demo) ────────── */
+
+.hc-demo-badge {
+  display: inline-block;
+  background: rgba(145, 71, 255, 0.15);
+  border: 1px solid rgba(145, 71, 255, 0.4);
+  color: var(--hc-accent, #9147ff);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 12px;
+  margin-bottom: 4px;
+  text-align: center;
+  align-self: flex-start;
+}

--- a/src/content/tourPanel.ts
+++ b/src/content/tourPanel.ts
@@ -1,0 +1,235 @@
+/**
+ * tourPanel.ts — Phase 2 onboarding tour
+ *
+ * Injects a non-blocking slide-out panel on Twitch pages when
+ * hcOnboardingPhase2Pending is true. Two steps:
+ *   Step 1: Highlight visible interceptable buttons
+ *   Step 2: Fire triggerDemoOverlay() so user experiences the real overlay
+ */
+
+import { ONBOARDING_KEYS } from '../shared/types';
+import { triggerDemoOverlay } from './interceptor';
+import { log } from '../shared/logger';
+
+/** Selectors used by detector.ts — kept in sync manually */
+const INTERCEPTABLE_SELECTORS = [
+  '[data-a-target="gift-button"]',
+  '[data-a-target="gift-sub-confirm-button"]',
+  'button[data-a-target="top-nav-get-bits-button"]',
+  'button[aria-label="Bits"]',
+  'button[data-a-target^="bits-purchase-button"]',
+];
+
+interface HighlightedButton {
+  el: HTMLElement;
+  ring: HTMLElement;
+  label: HTMLElement;
+}
+
+let panelEl: HTMLElement | null = null;
+let highlightedButtons: HighlightedButton[] = [];
+let completionTimeout: ReturnType<typeof setTimeout> | null = null;
+
+/** Mark onboarding as complete in storage */
+async function markComplete(): Promise<void> {
+  await chrome.storage.local.set({
+    [ONBOARDING_KEYS.phase2Pending]: false,
+    [ONBOARDING_KEYS.complete]: true,
+  });
+  log('Onboarding Phase 2 complete');
+}
+
+/** Remove all highlight rings from Twitch buttons */
+function clearHighlights(): void {
+  highlightedButtons.forEach(({ ring, label }) => {
+    ring.remove();
+    label.remove();
+  });
+  highlightedButtons = [];
+}
+
+/** Find interceptable buttons currently visible in the viewport */
+function findVisibleInterceptableButtons(): HTMLElement[] {
+  const found: HTMLElement[] = [];
+  for (const selector of INTERCEPTABLE_SELECTORS) {
+    document.querySelectorAll<HTMLElement>(selector).forEach(el => {
+      const rect = el.getBoundingClientRect();
+      const isVisible = rect.width > 0 && rect.height > 0 &&
+        rect.top >= 0 && rect.bottom <= window.innerHeight;
+      if (isVisible && !found.includes(el)) {
+        found.push(el);
+      }
+    });
+  }
+  return found;
+}
+
+/** Get a human-readable label for a highlighted button */
+function getLabelForButton(el: HTMLElement): string {
+  const dataTarget = el.getAttribute('data-a-target') || '';
+  const ariaLabel = (el.getAttribute('aria-label') || '').toLowerCase();
+
+  if (dataTarget.includes('gift')) return 'Gift Sub';
+  if (dataTarget.includes('bits') || ariaLabel === 'bits') return 'Get Bits';
+
+  // Bits purchase tier buttons
+  if (dataTarget.startsWith('bits-purchase-button')) {
+    const match = dataTarget.match(/bits-purchase-button-(\d+)/);
+    return match ? `Buy ${Number(match[1]).toLocaleString()} Bits` : 'Get Bits';
+  }
+
+  return 'Purchase Button';
+}
+
+/** Apply highlight ring and floating label to a button */
+function highlightButton(el: HTMLElement): HighlightedButton {
+  const rect = el.getBoundingClientRect();
+
+  const ring = document.createElement('div');
+  ring.className = 'hc-tour-highlight-ring';
+  ring.style.cssText = `
+    position: fixed;
+    top: ${rect.top - 4}px;
+    left: ${rect.left - 4}px;
+    width: ${rect.width + 8}px;
+    height: ${rect.height + 8}px;
+    pointer-events: none;
+    z-index: 999997;
+    border-radius: 6px;
+  `;
+
+  const label = document.createElement('div');
+  label.className = 'hc-tour-highlight-label';
+  label.textContent = getLabelForButton(el);
+  label.style.cssText = `
+    position: fixed;
+    top: ${rect.top - 28}px;
+    left: ${rect.left}px;
+    pointer-events: none;
+    z-index: 999998;
+  `;
+
+  document.body.appendChild(ring);
+  document.body.appendChild(label);
+
+  return { el, ring, label };
+}
+
+/** Render Step 2 content into the panel */
+function renderStep2(panel: HTMLElement): void {
+  const body = panel.querySelector('.hc-tour-body')!;
+  body.innerHTML = `
+    <p class="hc-tour-heading">Here's what happens when you click one</p>
+    <p class="hc-tour-sub">No real purchase will be made.</p>
+    <button class="hc-tour-btn-primary" id="hc-tour-try-btn">Try it now</button>
+  `;
+
+  panel.querySelector('#hc-tour-try-btn')?.addEventListener('click', async () => {
+    // Collapse panel to tab while overlay is active
+    panel.classList.add('hc-tour-panel--collapsed');
+
+    try {
+      await triggerDemoOverlay();
+    } finally {
+      // Re-expand after overlay is dismissed (triggerDemoOverlay resolves after user interacts)
+      panel.classList.remove('hc-tour-panel--collapsed');
+      showCompletion(panel);
+    }
+  });
+}
+
+/** Show completion message and auto-dismiss */
+function showCompletion(panel: HTMLElement): void {
+  const body = panel.querySelector('.hc-tour-body')!;
+  body.innerHTML = `<p class="hc-tour-complete">That's it. You're protected. 🛡️</p>`;
+
+  completionTimeout = setTimeout(async () => {
+    await markComplete();
+    panel.remove();
+    panelEl = null;
+  }, 3000);
+}
+
+/** Build and inject the tour panel into the page */
+function createPanel(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = 'hc-tour-panel';
+  panel.className = 'hc-tour-panel';
+  panel.setAttribute('role', 'complementary');
+  panel.setAttribute('aria-label', 'Hype Control onboarding tour');
+
+  panel.innerHTML = `
+    <div class="hc-tour-header">
+      <img class="hc-tour-icon" src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="20" height="20" alt="">
+      <span class="hc-tour-title">Hype Control</span>
+      <button class="hc-tour-close" id="hc-tour-close" aria-label="Dismiss tour">✕</button>
+    </div>
+    <div class="hc-tour-body">
+      <!-- Content injected per step -->
+    </div>
+    <!-- Collapsed tab state -->
+    <div class="hc-tour-tab">
+      <img src="${chrome.runtime.getURL('assets/icons/ChromeWebStore/HC_icon_48px.png')}" width="16" height="16" alt="HC">
+      <span>…</span>
+    </div>
+  `;
+
+  // Dismiss / close
+  panel.querySelector('#hc-tour-close')?.addEventListener('click', async () => {
+    if (completionTimeout) clearTimeout(completionTimeout);
+    clearHighlights();
+    await markComplete();
+    panel.remove();
+    panelEl = null;
+  });
+
+  return panel;
+}
+
+/** Run Step 1: find and highlight buttons, show panel */
+function runStep1(panel: HTMLElement): void {
+  const buttons = findVisibleInterceptableButtons();
+  const body = panel.querySelector('.hc-tour-body')!;
+
+  if (buttons.length > 0) {
+    // Highlight each visible button
+    buttons.forEach(btn => {
+      highlightedButtons.push(highlightButton(btn));
+    });
+
+    body.innerHTML = `
+      <p class="hc-tour-heading">Here's what I watch for you</p>
+      <p class="hc-tour-sub">${buttons.length} interceptable button${buttons.length !== 1 ? 's' : ''} on this page</p>
+      <button class="hc-tour-btn-primary" id="hc-tour-next-btn">Show me what happens →</button>
+    `;
+
+    panel.querySelector('#hc-tour-next-btn')?.addEventListener('click', () => {
+      clearHighlights();
+      renderStep2(panel);
+    });
+  } else {
+    // No buttons visible — skip to step 2
+    body.innerHTML = `
+      <p class="hc-tour-heading">Navigate to a channel to see what I protect</p>
+      <p class="hc-tour-sub">Or try a demo now.</p>
+      <button class="hc-tour-btn-primary" id="hc-tour-next-btn">Show me anyway →</button>
+    `;
+
+    panel.querySelector('#hc-tour-next-btn')?.addEventListener('click', () => {
+      renderStep2(panel);
+    });
+  }
+}
+
+/**
+ * Initialize the Phase 2 onboarding tour panel.
+ * Call from index.ts after DOM readiness check passes.
+ */
+export function initTourPanel(): void {
+  if (panelEl) return; // Already initialized
+
+  panelEl = createPanel();
+  document.body.appendChild(panelEl);
+  runStep1(panelEl);
+  log('Onboarding Phase 2 tour panel initialized');
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -629,3 +629,209 @@ body {
   font: inherit;
   color: inherit;
 }
+
+/* ── Onboarding Wizard ─────────────────────────────────────────────── */
+
+.hc-wizard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.hc-wizard[hidden] { display: none; }
+
+.hc-wizard-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.hc-wizard-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.hc-wizard-skip {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-decoration: none;
+  align-self: flex-start;
+}
+.hc-wizard-skip:hover { color: var(--text-primary); text-decoration: underline; }
+
+.hc-wizard-skip-confirm {
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hc-wizard-defaults-msg {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.hc-wizard-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.hc-wizard-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hc-wizard-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hc-wizard-input-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.hc-wizard-prefix,
+.hc-wizard-suffix {
+  font-size: 13px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.hc-wizard-input {
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 5px 8px;
+  width: 100%;
+  min-width: 0;
+}
+.hc-wizard-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.hc-wizard-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin: 0;
+}
+.hc-wizard-hint a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.hc-wizard-hint a:hover { text-decoration: underline; }
+
+.hc-wizard-calc-toggle {
+  font-size: 11px;
+  color: var(--accent);
+  text-decoration: none;
+  align-self: flex-start;
+}
+.hc-wizard-calc-toggle:hover { text-decoration: underline; }
+
+.hc-wizard-salary-calc {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+}
+.hc-wizard-salary-calc[hidden] { display: none; }
+
+/* Friction segmented control */
+.hc-wizard-seg {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.hc-wizard-seg-btn {
+  flex: 1;
+  padding: 5px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+  color: var(--text-muted);
+  transition: background 0.15s, color 0.15s;
+}
+.hc-wizard-seg-btn.active {
+  background: var(--accent);
+  color: #fff;
+}
+.hc-wizard-seg-btn:hover:not(.active) {
+  background: var(--bg-secondary, rgba(255,255,255,0.08));
+  color: var(--text-primary);
+}
+
+.hc-wizard-friction-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin: 0;
+  min-height: 16px;
+}
+
+/* Comparison chips */
+.hc-wizard-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hc-wizard-chip {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.hc-wizard-continue {
+  margin-top: 4px;
+  width: 100%;
+}
+
+/* Replay button in settings section */
+.hc-row--replay {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.btn-replay-tour {
+  font-size: 12px;
+}
+
+/* NOTE: .hc-demo-badge is intentionally NOT defined here.
+   It is used in overlay HTML rendered by interceptor.ts (content script),
+   which loads src/content/styles.css — not popup.css.
+   The badge style is defined in Task 9 (styles.css). */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -11,6 +11,75 @@
   </header>
 
   <div class="hc-body">
+
+    <!-- Onboarding Wizard (Phase 1) — shown on first popup open -->
+    <div id="hc-wizard" class="hc-wizard" hidden>
+      <div class="hc-wizard-header">
+        <img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="28" height="28" alt="">
+        <h2 class="hc-wizard-title">Welcome to Hype Control</h2>
+      </div>
+
+      <a class="hc-wizard-skip" id="wizard-skip" href="#">Skip setup, I'll configure it myself →</a>
+
+      <!-- Skip confirmation (shown after skip click) -->
+      <div id="wizard-skip-confirm" class="hc-wizard-skip-confirm" hidden>
+        <p class="hc-wizard-defaults-msg">You're all set with defaults: <strong>$20/hr wage · 7% sales tax · Medium friction · Preset comparison items enabled.</strong> Update these in Settings anytime.</p>
+        <button class="btn-primary" id="wizard-got-it">Got it →</button>
+      </div>
+
+      <!-- Main wizard form -->
+      <div id="wizard-form" class="hc-wizard-form">
+        <div class="hc-wizard-field">
+          <label class="hc-wizard-label" for="wizard-hourly-rate">Hourly Rate (take-home)</label>
+          <div class="hc-wizard-input-row">
+            <span class="hc-wizard-prefix">$</span>
+            <input type="number" id="wizard-hourly-rate" class="hc-wizard-input" value="20" min="1" max="999" step="0.01">
+          </div>
+          <p class="hc-wizard-hint">$20/hr is our default — update this for accurate results</p>
+          <a class="hc-wizard-calc-toggle" id="wizard-calc-toggle" href="#">Calculate from salary →</a>
+          <div id="wizard-salary-calc" class="hc-wizard-salary-calc" hidden>
+            <div class="hc-wizard-input-row">
+              <span class="hc-wizard-prefix">$</span>
+              <input type="number" id="wizard-annual-salary" class="hc-wizard-input" placeholder="Annual salary" min="1">
+            </div>
+            <div class="hc-wizard-input-row">
+              <input type="number" id="wizard-hours-per-week" class="hc-wizard-input" placeholder="Hours/week" value="40" min="1" max="168">
+              <span class="hc-wizard-suffix">hrs/wk</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="hc-wizard-field">
+          <label class="hc-wizard-label" for="wizard-tax-rate">Sales Tax Rate</label>
+          <div class="hc-wizard-input-row">
+            <input type="number" id="wizard-tax-rate" class="hc-wizard-input" value="7" min="0" max="20" step="0.1">
+            <span class="hc-wizard-suffix">%</span>
+          </div>
+        </div>
+
+        <div class="hc-wizard-field">
+          <span class="hc-wizard-label">Friction Level</span>
+          <div class="hc-wizard-seg" id="wizard-friction-seg" role="group" aria-label="Friction level">
+            <button class="hc-wizard-seg-btn" data-value="low">Low</button>
+            <button class="hc-wizard-seg-btn active" data-value="medium">Medium</button>
+            <button class="hc-wizard-seg-btn" data-value="high">High</button>
+            <button class="hc-wizard-seg-btn" data-value="extreme">Extreme</button>
+          </div>
+          <p class="hc-wizard-friction-desc" id="wizard-friction-desc">Overlay + reason selection</p>
+        </div>
+
+        <div class="hc-wizard-field">
+          <span class="hc-wizard-label">Comparison Items</span>
+          <div class="hc-wizard-chips" id="wizard-chips">
+            <!-- Populated by popup.ts from PRESET_COMPARISON_ITEMS -->
+          </div>
+          <p class="hc-wizard-hint">These are your default comparisons. <a href="#" id="wizard-customize-link">Customize in Settings →</a></p>
+        </div>
+
+        <button class="btn-primary hc-wizard-continue" id="wizard-continue">Continue →</button>
+      </div>
+    </div><!-- /#hc-wizard -->
+
     <div class="hc-content" id="hc-content">
 
       <!-- Section 1: Stats -->
@@ -257,6 +326,9 @@
         <div class="hc-row">
           <button class="btn-secondary" id="btn-view-logs">View Activity Logs</button>
         </div>
+        <div class="hc-row hc-row--replay">
+          <button class="btn-secondary btn-replay-tour" id="btn-replay-tour">↺ Replay setup tour</button>
+        </div>
       </section>
 
       <!-- Section 7: Credits -->
@@ -291,6 +363,7 @@
     <div class="footer-links">
       <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
       <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
+      <a class="footer-link" href="#" id="footer-replay-tour">↺ Tour</a>
     </div>
     <button class="btn-save" id="btn-save">💾 Save Settings</button>
     <span class="footer-version" id="footer-version"></span>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -290,12 +290,12 @@ async function main(): Promise<void> {
   });
 
   // Replay tour triggers
-  document.getElementById('footer-replay-tour')?.addEventListener('click', (e) => {
+  document.getElementById('footer-replay-tour')?.addEventListener('click', async (e) => {
     e.preventDefault();
-    triggerReplay();
+    await triggerReplay();
   });
-  document.getElementById('btn-replay-tour')?.addEventListener('click', () => {
-    triggerReplay();
+  document.getElementById('btn-replay-tour')?.addEventListener('click', async () => {
+    await triggerReplay();
   });
 }
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,6 +1,6 @@
 // src/popup/popup.ts
 import './popup.css';
-import { migrateSettings, ThemePreference } from '../shared/types';
+import { migrateSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS, UserSettings } from '../shared/types';
 import { initPending, getPending, setPendingField } from './pendingState';
 import { initScrollSpy, ScrollSpyItem } from './scrollSpy';
 import { initStats } from './sections/stats';
@@ -38,7 +38,157 @@ function applyTheme(theme: ThemePreference): void {
   document.documentElement.dataset.theme = resolved;
 }
 
+const FRICTION_DESCRIPTIONS: Record<string, string> = {
+  low: 'Main overlay only — one click to cancel',
+  medium: 'Overlay + reason selection',
+  high: 'Overlay + reason + cooldown timer',
+  extreme: 'Everything + math challenge + type-to-confirm',
+};
+
+function showWizard(onComplete: () => void): void {
+  const wizard = document.getElementById('hc-wizard')!;
+  const form = document.getElementById('wizard-form')!;
+  const skipLink = document.getElementById('wizard-skip')!;
+  const skipConfirm = document.getElementById('wizard-skip-confirm')!;
+  const gotItBtn = document.getElementById('wizard-got-it')!;
+  const hourlyInput = document.getElementById('wizard-hourly-rate') as HTMLInputElement;
+  const taxInput = document.getElementById('wizard-tax-rate') as HTMLInputElement;
+  const calcToggle = document.getElementById('wizard-calc-toggle')!;
+  const salaryCalc = document.getElementById('wizard-salary-calc')!;
+  const salaryInput = document.getElementById('wizard-annual-salary') as HTMLInputElement;
+  const hoursInput = document.getElementById('wizard-hours-per-week') as HTMLInputElement;
+  const frictionSeg = document.getElementById('wizard-friction-seg')!;
+  const frictionDesc = document.getElementById('wizard-friction-desc')!;
+  const chips = document.getElementById('wizard-chips')!;
+  const continueBtn = document.getElementById('wizard-continue')!;
+  const customizeLink = document.getElementById('wizard-customize-link')!;
+
+  // Show wizard, hide main content
+  wizard.removeAttribute('hidden');
+  const content = document.getElementById('hc-content')!;
+  const nav = document.getElementById('hc-nav')!;
+  content.setAttribute('hidden', '');
+  nav.setAttribute('hidden', '');
+
+  // Populate comparison chips (first 4 enabled presets)
+  const previewItems = PRESET_COMPARISON_ITEMS.filter(i => i.enabled).slice(0, 4);
+  chips.innerHTML = '';
+  previewItems.forEach(item => {
+    const chip = document.createElement('span');
+    chip.className = 'hc-wizard-chip';
+    chip.textContent = `${item.emoji} ${item.name}`;
+    chips.appendChild(chip);
+  });
+
+  // Salary calculator toggle
+  calcToggle.addEventListener('click', (e) => {
+    e.preventDefault();
+    const isHidden = salaryCalc.hasAttribute('hidden');
+    if (isHidden) {
+      salaryCalc.removeAttribute('hidden');
+      calcToggle.textContent = 'Hide calculator ↑';
+    } else {
+      salaryCalc.setAttribute('hidden', '');
+      calcToggle.textContent = 'Calculate from salary →';
+    }
+  });
+
+  // Salary calculator: auto-compute hourly rate
+  function updateHourlyFromSalary(): void {
+    const salary = parseFloat(salaryInput.value);
+    const hours = parseFloat(hoursInput.value) || 40;
+    if (salary > 0 && hours > 0) {
+      hourlyInput.value = (salary / 52 / hours).toFixed(2);
+    }
+  }
+  salaryInput.addEventListener('input', updateHourlyFromSalary);
+  hoursInput.addEventListener('input', updateHourlyFromSalary);
+
+  // Friction segmented control
+  frictionSeg.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest('.hc-wizard-seg-btn') as HTMLButtonElement | null;
+    if (!btn) return;
+    frictionSeg.querySelectorAll('.hc-wizard-seg-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    frictionDesc.textContent = FRICTION_DESCRIPTIONS[btn.dataset.value ?? 'medium'] ?? '';
+  });
+
+  // Skip path
+  skipLink.addEventListener('click', async (e) => {
+    e.preventDefault();
+    // Write defaults to storage
+    await chrome.storage.sync.set({ hcSettings: DEFAULT_SETTINGS });
+    // Clear wizard pending flag; leave phase2 pending
+    await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
+    // Show skip confirmation
+    form.setAttribute('hidden', '');
+    skipLink.setAttribute('hidden', '');
+    skipConfirm.removeAttribute('hidden');
+    // Auto-close after 3s fallback
+    const autoClose = setTimeout(() => closeWizard(), 3000);
+    gotItBtn.addEventListener('click', () => {
+      clearTimeout(autoClose);
+      closeWizard();
+    });
+  });
+
+  // Customize link — close wizard and navigate to Comparisons section
+  customizeLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    closeWizard();
+    // Scroll to comparisons section
+    setTimeout(() => {
+      document.getElementById('section-comparisons')?.scrollIntoView({ behavior: 'smooth' });
+    }, 50);
+  });
+
+  // Continue button
+  continueBtn.addEventListener('click', async () => {
+    const hourlyRate = parseFloat(hourlyInput.value) || 20;
+    const taxRate = parseFloat(taxInput.value) || 7;
+    const activeBtn = frictionSeg.querySelector<HTMLButtonElement>('.hc-wizard-seg-btn.active');
+    const frictionIntensity = (activeBtn?.dataset.value ?? 'medium') as UserSettings['frictionIntensity'];
+
+    // Load current settings (handles reinstall case — prefills from existing)
+    const result = await chrome.storage.sync.get('hcSettings');
+    const current = migrateSettings(result.hcSettings ?? {});
+    const updated = { ...current, hourlyRate, taxRate, frictionIntensity };
+    await chrome.storage.sync.set({ hcSettings: updated });
+    await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
+    closeWizard();
+  });
+
+  function closeWizard(): void {
+    wizard.setAttribute('hidden', '');
+    content.removeAttribute('hidden');
+    nav.removeAttribute('hidden');
+    onComplete();
+  }
+}
+
+async function triggerReplay(): Promise<void> {
+  await chrome.storage.local.set({
+    [ONBOARDING_KEYS.wizardPending]: true,
+    [ONBOARDING_KEYS.phase2Pending]: true,
+    [ONBOARDING_KEYS.complete]: false,
+  });
+  // Re-render wizard in place.
+  // On completion, reload the popup window to avoid double-initializing
+  // section controllers and event listeners (main() already ran once).
+  showWizard(() => window.location.reload());
+}
+
 async function main(): Promise<void> {
+  // Check if onboarding wizard should be shown (first open)
+  const onboardingState = await chrome.storage.local.get([
+    ONBOARDING_KEYS.wizardPending,
+  ]);
+  if (onboardingState[ONBOARDING_KEYS.wizardPending] === true) {
+    // Show wizard; when complete, re-run main() to populate normal popup state
+    showWizard(() => main());
+    return;
+  }
+
   // Load and migrate settings
   const result = await chrome.storage.sync.get(SETTINGS_KEY);
   const settings = migrateSettings(result[SETTINGS_KEY] ?? {});
@@ -137,6 +287,15 @@ async function main(): Promise<void> {
       saveBtnEl.disabled = false;
       saveBtnEl.textContent = '💾 Save Settings';
     }
+  });
+
+  // Replay tour triggers
+  document.getElementById('footer-replay-tour')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    triggerReplay();
+  });
+  document.getElementById('btn-replay-tour')?.addEventListener('click', () => {
+    triggerReplay();
   });
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,7 @@ export interface PurchaseAttempt {
   channel: string;
   timestamp: Date;
   element: HTMLElement;
+  isDemoMode?: boolean;  // true when fired from triggerDemoOverlay() — skips storage writes
 }
 
 /** Result of the user's decision on the overlay */
@@ -274,3 +275,10 @@ export function migrateSettings(saved: Partial<UserSettings>): UserSettings {
     theme: saved.theme ?? DEFAULT_SETTINGS.theme,
   };
 }
+
+/** Storage keys for onboarding state — all stored in chrome.storage.local */
+export const ONBOARDING_KEYS = {
+  wizardPending: 'hcOnboardingWizardPending',
+  phase2Pending: 'hcOnboardingPhase2Pending',
+  complete: 'hcOnboardingComplete',
+} as const;


### PR DESCRIPTION
## Summary

- **Phase 1 — Popup Wizard:** On first popup open, users are greeted with a single-screen config wizard (hourly rate, tax rate, friction level, comparison items preview). Skip path writes defaults and still activates Phase 2. Replay available from footer and Settings section.
- **Phase 2 — Twitch-Side Tour:** On first Twitch visit, a non-blocking slide-out panel highlights interceptable buttons (Step 1) and fires the real friction overlay in demo mode (Step 2) — no purchase data recorded. Panel collapses to a tab while the overlay is active, then auto-dismisses with a confirmation message.
- **`triggerDemoOverlay()`:** New stable export in `interceptor.ts` that runs the real `runFrictionFlow()` with a mock purchase and a fresh tracker — no storage writes. `HC.testOverlay()` now delegates to this instead of its own inline HTML.
- **Demo badge:** `isDemoMode` field on `PurchaseAttempt` renders a "Demo mode — no real purchase will be made" badge in the overlay.
- **Storage:** Three `chrome.storage.local` flags (`hcOnboardingWizardPending`, `hcOnboardingPhase2Pending`, `hcOnboardingComplete`) set on install via `onInstalled` handler.

## Test plan

- [ ] Remove and reload extension unpacked — verify `hcOnboardingWizardPending: true` and `hcOnboardingPhase2Pending: true` in service worker DevTools storage
- [ ] Open popup — wizard appears, normal popup hidden
- [ ] Test continue path: adjust hourly rate → Continue → settings saved, returns to normal popup
- [ ] Test skip path: click "Skip setup" → defaults summary shown → "Got it →" closes → Phase 2 still pending
- [ ] Navigate to Twitch (logged in) — tour panel appears after selector found
- [ ] Step 1: interceptable buttons highlighted with pulsing ring and label (if present)
- [ ] Step 2: "Try it now" → real overlay fires with "Demo mode" badge, panel collapses to tab
- [ ] Dismiss overlay → panel re-expands → "You're protected." → auto-dismisses → `hcOnboardingComplete: true`
- [ ] Reopen popup — normal stats view, no wizard
- [ ] Replay: "↺ Tour" footer link and "↺ Replay setup tour" in Settings both re-trigger wizard in place
- [ ] `HC.testOverlay()` in console fires the real overlay (not the old static test HTML)
- [ ] Verify demo interactions do NOT appear in activity log or affect spending totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)