### PR TITLE
feat: add spending history view (Add-on 2)

### DIFF
--- a/HypeControl-TODO.md
+++ b/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
 **Updated:** 2026-03-16
-**Current Version:** 0.4.22
+**Current Version:** 0.4.23
 **Based On:** MTS-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -20,7 +20,7 @@
 | Add-on 5 — Streamer Whitelist             | ✅ Complete       |
 | Add-on 1 — Delay Timer                   | ✅ Complete       |
 | Add-on 4 — Custom Comparison Items       | ✅ Complete       |
-| Add-on 2 — Spending History View         | 🔲 Not Started    |
+| Add-on 2 — Spending History View         | ✅ Complete       |
 | Add-on 3 — Weekly/Monthly Limits         | ✅ Complete       |
 | Interactive Onboarding Tour              | ✅ Complete        |
 | Firefox AMO Port                         | 🔲 Not Started    |
@@ -218,8 +218,8 @@ Guided first-install walkthrough that overlays the Twitch page and highlights ea
 
 ### In-Scope (Still To Build)
 
-- [ ] **Add-on 2 — Spending Tracker (History View)** ⭐⭐
-      Full-page view of all logged intercept events. Filter by date range, channel, outcome (cancelled/proceeded). Sort controls. Totals row (total spent, total blocked, total "saved").
+- [x] **Add-on 2 — Spending Tracker (History View)** ⭐⭐
+      Full-page view of all logged intercept events with 6-metric summary bar, filterable by date range, channel, and outcome. Sortable table with expandable row detail. Accessed via popup button.
 
 - [x] **Add-on 3 — Weekly/Monthly Spending Limits** ⭐⭐
       Weekly and monthly caps with independent toggles, 4-tier color progress bars in overlay (green < 60%, yellow 60–79%, orange 80–99%, red 100%+), escalated friction at 100% (doubled delay + acknowledgment checkbox), calendar-aligned resets (Monday/1st), unified budget toast.
@@ -293,4 +293,4 @@ Firefox supports MV3 (since Firefox 109), so this is an adaptation rather than a
 
 ---
 
-_Last updated 2026-03-16 against the v0.4.22 codebase. Weekly/monthly spending limits complete — independent caps with 4-tier progress bars, escalated friction, calendar-aligned resets._
+_Last updated 2026-03-16 against the v0.4.23 codebase. Spending History View complete — full-tab page with 6-metric summary bar, filterable/sortable table, expandable row detail, popup access button._

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,37 @@
+# Scope Contract
+**Task:** Add-on 2 — Spending History View | **Spec:** `docs/superpowers/specs/2026-03-16-spending-history-view-design.md` | **Date:** 2026-03-16 | **Status:** ACTIVE
+
+## In Scope
+- **Files (new):** `src/history/history.html`, `src/history/history.ts`, `src/history/history.css`
+- **Files (modify):** `webpack.config.js`, `src/popup/popup.html`, `src/popup/popup.ts`
+- **Files (version bump):** `manifest.json`, `package.json`, `HypeControl-TODO.md`
+- **Features:**
+  - Full extension page with filterable/sortable table of InterceptEvents
+  - 6-metric summary bar (Total Spent, Total Saved, Cancel Rate, Event Count, Top Cancel Step, Top Reason)
+  - 3 filters (date range, channel, outcome)
+  - Expandable row detail (purchase type, raw price, tax price, step, reason)
+  - Sortable column headers (default: newest first)
+  - Theme support (auto/light/dark)
+  - "View Spending History" button in popup
+  - Empty states
+- **Explicit Boundaries:** No charts, no export, no new storage schemas
+
+## Out of Scope
+- Toggle alignment in popup (CSS fix — separate branch)
+- Tour button placement (HTML reorder — separate branch)
+- Weekly reset day preference (Sunday vs Monday — follow-up to PR #15)
+- Data export (Add-on 6)
+- Charts/visualizations (Add-ons 11/12)
+- Any changes to interceptor.ts or the friction overlay
+
+# Scope Change Log
+| # | Category | What | Why | Decision | Outcome |
+|---|----------|------|-----|----------|---------|
+| 1 | user-expansion | Toggle alignment fix | User noticed misaligned toggles in popup | Defer | Follow-up task |
+| 2 | user-expansion | Tour button move to right of Save | User wants different placement | Defer | Follow-up task |
+| 3 | user-expansion | Weekly reset day (Sun vs Mon) | User questioning Monday default | Defer | Follow-up task |
+
+# Follow-up Tasks
+- [ ] Fix popup toggle alignment (CSS) — scope change #1
+- [ ] Move Tour button to right of Save Settings — scope change #2
+- [ ] Decide weekly reset start day (Sunday vs Monday) — scope change #3

--- a/docs/superpowers/specs/2026-03-16-spending-history-view-design.md
+++ b/docs/superpowers/specs/2026-03-16-spending-history-view-design.md
@@ -1,0 +1,182 @@
+# Add-on 2: Spending History View — Design Spec
+
+**Date:** 2026-03-16
+**Status:** Approved
+**Complexity:** ⭐⭐
+
+---
+
+## Overview
+
+A full extension page (opens in a new browser tab) showing a filterable, sortable table of all InterceptEvents from the last 90 days, with a 6-metric summary bar and expandable row details. Accessed via a "View Spending History" button in the popup.
+
+This is the "look back" companion to the weekly/monthly spending limits (Add-on 3). Users set caps to control future spending; this view lets them understand past spending patterns.
+
+---
+
+## Access Point
+
+A "View Spending History" button in the popup, alongside the existing "View Activity Logs" button. Opens via `chrome.tabs.create({ url: 'history.html' })`.
+
+---
+
+## Page Layout
+
+```
++----------------------------------------------------------+
+| Summary Bar (6 metrics, updates with filters)            |
++----------------------------------------------------------+
+| Filters: [Date Range] [Channel ▾] [Outcome: All|C|P]    |
++----------------------------------------------------------+
+| Table Header (sortable columns)                          |
+|   Date/Time | Channel | Amount | Outcome | Saved         |
++----------------------------------------------------------+
+| Row 1                                                    |
+|   > Expanded detail (purchase type, raw price, step,     |
+|     reason)                                              |
+| Row 2                                                    |
+| Row 3                                                    |
+| ...                                                      |
++----------------------------------------------------------+
+| [Future: Export toolbar area — reserved, not implemented] |
++----------------------------------------------------------+
+```
+
+Respects the user's theme setting (auto/light/dark) by reading `hcSettings.theme` from `chrome.storage.sync` and applying the `data-theme` attribute, matching the logs page pattern (`initTheme()` in logs.ts). Space Grotesk, dark backgrounds, purple accent. Full browser tab width.
+
+---
+
+## Summary Bar — 6 Metrics
+
+All metrics are dynamically scoped to the current filter state. When filters change, the summary updates.
+
+| Metric | Source | Display |
+|--------|--------|---------|
+| **Total Spent** | Sum of `priceWithTax` for proceeded events (null = $0) | `$XX.XX` |
+| **Total Saved** | Sum of `savedAmount` for cancelled events (null = $0) | `$XX.XX` |
+| **Cancel Rate** | `cancelled.length / total.length * 100` | `XX.X%` |
+| **Event Count** | Total events matching filters | `N` |
+| **Top Cancel Step** | Step number with highest cancel frequency | `Step N` or `—` |
+| **Top Reason** | Most common `purchaseReason` among proceeded events | `[reason] (Nx)` or `—` |
+
+**Top Cancel Step:** Displays as `Step N` (number only). The `InterceptEvent` stores `cancelledAtStep` but not the friction intensity that was active, so step numbers can't be reliably mapped to step names (step 3 could be "Reason selection" or a comparison item depending on intensity). Matching the popup's existing "Best Step" display pattern which also shows just the number. On ties, lowest step number wins.
+
+**Top Reason:** Only counts proceeded events that have a `purchaseReason` set. If no events have reasons (e.g., all at low intensity), shows `—`.
+
+**Currency math:** All sums use `Math.round(value * 100) / 100` at computation time.
+
+---
+
+## Table — 5 Visible Columns
+
+| Column | Source Field | Format | Sortable |
+|--------|-------------|--------|----------|
+| **Date/Time** | `timestamp` | Local date + time (e.g., "Mar 16, 2026 8:42 PM") | Yes (default: newest first) |
+| **Channel** | `channel` | Plain text | Yes (alphabetical) |
+| **Amount** | `priceWithTax` | `$XX.XX` or `—` if null | Yes (numeric) |
+| **Outcome** | `outcome` | "Cancelled" or "Proceeded" | Yes |
+| **Saved** | `savedAmount` | `$XX.XX` for cancelled, `—` for proceeded | Yes (numeric) |
+
+### Outcome Styling
+- **Cancelled:** Green text (`#22C55E` dark / `#16A34A` light) — celebrates the save
+- **Proceeded:** Muted text (`#adadb8` dark / `#53535f` light) — acknowledges without judging
+
+### Sort Behavior
+- Click column header to sort ascending; click again for descending
+- Sort indicator arrow on the active column
+- Default: Date/Time descending (newest first)
+- Only one column sorted at a time
+
+---
+
+## Expandable Row Detail
+
+Click any row to expand/collapse a detail panel below it. Only one row expanded at a time (clicking another collapses the previous).
+
+**Detail fields:**
+
+| Field | Source | Display |
+|-------|--------|---------|
+| **Purchase Type** | `purchaseType` | Plain text (e.g., "Gift a Sub") |
+| **Raw Price** | `rawPrice` | Original string from Twitch (e.g., "$4.99") |
+| **Price with Tax** | `priceWithTax` | `$XX.XX` (computed value) |
+| **Cancelled at Step** | `cancelledAtStep` | `Step N` (only for cancelled events) |
+| **Purchase Reason** | `purchaseReason` | Plain text (only if set) |
+
+Fields with no data (null/undefined) are omitted from the detail panel, not shown as blank.
+
+**Security:** All field values rendered via `textContent`, never innerHTML. Channel names and purchase types come from Twitch DOM / storage and must not be interpolated into HTML.
+
+---
+
+## Filters — 3 Controls
+
+Positioned between the summary bar and the table. All filters apply immediately on change (no "Apply" button).
+
+### Date Range
+- Two date inputs: start date and end date
+- Default: last 30 days (today minus 30 days through today)
+- Max range: 90 days (limited by data retention)
+- Changing dates re-filters the table and updates the summary bar
+
+### Channel
+- Dropdown / select element
+- Auto-populated from unique channel names in the current data set
+- Default: "All Channels"
+- Updates when date range changes (only shows channels with events in the selected range)
+- If the currently selected channel has no events in the new date range, resets to "All Channels"
+
+### Outcome
+- Three-state toggle or segmented control: All / Cancelled / Proceeded
+- Default: All
+- Visual styling matches the outcome column colors
+
+---
+
+## Data Source
+
+- Reads from `chrome.storage.local` via the existing `readInterceptEvents()` function from `src/shared/interceptLogger.ts`
+- No new storage schemas or write paths needed
+- 90-day rolling window maintained by existing pruning logic
+- All filtering, sorting, and aggregation happens client-side in the page's TypeScript
+
+---
+
+## Empty States
+
+- **No events at all:** "No spending activity recorded yet. HypeControl will log purchases as you browse Twitch."
+- **No events matching filters:** "No events match your filters. Try adjusting the date range or clearing filters."
+- **No price data:** Some events may have `priceWithTax: null` (price not detected). These show `—` in the Amount column and sort as 0.
+
+---
+
+## File Structure
+
+New files (following existing patterns):
+- `src/history/history.html` — page HTML
+- `src/history/history.ts` — page logic (filtering, sorting, rendering). Must `import './history.css'` at top for webpack CSS extraction (matches logs.ts pattern).
+- `src/history/history.css` — page styles
+
+Modified files:
+- `webpack.config.js` — add `history` entry point AND CopyPlugin pattern: `{ from: 'src/history/history.html', to: 'history.html' }` (matches existing logs.html pattern)
+- `src/popup/popup.html` — add "View Spending History" button in the Settings section, adjacent to the existing "View Activity Logs" button
+- `src/popup/popup.ts` — wire button to open history page via `chrome.tabs.create()`
+
+---
+
+## Design Principles Applied
+
+1. **Numbers are the hero.** Summary bar metrics and the Amount/Saved columns are visually prominent.
+2. **Voice over chrome.** The empty states carry personality without decorative elements.
+3. **Green means saved.** Cancelled outcomes and saved amounts use the success color consistently.
+4. **Distinct, not foreign.** Dark theme, Space Grotesk, purple accent — matches the extension and lives comfortably in Twitch's world.
+5. **Friction is the feature.** The Top Cancel Step metric reinforces which friction steps actually work.
+
+---
+
+## Out of Scope
+
+- **Data export (CSV/JSON/PDF)** — Deferred to Add-on 6. Page layout reserves space for a future export toolbar.
+- **Charts/visualizations** — Deferred to Add-ons 11/12. The table and summary bar are sufficient for the data volume.
+- **Peak spending hours / time bucketing** — Noted in TODO as deferred to this add-on, but the raw timestamp data in the table covers this. Dedicated time analysis can come with the analytics dashboard.
+- **Cross-device sync** — InterceptEvents are in `chrome.storage.local` (device-only). This is by design.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/history/history.css
+++ b/src/history/history.css
@@ -1,0 +1,354 @@
+/* ─── Font faces (same as logs.css) ─────────────────────── */
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-SemiBold.woff2') format('woff2');
+  font-weight: 600;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-display: swap;
+}
+
+/* ─── Variables (same token system as logs.css) ─────────── */
+:root {
+  --bg-primary:    #18181b;
+  --bg-secondary:  #1f1f23;
+  --bg-input:      #0e0e10;
+  --border-color:  #2a2a2e;
+  --accent:        #9147ff;
+  --accent-hover:  #772ce8;
+  --accent-rgb:    145, 71, 255;
+  --text-primary:  #efeff1;
+  --text-secondary:#adadb8;
+  --text-muted:    #666;
+  --danger:        #e91916;
+  --danger-rgb:    233, 25, 22;
+  --success:       #22C55E;
+  --success-light: #16A34A;
+  --outcome-proceeded: #adadb8;
+  --outcome-proceeded-light: #53535f;
+  --radius:        4px;
+  --font:          'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono:     'Space Grotesk', 'Consolas', 'Monaco', monospace;
+}
+
+/* ─── Light mode overrides ───────────────────────────────── */
+[data-theme="light"] {
+  --bg-primary:    #ffffff;
+  --bg-secondary:  #f4f4f5;
+  --bg-input:      #e9e9ec;
+  --border-color:  #d4d4d8;
+  --text-primary:  #18181b;
+  --text-secondary:#3f3f46;
+  --text-muted:    #71717a;
+  --accent:        #7c3aed;
+  --accent-hover:  #6d28d9;
+  --accent-rgb:    124, 58, 237;
+  --danger:        #e91916;
+  --success:       #16A34A;
+  --outcome-proceeded: #53535f;
+}
+
+/* ─── Reset ──────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ─── Base ───────────────────────────────────────────────── */
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font);
+  font-size: 14px;
+  padding: 24px;
+}
+
+/* ─── Layout ─────────────────────────────────────────────── */
+.history-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* ─── Heading ────────────────────────────────────────────── */
+.history-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+/* ─── Summary Bar ────────────────────────────────────────── */
+.summary-bar {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.summary-metric {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 14px 12px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric-value {
+  font-family: var(--font-mono);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.metric-label {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+#metric-saved .metric-value {
+  color: var(--success);
+}
+
+/* ─── Filter Bar ─────────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  gap: 16px;
+  align-items: flex-end;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.filter-input,
+.filter-select {
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+  font-family: var(--font);
+  font-size: 13px;
+}
+
+.filter-input:focus,
+.filter-select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ─── Outcome Toggle ─────────────────────────────────────── */
+.outcome-toggle {
+  display: flex;
+  gap: 2px;
+}
+
+.outcome-btn {
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  font-family: var(--font);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+
+.outcome-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.outcome-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.outcome-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ─── Table ──────────────────────────────────────────────── */
+.table-container {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.history-table th {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+  user-select: none;
+}
+
+.history-table th.sortable {
+  cursor: pointer;
+}
+
+.history-table th.sortable:hover {
+  color: var(--text-primary);
+}
+
+.history-table th.active {
+  color: var(--accent);
+}
+
+.sort-arrow {
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+.history-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 13px;
+  vertical-align: top;
+}
+
+.history-table tbody tr {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.history-table tbody tr:hover {
+  background: var(--bg-secondary);
+}
+
+.history-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Column widths */
+.history-table th:nth-child(1),
+.history-table td:nth-child(1) { width: 26%; }
+.history-table th:nth-child(2),
+.history-table td:nth-child(2) { width: 20%; }
+.history-table th:nth-child(3),
+.history-table td:nth-child(3) { width: 14%; font-family: var(--font-mono); }
+.history-table th:nth-child(4),
+.history-table td:nth-child(4) { width: 16%; }
+.history-table th:nth-child(5),
+.history-table td:nth-child(5) { width: 14%; font-family: var(--font-mono); }
+
+.outcome-cancelled {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.outcome-proceeded {
+  color: var(--outcome-proceeded);
+}
+
+.saved-value {
+  color: var(--success);
+  font-weight: 600;
+}
+
+/* ─── Expandable Row Detail ──────────────────────────────── */
+.detail-row td {
+  padding: 0 12px 12px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-input);
+}
+
+.detail-row:hover {
+  background: var(--bg-input) !important;
+}
+
+.detail-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px 24px;
+  padding: 12px 0;
+}
+
+.detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.detail-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.detail-field-value {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+/* ─── Empty States ───────────────────────────────────────── */
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 48px 24px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .summary-bar {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .filter-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/history/history.html
+++ b/src/history/history.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Spending History — Hype Control</title>
+  <link rel="stylesheet" href="history.css">
+</head>
+<body>
+  <div class="history-wrapper">
+    <h1 class="history-title">
+      <img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="40" height="40" alt="Hype Control">
+      Spending History
+    </h1>
+
+    <!-- Summary Bar -->
+    <div class="summary-bar" id="summary-bar">
+      <div class="summary-metric" id="metric-spent">
+        <span class="metric-value">$0.00</span>
+        <span class="metric-label">Total Spent</span>
+      </div>
+      <div class="summary-metric" id="metric-saved">
+        <span class="metric-value">$0.00</span>
+        <span class="metric-label">Total Saved</span>
+      </div>
+      <div class="summary-metric" id="metric-cancel-rate">
+        <span class="metric-value">0.0%</span>
+        <span class="metric-label">Cancel Rate</span>
+      </div>
+      <div class="summary-metric" id="metric-count">
+        <span class="metric-value">0</span>
+        <span class="metric-label">Events</span>
+      </div>
+      <div class="summary-metric" id="metric-top-step">
+        <span class="metric-value">—</span>
+        <span class="metric-label">Top Cancel Step</span>
+      </div>
+      <div class="summary-metric" id="metric-top-reason">
+        <span class="metric-value">—</span>
+        <span class="metric-label">Top Reason</span>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="filter-bar" id="filter-bar">
+      <div class="filter-group">
+        <label class="filter-label" for="filter-start">From</label>
+        <input type="date" id="filter-start" class="filter-input">
+      </div>
+      <div class="filter-group">
+        <label class="filter-label" for="filter-end">To</label>
+        <input type="date" id="filter-end" class="filter-input">
+      </div>
+      <div class="filter-group">
+        <label class="filter-label" for="filter-channel">Channel</label>
+        <select id="filter-channel" class="filter-select">
+          <option value="">All Channels</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label class="filter-label">Outcome</label>
+        <div class="outcome-toggle" id="outcome-toggle" role="group" aria-label="Outcome filter">
+          <button class="outcome-btn active" data-value="all">All</button>
+          <button class="outcome-btn" data-value="cancelled">Cancelled</button>
+          <button class="outcome-btn" data-value="proceeded">Proceeded</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Table -->
+    <div class="table-container">
+      <table class="history-table" id="history-table">
+        <thead>
+          <tr>
+            <th class="sortable active" data-sort="timestamp">Date/Time <span class="sort-arrow">▼</span></th>
+            <th class="sortable" data-sort="channel">Channel <span class="sort-arrow"></span></th>
+            <th class="sortable" data-sort="amount">Amount <span class="sort-arrow"></span></th>
+            <th class="sortable" data-sort="outcome">Outcome <span class="sort-arrow"></span></th>
+            <th class="sortable" data-sort="saved">Saved <span class="sort-arrow"></span></th>
+          </tr>
+        </thead>
+        <tbody id="history-tbody">
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Empty states -->
+    <div class="empty-state" id="empty-no-data" hidden>
+      No spending activity recorded yet. HypeControl will log purchases as you browse Twitch.
+    </div>
+    <div class="empty-state" id="empty-no-match" hidden>
+      No events match your filters. Try adjusting the date range or clearing filters.
+    </div>
+  </div>
+
+  <script src="history.js"></script>
+</body>
+</html>

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -1,0 +1,71 @@
+/**
+ * Hype Control — Spending History page
+ * Full-tab view of InterceptEvents with filtering, sorting, and summary metrics.
+ */
+
+import './history.css';
+import { InterceptEvent } from '../shared/types';
+import { readInterceptEvents } from '../shared/interceptLogger';
+
+// ─── State ──────────────────────────────────────────────────
+let allEvents: InterceptEvent[] = [];
+let filteredEvents: InterceptEvent[] = [];
+let sortColumn: 'timestamp' | 'channel' | 'amount' | 'outcome' | 'saved' = 'timestamp';
+let sortAsc = false; // default: newest first (descending)
+let expandedRowId: string | null = null;
+
+// ─── Theme ──────────────────────────────────────────────────
+async function initTheme(): Promise<void> {
+  try {
+    const result = await chrome.storage.sync.get('hcSettings');
+    const theme = result?.hcSettings?.theme;
+    if (theme === 'light') {
+      document.documentElement.setAttribute('data-theme', 'light');
+    } else if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: light)').matches) {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  } catch {
+    // non-extension context — ignore
+  }
+}
+
+// ─── Formatting helpers ─────────────────────────────────────
+function formatCurrency(value: number | null | undefined): string {
+  if (value == null) return '—';
+  return '$' + value.toFixed(2);
+}
+
+function formatDate(timestamp: number): string {
+  const d = new Date(timestamp);
+  return d.toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+  }) + ' ' + d.toLocaleTimeString('en-US', {
+    hour: 'numeric', minute: '2-digit', hour12: true,
+  });
+}
+
+function toDateInputValue(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// ─── Placeholder functions (filled in by subsequent tasks) ──
+function applyFilters(): void { /* Task 6 */ }
+function computeSummary(): void { /* Task 7 */ }
+function renderTable(): void { /* Task 8 */ }
+function setupFilters(): void { /* Task 6 */ }
+function setupSort(): void { /* Task 8 */ }
+
+// ─── Entry point ────────────────────────────────────────────
+async function main(): Promise<void> {
+  await initTheme();
+  allEvents = await readInterceptEvents();
+
+  setupFilters();
+  setupSort();
+  applyFilters();
+}
+
+document.addEventListener('DOMContentLoaded', () => { main(); });

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -51,12 +51,339 @@ function toDateInputValue(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
-// ─── Placeholder functions (filled in by subsequent tasks) ──
-function applyFilters(): void { /* Task 6 */ }
-function computeSummary(): void { /* Task 7 */ }
-function renderTable(): void { /* Task 8 */ }
-function setupFilters(): void { /* Task 6 */ }
-function setupSort(): void { /* Task 8 */ }
+// ─── Filter helpers ─────────────────────────────────────────
+function updateChannelDropdown(channelEl: HTMLSelectElement): void {
+  const startEl = document.getElementById('filter-start') as HTMLInputElement;
+  const endEl = document.getElementById('filter-end') as HTMLInputElement;
+  const startDate = startEl.value ? new Date(startEl.value + 'T00:00:00') : null;
+  const endDate = endEl.value ? new Date(endEl.value + 'T23:59:59.999') : null;
+
+  const channelsInRange = new Set<string>();
+  for (const event of allEvents) {
+    if (startDate && event.timestamp < startDate.getTime()) continue;
+    if (endDate && event.timestamp > endDate.getTime()) continue;
+    channelsInRange.add(event.channel);
+  }
+
+  const previousValue = channelEl.value;
+  channelEl.innerHTML = '';
+
+  const allOption = document.createElement('option');
+  allOption.value = '';
+  allOption.textContent = 'All Channels';
+  channelEl.appendChild(allOption);
+
+  const sorted = [...channelsInRange].sort((a, b) => a.localeCompare(b));
+  for (const ch of sorted) {
+    const opt = document.createElement('option');
+    opt.value = ch;
+    opt.textContent = ch;
+    channelEl.appendChild(opt);
+  }
+
+  if (channelsInRange.has(previousValue)) {
+    channelEl.value = previousValue;
+  } else {
+    channelEl.value = '';
+  }
+}
+
+function updateEmptyStates(): void {
+  const noDataEl = document.getElementById('empty-no-data')!;
+  const noMatchEl = document.getElementById('empty-no-match')!;
+  const tableContainer = document.querySelector('.table-container') as HTMLElement;
+
+  if (allEvents.length === 0) {
+    noDataEl.removeAttribute('hidden');
+    noMatchEl.setAttribute('hidden', '');
+    tableContainer.style.display = 'none';
+  } else if (filteredEvents.length === 0) {
+    noDataEl.setAttribute('hidden', '');
+    noMatchEl.removeAttribute('hidden');
+    tableContainer.style.display = 'none';
+  } else {
+    noDataEl.setAttribute('hidden', '');
+    noMatchEl.setAttribute('hidden', '');
+    tableContainer.style.display = '';
+  }
+}
+
+function sortEvents(): void {
+  filteredEvents.sort((a, b) => {
+    let cmp = 0;
+    switch (sortColumn) {
+      case 'timestamp':
+        cmp = a.timestamp - b.timestamp;
+        break;
+      case 'channel':
+        cmp = a.channel.localeCompare(b.channel);
+        break;
+      case 'amount':
+        cmp = (a.priceWithTax ?? 0) - (b.priceWithTax ?? 0);
+        break;
+      case 'outcome':
+        cmp = a.outcome.localeCompare(b.outcome);
+        break;
+      case 'saved':
+        cmp = (a.savedAmount ?? 0) - (b.savedAmount ?? 0);
+        break;
+    }
+    return sortAsc ? cmp : -cmp;
+  });
+}
+
+function setupFilters(): void {
+  const startEl = document.getElementById('filter-start') as HTMLInputElement;
+  const endEl = document.getElementById('filter-end') as HTMLInputElement;
+  const channelEl = document.getElementById('filter-channel') as HTMLSelectElement;
+  const outcomeToggle = document.getElementById('outcome-toggle')!;
+
+  // Default date range: last 30 days
+  const today = new Date();
+  const thirtyAgo = new Date(today);
+  thirtyAgo.setDate(thirtyAgo.getDate() - 30);
+  startEl.value = toDateInputValue(thirtyAgo);
+  endEl.value = toDateInputValue(today);
+
+  startEl.addEventListener('change', () => applyFilters());
+  endEl.addEventListener('change', () => applyFilters());
+  channelEl.addEventListener('change', () => applyFilters());
+
+  outcomeToggle.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest('.outcome-btn') as HTMLButtonElement | null;
+    if (!btn) return;
+    outcomeToggle.querySelectorAll('.outcome-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    applyFilters();
+  });
+}
+
+function applyFilters(): void {
+  const startEl = document.getElementById('filter-start') as HTMLInputElement;
+  const endEl = document.getElementById('filter-end') as HTMLInputElement;
+  const channelEl = document.getElementById('filter-channel') as HTMLSelectElement;
+  const outcomeToggle = document.getElementById('outcome-toggle')!;
+  const activeOutcome = outcomeToggle.querySelector('.outcome-btn.active') as HTMLButtonElement;
+  const outcomeFilter = activeOutcome?.dataset.value ?? 'all';
+
+  const startDate = startEl.value ? new Date(startEl.value + 'T00:00:00') : null;
+  const endDate = endEl.value ? new Date(endEl.value + 'T23:59:59.999') : null;
+
+  filteredEvents = allEvents.filter(event => {
+    if (startDate && event.timestamp < startDate.getTime()) return false;
+    if (endDate && event.timestamp > endDate.getTime()) return false;
+    if (channelEl.value && event.channel !== channelEl.value) return false;
+    if (outcomeFilter !== 'all' && event.outcome !== outcomeFilter) return false;
+    return true;
+  });
+
+  updateChannelDropdown(channelEl);
+  sortEvents();
+  computeSummary();
+  renderTable();
+  updateEmptyStates();
+}
+
+// ─── Summary bar ────────────────────────────────────────────
+function setMetricValue(metricId: string, value: string): void {
+  const el = document.getElementById(metricId);
+  if (!el) return;
+  const valueEl = el.querySelector('.metric-value');
+  if (valueEl) valueEl.textContent = value;
+}
+
+function computeSummary(): void {
+  const proceeded = filteredEvents.filter(e => e.outcome === 'proceeded');
+  const cancelled = filteredEvents.filter(e => e.outcome === 'cancelled');
+
+  const totalSpent = Math.round(
+    proceeded.reduce((sum, e) => sum + (e.priceWithTax ?? 0), 0) * 100
+  ) / 100;
+
+  const totalSaved = Math.round(
+    cancelled.reduce((sum, e) => sum + (e.savedAmount ?? 0), 0) * 100
+  ) / 100;
+
+  const cancelRate = filteredEvents.length === 0
+    ? 0
+    : Math.round((cancelled.length / filteredEvents.length) * 1000) / 10;
+
+  const eventCount = filteredEvents.length;
+
+  const stepCounts: Record<number, number> = {};
+  for (const e of cancelled) {
+    if (e.cancelledAtStep !== undefined) {
+      stepCounts[e.cancelledAtStep] = (stepCounts[e.cancelledAtStep] ?? 0) + 1;
+    }
+  }
+  let topStep: number | null = null;
+  let maxStepCount = 0;
+  for (const [step, count] of Object.entries(stepCounts)) {
+    const stepNum = Number(step);
+    if (count > maxStepCount || (count === maxStepCount && topStep !== null && stepNum < topStep)) {
+      maxStepCount = count;
+      topStep = stepNum;
+    }
+  }
+
+  const reasonCounts: Record<string, number> = {};
+  for (const e of proceeded) {
+    if (e.purchaseReason) {
+      reasonCounts[e.purchaseReason] = (reasonCounts[e.purchaseReason] ?? 0) + 1;
+    }
+  }
+  let topReason: string | null = null;
+  let topReasonCount = 0;
+  for (const [reason, count] of Object.entries(reasonCounts)) {
+    if (count > topReasonCount) {
+      topReasonCount = count;
+      topReason = reason;
+    }
+  }
+
+  setMetricValue('metric-spent', formatCurrency(totalSpent));
+  setMetricValue('metric-saved', formatCurrency(totalSaved));
+  setMetricValue('metric-cancel-rate', cancelRate.toFixed(1) + '%');
+  setMetricValue('metric-count', String(eventCount));
+  setMetricValue('metric-top-step', topStep !== null ? `Step ${topStep}` : '—');
+  setMetricValue('metric-top-reason',
+    topReason ? `${topReason} (${topReasonCount}x)` : '—'
+  );
+}
+
+// ─── Table rendering ─────────────────────────────────────────
+function makeDetailField(label: string, value: string): HTMLElement {
+  const field = document.createElement('div');
+  field.className = 'detail-field';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'detail-field-label';
+  labelEl.textContent = label;
+  field.appendChild(labelEl);
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'detail-field-value';
+  valueEl.textContent = value;
+  field.appendChild(valueEl);
+
+  return field;
+}
+
+function appendDetailRow(event: InterceptEvent, afterRow: HTMLTableRowElement): void {
+  const detailTr = document.createElement('tr');
+  detailTr.className = 'detail-row';
+
+  const detailTd = document.createElement('td');
+  detailTd.colSpan = 5;
+
+  const panel = document.createElement('div');
+  panel.className = 'detail-panel';
+
+  if (event.purchaseType) {
+    panel.appendChild(makeDetailField('Purchase Type', event.purchaseType));
+  }
+  if (event.rawPrice) {
+    panel.appendChild(makeDetailField('Raw Price', event.rawPrice));
+  }
+  if (event.priceWithTax != null) {
+    panel.appendChild(makeDetailField('Price with Tax', formatCurrency(event.priceWithTax)));
+  }
+  if (event.outcome === 'cancelled' && event.cancelledAtStep !== undefined) {
+    panel.appendChild(makeDetailField('Cancelled at Step', `Step ${event.cancelledAtStep}`));
+  }
+  if (event.purchaseReason) {
+    panel.appendChild(makeDetailField('Purchase Reason', event.purchaseReason));
+  }
+
+  detailTd.appendChild(panel);
+  detailTr.appendChild(detailTd);
+  afterRow.after(detailTr);
+}
+
+function toggleDetail(event: InterceptEvent, tr: HTMLTableRowElement): void {
+  const tbody = document.getElementById('history-tbody')!;
+  const existingDetail = tbody.querySelector('.detail-row');
+  if (existingDetail) existingDetail.remove();
+
+  if (expandedRowId === event.id) {
+    expandedRowId = null;
+    return;
+  }
+
+  expandedRowId = event.id;
+  appendDetailRow(event, tr);
+}
+
+function renderTable(): void {
+  const tbody = document.getElementById('history-tbody')!;
+  tbody.innerHTML = '';
+
+  for (const event of filteredEvents) {
+    const tr = document.createElement('tr');
+    tr.dataset.eventId = event.id;
+
+    const tdDate = document.createElement('td');
+    tdDate.textContent = formatDate(event.timestamp);
+    tr.appendChild(tdDate);
+
+    const tdChannel = document.createElement('td');
+    tdChannel.textContent = event.channel;
+    tr.appendChild(tdChannel);
+
+    const tdAmount = document.createElement('td');
+    tdAmount.textContent = formatCurrency(event.priceWithTax);
+    tr.appendChild(tdAmount);
+
+    const tdOutcome = document.createElement('td');
+    tdOutcome.textContent = event.outcome === 'cancelled' ? 'Cancelled' : 'Proceeded';
+    tdOutcome.className = event.outcome === 'cancelled' ? 'outcome-cancelled' : 'outcome-proceeded';
+    tr.appendChild(tdOutcome);
+
+    const tdSaved = document.createElement('td');
+    if (event.outcome === 'cancelled' && event.savedAmount != null) {
+      tdSaved.textContent = formatCurrency(event.savedAmount);
+      tdSaved.className = 'saved-value';
+    } else {
+      tdSaved.textContent = '—';
+    }
+    tr.appendChild(tdSaved);
+
+    tr.addEventListener('click', () => toggleDetail(event, tr));
+    tbody.appendChild(tr);
+
+    if (expandedRowId === event.id) {
+      appendDetailRow(event, tr);
+    }
+  }
+}
+
+function setupSort(): void {
+  const headers = document.querySelectorAll<HTMLTableCellElement>('.history-table th.sortable');
+
+  headers.forEach(th => {
+    th.addEventListener('click', () => {
+      const column = th.dataset.sort as typeof sortColumn;
+      if (sortColumn === column) {
+        sortAsc = !sortAsc;
+      } else {
+        sortColumn = column;
+        sortAsc = column === 'channel'; // alpha defaults ascending; everything else descending
+      }
+
+      headers.forEach(h => {
+        h.classList.remove('active');
+        const arrow = h.querySelector('.sort-arrow');
+        if (arrow) arrow.textContent = '';
+      });
+      th.classList.add('active');
+      const arrow = th.querySelector('.sort-arrow');
+      if (arrow) arrow.textContent = sortAsc ? '▲' : '▼';
+
+      sortEvents();
+      renderTable();
+    });
+  });
+}
 
 // ─── Entry point ────────────────────────────────────────────
 async function main(): Promise<void> {

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -66,7 +66,7 @@ function updateChannelDropdown(channelEl: HTMLSelectElement): void {
   }
 
   const previousValue = channelEl.value;
-  channelEl.innerHTML = '';
+  channelEl.replaceChildren();
 
   const allOption = document.createElement('option');
   allOption.value = '';
@@ -316,7 +316,7 @@ function toggleDetail(event: InterceptEvent, tr: HTMLTableRowElement): void {
 
 function renderTable(): void {
   const tbody = document.getElementById('history-tbody')!;
-  tbody.innerHTML = '';
+  tbody.replaceChildren();
 
   for (const event of filteredEvents) {
     const tr = document.createElement('tr');

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -348,6 +348,9 @@
           <input type="number" id="toast-duration" min="1" max="30" step="1" class="hc-input hc-input--sm" />
         </div>
         <div class="hc-row">
+          <button class="btn-secondary" id="btn-view-history">View Spending History</button>
+        </div>
+        <div class="hc-row">
           <button class="btn-secondary" id="btn-view-logs">View Activity Logs</button>
         </div>
         <div class="hc-row hc-row--replay">

--- a/src/popup/sections/settings-section.ts
+++ b/src/popup/sections/settings-section.ts
@@ -13,6 +13,7 @@ export interface SettingsSectionController {
 export function initSettingsSection(el: HTMLElement, callbacks: SettingsSectionCallbacks = {}): SettingsSectionController {
   const themeEl = el.querySelector<HTMLSelectElement>('#theme-select')!;
   const toastEl = el.querySelector<HTMLInputElement>('#toast-duration')!;
+  const historyBtn = el.querySelector<HTMLButtonElement>('#btn-view-history')!;
   const logsBtn = el.querySelector<HTMLButtonElement>('#btn-view-logs')!;
 
   themeEl.addEventListener('change', () => {
@@ -23,6 +24,10 @@ export function initSettingsSection(el: HTMLElement, callbacks: SettingsSectionC
 
   toastEl.addEventListener('input', () => {
     setPendingField('toastDurationSeconds', parseInt(toastEl.value, 10) || 15);
+  });
+
+  historyBtn.addEventListener('click', () => {
+    chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
   });
 
   logsBtn.addEventListener('click', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const pkg = require('./package.json');
 module.exports = {
   entry: {
     content: './src/content/index.ts',
+    history: './src/history/history.ts',
     logs: './src/logs/logs.ts',
     popup: './src/popup/popup.ts',
     serviceWorker: './src/background/serviceWorker.ts',
@@ -47,6 +48,7 @@ module.exports = {
             return JSON.stringify(manifest, null, 2);
           },
         },
+        { from: 'src/history/history.html', to: 'history.html' },
         { from: 'src/logs/logs.html', to: 'logs.html' },
         { from: 'src/popup/popup.html', to: 'popup.html' },
         { from: 'assets', to: 'assets', noErrorOnMissing: true },


### PR DESCRIPTION
## Summary

- Add full-tab spending history page (`history.html`) with 6-metric summary bar, filterable/sortable table of InterceptEvents, and expandable row detail
- Wire "View Spending History" button in popup Settings section (opens via `chrome.tabs.create`)
- Add webpack entry point and CopyPlugin pattern for the new page

## Details

**Summary Bar (6 metrics):** Total Spent, Total Saved, Cancel Rate, Event Count, Top Cancel Step, Top Reason — all dynamically scoped to current filter state.

**Filters:** Date range (default last 30 days), channel dropdown (auto-populated from data), outcome toggle (All/Cancelled/Proceeded). All apply immediately on change.

**Table:** 5 sortable columns (Date/Time, Channel, Amount, Outcome, Saved). Click any row to expand detail panel showing purchase type, raw price, tax price, cancel step, and purchase reason. Only one row expanded at a time.

**Security:** All user-controlled values rendered via `textContent` and `replaceChildren()` — no innerHTML with interpolated data.

## New Files
- `src/history/history.html` — page shell
- `src/history/history.ts` — all page logic (filtering, sorting, summary computation, table rendering)
- `src/history/history.css` — styles with dark/light theme support

## Modified Files
- `webpack.config.js` — history entry point + copy pattern
- `src/popup/popup.html` — "View Spending History" button
- `src/popup/sections/settings-section.ts` — button click handler

## Test Plan
- [ ] Load extension, open popup, click "View Spending History" — page opens in new tab
- [ ] Verify summary bar shows correct metrics for existing InterceptEvents
- [ ] Test date range filter narrows results and updates summary
- [ ] Test channel dropdown filters to single channel
- [ ] Test outcome toggle filters Cancelled/Proceeded/All
- [ ] Click column headers to sort ascending/descending
- [ ] Click a row to expand detail panel; click another to collapse previous
- [ ] Verify empty states show when no data / no filter matches
- [ ] Toggle theme in popup Settings — history page respects theme on next load
- [ ] Verify light mode styling renders correctly

Generated with [Claude Code](https://claude.com/claude-code)