### PR TITLE
maint: popup polish, dynamic intensity escalation, wizard UX (v0.4.24)

### DIFF
--- a/HypeControl-TODO.md
+++ b/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
 **Updated:** 2026-03-16
-**Current Version:** 0.4.23
+**Current Version:** 0.4.24
 **Based On:** MTS-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -293,4 +293,21 @@ Firefox supports MV3 (since Firefox 109), so this is an adaptation rather than a
 
 ---
 
-_Last updated 2026-03-16 against the v0.4.23 codebase. Spending History View complete — full-tab page with 6-metric summary bar, filterable/sortable table, expandable row detail, popup access button._
+## MAINTENANCE PASS — v0.4.24 (2026-03-16)
+
+All items in the maintenance pass are complete:
+
+- [x] **Toggle vertical alignment** — `.toggle-wrap` flex items now align via `align-items: center`
+- [x] **History summary bar true-center** — `.hc-history-summary` uses `justify-content: center` with `flex-wrap: wrap`
+- [x] **History metric color parity** — Positive/negative/neutral metric values use green/red/default tokens consistently
+- [x] **Replay tour button relocation** — "Replay Setup Tour" button moved to bottom of `.hc-content` (above nav), out of Settings section
+- [x] **New settings fields + migration** — `weeklyResetDay` (monday/sunday), `intensityLocked` (bool), `dynamicIntensity` (bool) added to `UserSettings` with defaults and migration
+- [x] **Escalation logic module** — `src/shared/escalation.ts` computes escalated intensity from cap percentage thresholds
+- [x] **Weekly reset day preference** — Popup Limits section shows Mon/Sun segmented control when weekly cap is enabled; `getWeekStart()` respects the setting
+- [x] **Escalation wired into content script** — `interceptor.ts` reads tracker + settings, computes effective intensity via `computeEscalatedIntensity`, uses it for overlay
+- [x] **Escalation UI in popup** — Stats and Friction sections show escalation indicator banner + lock toggle; bidirectional intensity mirrors updated
+- [x] **Wizard default changed to Low** — Wizard friction segmented control, skip-confirmation text, friction-desc, and fallback all updated to Low intensity
+
+---
+
+_Last updated 2026-03-16 against the v0.4.24 codebase. Maintenance pass complete — toggle alignment, tour button relocation, weekly reset day, history centering + colors, dynamic intensity escalation, wizard default Low._

--- a/docs/superpowers/plans/2026-03-16-popup-polish-and-escalation.md
+++ b/docs/superpowers/plans/2026-03-16-popup-polish-and-escalation.md
@@ -1,0 +1,1064 @@
+# Popup Polish & Dynamic Intensity Escalation — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a 6-fix maintenance pass: toggle alignment, tour button relocation, weekly reset day preference, history summary centering, dynamic intensity escalation, and history metric color parity.
+
+**Architecture:** Pure CSS fixes (1, 4, 6) are independent. HTML/TS changes (2, 3, 5) touch popup.html and popup.ts. Fix 5 (escalation) is the meatiest — it adds a `computeEscalatedIntensity()` function to a new shared module and wires it into both the popup and the content-script interceptor. Fix 3 modifies `getCurrentWeekStart()` in interceptor.ts. All new settings fields get migration in `migrateSettings()`.
+
+**Tech Stack:** TypeScript, webpack, Chrome Extension MV3, Jest (ts-jest)
+
+**Spec:** `docs/superpowers/specs/2026-03-16-popup-polish-and-escalation-design.md`
+
+---
+
+## Chunk 1: CSS-Only Fixes (Tasks 1–3)
+
+These three tasks are independent and touch no TypeScript. Each is a single-file CSS edit.
+
+### Task 1: Toggle Vertical Alignment (Fix 1)
+
+**Files:**
+- Modify: `src/popup/popup.css:219` (`.hc-label` min-width)
+
+- [ ] **Step 1: Edit `.hc-label` min-width**
+
+In `src/popup/popup.css`, change `.hc-label` `min-width` from `110px` to `140px`:
+
+```css
+.hc-label {
+  flex: 0 0 auto;
+  min-width: 140px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+Expected: Build succeeds. All toggles in Friction, Limits, and Channels sections now align vertically.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/popup/popup.css
+git commit -m "fix: align toggles vertically by widening label min-width to 140px"
+```
+
+---
+
+### Task 2: History Summary Bar True-Center (Fix 4)
+
+**Files:**
+- Modify: `src/history/history.css:104-113` (`.summary-metric`)
+
+- [ ] **Step 1: Add vertical centering and min-height to `.summary-metric`**
+
+In `src/history/history.css`, update `.summary-metric`:
+
+```css
+.summary-metric {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 14px 12px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  min-height: 80px;
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+Expected: All 6 summary metric cards are vertically and horizontally centered.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/history/history.css
+git commit -m "fix: true-center history summary metric cards"
+```
+
+---
+
+### Task 3: History Metric Color Parity (Fix 6)
+
+**Files:**
+- Modify: `src/history/history.css:130-132` (add color overrides after existing `#metric-saved`)
+
+- [ ] **Step 1: Add metric color overrides**
+
+In `src/history/history.css`, after the existing `#metric-saved .metric-value` rule, add:
+
+```css
+#metric-saved .metric-value {
+  color: var(--success);
+}
+
+#metric-spent .metric-value {
+  color: var(--danger);
+}
+
+#metric-cancel-rate .metric-value {
+  color: #f59e0b;
+}
+
+#metric-top-step .metric-value {
+  color: var(--accent);
+}
+```
+
+This replaces the existing `#metric-saved` rule and adds three new ones. `#metric-count` and `#metric-top-reason` keep default text color (no popup equivalent).
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+Expected: Total Spent = red, Total Saved = green, Cancel Rate = amber, Top Cancel Step = purple.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/history/history.css
+git commit -m "fix: match history summary metric colors to popup stat tiles"
+```
+
+---
+
+## Chunk 2: Tour Button Relocation (Task 4)
+
+### Task 4: Relocate Replay Tour Button (Fix 2)
+
+**Files:**
+- Modify: `src/popup/popup.html:356-358` (remove Settings section button), `src/popup/popup.html:393` (remove footer link)
+- Modify: `src/popup/popup.css:823-832` (remove old styles, add new)
+- Modify: `src/popup/popup.ts:292-299` (rewire event handler)
+
+- [ ] **Step 1: Remove old tour button from Settings section in popup.html**
+
+Remove lines 356-358 (the `.hc-row--replay` div):
+
+```html
+      <div class="hc-row hc-row--replay">
+          <button class="btn-secondary btn-replay-tour" id="btn-replay-tour">↺ Replay setup tour</button>
+        </div>
+```
+
+- [ ] **Step 2: Remove footer tour link from popup.html**
+
+In the `.footer-links` div (around line 393), remove:
+
+```html
+      <a class="footer-link" href="#" id="footer-replay-tour">↺ Tour</a>
+```
+
+- [ ] **Step 3: Add new tour button below Credits section in popup.html**
+
+After the closing `</section>` of `section-credits` (after line 373) and before the closing `</div><!-- /.hc-content -->`, add:
+
+```html
+    <button class="btn-secondary btn-replay-bottom" id="btn-replay-bottom">↺ Replay Setup Tour</button>
+```
+
+- [ ] **Step 4: Update popup.css — remove old styles, add new**
+
+Replace the old replay button styles (lines 823-832):
+
+```css
+/* Replay button in settings section */
+.hc-row--replay {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.btn-replay-tour {
+  font-size: 12px;
+}
+```
+
+With:
+
+```css
+/* Replay tour button — lives below Credits at the very bottom */
+.btn-replay-bottom {
+  display: block;
+  margin: 24px auto 16px;
+  font-size: 12px;
+  opacity: 0.7;
+}
+.btn-replay-bottom:hover {
+  opacity: 1;
+}
+```
+
+- [ ] **Step 5: Update popup.ts — rewire event handler**
+
+Replace the two replay tour handlers (lines 292-299):
+
+```typescript
+  // Replay tour triggers
+  document.getElementById('footer-replay-tour')?.addEventListener('click', async (e) => {
+    e.preventDefault();
+    await triggerReplay();
+  });
+  document.getElementById('btn-replay-tour')?.addEventListener('click', async () => {
+    await triggerReplay();
+  });
+```
+
+With a single handler:
+
+```typescript
+  // Replay tour trigger
+  document.getElementById('btn-replay-bottom')?.addEventListener('click', async () => {
+    await triggerReplay();
+  });
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `npm run build`
+Expected: No tour button in footer or Settings section. Single "Replay Setup Tour" button at bottom of page below Credits.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/popup/popup.html src/popup/popup.css src/popup/popup.ts
+git commit -m "fix: relocate replay tour button to bottom of page below Credits"
+```
+
+---
+
+## Chunk 3: Types, Migration & Escalation Logic (Tasks 5–6)
+
+### Task 5: Add New Settings Fields & Migration
+
+**Files:**
+- Modify: `src/shared/types.ts:102-118` (UserSettings interface)
+- Modify: `src/shared/types.ts:155-195` (DEFAULT_SETTINGS)
+- Modify: `src/shared/types.ts:205` (weeklyStartDate comment)
+- Modify: `src/shared/types.ts:237-315` (migrateSettings)
+
+- [ ] **Step 1: Write failing tests for new settings fields**
+
+Create `tests/shared/types.test.ts`:
+
+```typescript
+import { migrateSettings, DEFAULT_SETTINGS, UserSettings } from '../../src/shared/types';
+
+describe('migrateSettings', () => {
+  test('adds weeklyResetDay with default monday for existing users', () => {
+    const saved: Partial<UserSettings> = { hourlyRate: 25 };
+    const result = migrateSettings(saved);
+    expect(result.weeklyResetDay).toBe('monday');
+  });
+
+  test('preserves existing weeklyResetDay value', () => {
+    const saved: Partial<UserSettings> = { weeklyResetDay: 'sunday' } as any;
+    const result = migrateSettings(saved);
+    expect(result.weeklyResetDay).toBe('sunday');
+  });
+
+  test('adds intensityLocked with default false for existing users', () => {
+    const saved: Partial<UserSettings> = { hourlyRate: 25 };
+    const result = migrateSettings(saved);
+    expect(result.intensityLocked).toBe(false);
+  });
+
+  test('preserves existing intensityLocked value', () => {
+    const saved: Partial<UserSettings> = { intensityLocked: true } as any;
+    const result = migrateSettings(saved);
+    expect(result.intensityLocked).toBe(true);
+  });
+
+  test('DEFAULT_SETTINGS has frictionIntensity set to low', () => {
+    expect(DEFAULT_SETTINGS.frictionIntensity).toBe('low');
+  });
+
+  test('does not overwrite existing frictionIntensity on migration', () => {
+    const saved: Partial<UserSettings> = { frictionIntensity: 'high' };
+    const result = migrateSettings(saved);
+    expect(result.frictionIntensity).toBe('high');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest tests/shared/types.test.ts -v`
+Expected: FAIL — `weeklyResetDay` and `intensityLocked` are undefined, `frictionIntensity` default is `'medium'`
+
+- [ ] **Step 3: Add fields to UserSettings interface**
+
+In `src/shared/types.ts`, add to the `UserSettings` interface (after `theme: ThemePreference;`):
+
+```typescript
+  weeklyResetDay: 'monday' | 'sunday';
+  intensityLocked: boolean;
+```
+
+- [ ] **Step 4: Update DEFAULT_SETTINGS**
+
+Change `frictionIntensity: 'medium'` to `frictionIntensity: 'low'`.
+
+Add new defaults at the end (before the closing `};`):
+
+```typescript
+  weeklyResetDay: 'monday',
+  intensityLocked: false,
+```
+
+- [ ] **Step 5: Update weeklyStartDate comment**
+
+Change line 205 from:
+```typescript
+  weeklyStartDate: string;   // ISO date of the Monday that starts the current week (YYYY-MM-DD)
+```
+To:
+```typescript
+  weeklyStartDate: string;   // ISO date of the day that starts the current week (Monday or Sunday, YYYY-MM-DD)
+```
+
+- [ ] **Step 6: Add migration for new fields**
+
+In `migrateSettings()`, in the return block, add these two lines (after the `theme` line):
+
+```typescript
+    weeklyResetDay: saved.weeklyResetDay ?? DEFAULT_SETTINGS.weeklyResetDay,
+    intensityLocked: saved.intensityLocked ?? DEFAULT_SETTINGS.intensityLocked,
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npx jest tests/shared/types.test.ts -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 8: Fix existing test — pendingState.test.ts**
+
+The test at `tests/popup/pendingState.test.ts:19` asserts `frictionIntensity` is `'medium'`. Update to `'low'`:
+
+```typescript
+    expect(p.frictionIntensity).toBe('low');
+```
+
+Also at line 38 (resetPending test), same change:
+
+```typescript
+    expect(mod.getPending().frictionIntensity).toBe('low');
+```
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `npx jest -v`
+Expected: All tests PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/shared/types.ts tests/shared/types.test.ts tests/popup/pendingState.test.ts
+git commit -m "feat: add weeklyResetDay, intensityLocked settings; change default intensity to low"
+```
+
+---
+
+### Task 6: Create Escalation Logic Module
+
+**Files:**
+- Create: `src/shared/escalation.ts`
+- Create: `tests/shared/escalation.test.ts`
+
+- [ ] **Step 1: Write failing tests for `computeEscalatedIntensity`**
+
+Create `tests/shared/escalation.test.ts`:
+
+```typescript
+import { computeEscalatedIntensity, computeMaxCapPercent } from '../../src/shared/escalation';
+import { DEFAULT_SETTINGS, UserSettings, SpendingTracker, DEFAULT_SPENDING_TRACKER } from '../../src/shared/types';
+
+describe('computeMaxCapPercent', () => {
+  const baseSettings = { ...DEFAULT_SETTINGS };
+  const baseTracker = { ...DEFAULT_SPENDING_TRACKER };
+
+  test('returns 0 when no caps are enabled', () => {
+    expect(computeMaxCapPercent(baseSettings, baseTracker)).toBe(0);
+  });
+
+  test('returns daily cap percentage when only daily cap enabled', () => {
+    const settings = { ...baseSettings, dailyCap: { enabled: true, amount: 100 } };
+    const tracker = { ...baseTracker, dailyTotal: 60 };
+    expect(computeMaxCapPercent(settings, tracker)).toBe(60);
+  });
+
+  test('returns highest percentage across multiple caps', () => {
+    const settings = {
+      ...baseSettings,
+      dailyCap: { enabled: true, amount: 100 },
+      weeklyCap: { enabled: true, amount: 200 },
+      monthlyCap: { enabled: true, amount: 1000 },
+    };
+    const tracker = { ...baseTracker, dailyTotal: 30, weeklyTotal: 180, monthlyTotal: 100 };
+    // daily=30%, weekly=90%, monthly=10% → max=90
+    expect(computeMaxCapPercent(settings, tracker)).toBe(90);
+  });
+
+  test('returns percentage above 100 when cap exceeded', () => {
+    const settings = { ...baseSettings, dailyCap: { enabled: true, amount: 50 } };
+    const tracker = { ...baseTracker, dailyTotal: 75 };
+    expect(computeMaxCapPercent(settings, tracker)).toBe(150);
+  });
+
+  test('ignores disabled caps', () => {
+    const settings = {
+      ...baseSettings,
+      dailyCap: { enabled: false, amount: 10 },
+      weeklyCap: { enabled: true, amount: 200 },
+    };
+    const tracker = { ...baseTracker, dailyTotal: 100, weeklyTotal: 50 };
+    // daily disabled (even though 1000%), weekly=25% → max=25
+    expect(computeMaxCapPercent(settings, tracker)).toBe(25);
+  });
+});
+
+describe('computeEscalatedIntensity', () => {
+  test('returns base intensity when no caps enabled (maxPercent=0)', () => {
+    expect(computeEscalatedIntensity('low', 0, false)).toBe('low');
+  });
+
+  test('returns base intensity when under 60%', () => {
+    expect(computeEscalatedIntensity('low', 59, false)).toBe('low');
+  });
+
+  test('escalates to medium at 60%', () => {
+    expect(computeEscalatedIntensity('low', 60, false)).toBe('medium');
+  });
+
+  test('escalates to high at 80%', () => {
+    expect(computeEscalatedIntensity('low', 80, false)).toBe('high');
+  });
+
+  test('escalates to extreme at 100%', () => {
+    expect(computeEscalatedIntensity('low', 100, false)).toBe('extreme');
+  });
+
+  test('escalates to extreme above 100%', () => {
+    expect(computeEscalatedIntensity('low', 150, false)).toBe('extreme');
+  });
+
+  test('does not escalate below base intensity', () => {
+    // Base is high, 65% would suggest medium, but high > medium so stays high
+    expect(computeEscalatedIntensity('high', 65, false)).toBe('high');
+  });
+
+  test('does not escalate when locked', () => {
+    expect(computeEscalatedIntensity('low', 95, true)).toBe('low');
+  });
+
+  test('does not escalate when locked even at 100%+', () => {
+    expect(computeEscalatedIntensity('low', 150, true)).toBe('low');
+  });
+
+  test('medium base at 80% escalates to high', () => {
+    expect(computeEscalatedIntensity('medium', 80, false)).toBe('high');
+  });
+
+  test('medium base at 65% stays medium (already at that tier)', () => {
+    expect(computeEscalatedIntensity('medium', 65, false)).toBe('medium');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest tests/shared/escalation.test.ts -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `src/shared/escalation.ts`**
+
+```typescript
+import { FrictionIntensity, UserSettings, SpendingTracker } from './types';
+
+/** Ordered intensity levels from lowest to highest */
+const INTENSITY_ORDER: FrictionIntensity[] = ['low', 'medium', 'high', 'extreme'];
+
+/**
+ * Compute the highest spending percentage across all active caps.
+ * Returns 0 when no caps are enabled.
+ */
+export function computeMaxCapPercent(settings: UserSettings, tracker: SpendingTracker): number {
+  const percentages: number[] = [];
+
+  if (settings.dailyCap.enabled && settings.dailyCap.amount > 0) {
+    percentages.push(Math.round(tracker.dailyTotal / settings.dailyCap.amount * 10000) / 100);
+  }
+  if (settings.weeklyCap.enabled && settings.weeklyCap.amount > 0) {
+    percentages.push(Math.round(tracker.weeklyTotal / settings.weeklyCap.amount * 10000) / 100);
+  }
+  if (settings.monthlyCap.enabled && settings.monthlyCap.amount > 0) {
+    percentages.push(Math.round(tracker.monthlyTotal / settings.monthlyCap.amount * 10000) / 100);
+  }
+
+  return percentages.length === 0 ? 0 : Math.max(...percentages);
+}
+
+/**
+ * Compute the effective friction intensity based on spending threshold escalation.
+ *
+ * Escalation tiers:
+ * - Under 60%: no change (base)
+ * - 60–79%: Medium
+ * - 80–99%: High
+ * - 100%+: Extreme
+ *
+ * Rules:
+ * - Only escalates UP from base, never down
+ * - Returns base immediately if locked
+ * - Returns base if maxPercent is 0 (no caps enabled)
+ */
+export function computeEscalatedIntensity(
+  base: FrictionIntensity,
+  maxPercent: number,
+  locked: boolean,
+): FrictionIntensity {
+  if (locked || maxPercent === 0) return base;
+
+  let tier: FrictionIntensity;
+  if (maxPercent >= 100) {
+    tier = 'extreme';
+  } else if (maxPercent >= 80) {
+    tier = 'high';
+  } else if (maxPercent >= 60) {
+    tier = 'medium';
+  } else {
+    return base; // Under 60% — no escalation
+  }
+
+  // Only escalate up: if base is already higher than tier, keep base
+  const baseIndex = INTENSITY_ORDER.indexOf(base);
+  const tierIndex = INTENSITY_ORDER.indexOf(tier);
+  return tierIndex > baseIndex ? tier : base;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest tests/shared/escalation.test.ts -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/escalation.ts tests/shared/escalation.test.ts
+git commit -m "feat: add escalation module with computeEscalatedIntensity and computeMaxCapPercent"
+```
+
+---
+
+## Chunk 4: Weekly Reset Day (Task 7)
+
+### Task 7: Weekly Reset Day Preference (Fix 3)
+
+**Files:**
+- Modify: `src/content/interceptor.ts:43-53` (`getCurrentWeekStart`)
+- Modify: `src/popup/popup.html` (Limits section — add segmented control)
+- Modify: `src/popup/sections/limits.ts` (bind new control)
+
+- [ ] **Step 1: Update `getCurrentWeekStart` in interceptor.ts**
+
+Change the function signature and body to accept a reset day parameter:
+
+```typescript
+/**
+ * Get the start of the current week as YYYY-MM-DD.
+ * Supports Monday-start (ISO default) or Sunday-start weeks.
+ */
+function getCurrentWeekStart(date: Date = new Date(), resetDay: 'monday' | 'sunday' = 'monday'): string {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  if (resetDay === 'sunday') {
+    // Sunday = 0, so offset is just -dayOfWeek
+    d.setDate(d.getDate() - dayOfWeek);
+  } else {
+    // Monday start (ISO): Sunday needs -6, others need 1-dayOfWeek
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    d.setDate(d.getDate() + mondayOffset);
+  }
+  return formatLocalDate(d);
+}
+```
+
+- [ ] **Step 2: Update `loadSpendingTracker` to pass the reset day**
+
+In `loadSpendingTracker`, the function needs access to settings. Update the call site at line 94:
+
+Change:
+```typescript
+    const currentWeekStart = getCurrentWeekStart();
+```
+To:
+```typescript
+    const currentWeekStart = getCurrentWeekStart(new Date(), settings.weeklyResetDay ?? 'monday');
+```
+
+This requires passing `settings` into `loadSpendingTracker`. Update the function signature:
+
+```typescript
+async function loadSpendingTracker(settings: UserSettings): Promise<SpendingTracker> {
+```
+
+There is one call site at approximately line 1896 inside `handlePurchaseAttempt()`, where `settings` is already loaded into a local variable earlier in the same function. Update that single call to `loadSpendingTracker(settings)`.
+
+- [ ] **Step 3: Add reset day segmented control to popup.html**
+
+In the Limits section, after the weekly cap row (after line 243 — `weeklyCapAmountEl`), add a new row for the reset day selector:
+
+```html
+        <div class="hc-row" id="weekly-reset-day-row" hidden>
+          <label class="hc-label">Week starts</label>
+          <div class="segmented" id="weekly-reset-day" data-pending-field="weeklyResetDay">
+            <button class="seg-btn" data-value="monday">Mon</button>
+            <button class="seg-btn" data-value="sunday">Sun</button>
+          </div>
+        </div>
+```
+
+- [ ] **Step 4: Wire the reset day control in limits.ts**
+
+In `src/popup/sections/limits.ts`, add element references after existing weekly cap refs:
+
+```typescript
+  const weeklyResetDayRowEl = el.querySelector<HTMLElement>('#weekly-reset-day-row')!;
+  const weeklyResetDayEl = el.querySelector<HTMLElement>('#weekly-reset-day')!;
+```
+
+Add event handler for the segmented control (after weekly cap handlers):
+
+```typescript
+  // Weekly reset day
+  weeklyResetDayEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const val = btn.dataset.value as 'monday' | 'sunday';
+      setPendingField('weeklyResetDay', val);
+      weeklyResetDayEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.value === val);
+      });
+    });
+  });
+```
+
+Update the weekly cap enabled handler to also show/hide the reset day row:
+
+```typescript
+  weeklyCapEnabledEl.addEventListener('change', () => {
+    const enabled = weeklyCapEnabledEl.checked;
+    weeklyCapAmountEl.hidden = !enabled;
+    weeklyResetDayRowEl.hidden = !enabled;
+    setPendingField('weeklyCap', { ...getPending().weeklyCap, enabled });
+  });
+```
+
+Update `render()` to handle the new control:
+
+```typescript
+    weeklyResetDayRowEl.hidden = !settings.weeklyCap.enabled;
+    weeklyResetDayEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.value === settings.weeklyResetDay);
+    });
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `npm run build`
+Expected: Build succeeds. Weekly "Mon / Sun" toggle appears when weekly cap is enabled.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npx jest -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/content/interceptor.ts src/popup/popup.html src/popup/sections/limits.ts
+git commit -m "feat: add weekly reset day preference (Monday/Sunday) in Limits section"
+```
+
+---
+
+## Chunk 5: Wire Escalation into Interceptor & Popup (Tasks 8–9)
+
+### Task 8: Wire Escalation into Content Script
+
+**Files:**
+- Modify: `src/content/interceptor.ts:1702` (use escalated intensity instead of raw setting)
+- Modify: `src/content/interceptor.ts:1-16` (add import)
+
+- [ ] **Step 1: Add import for escalation module**
+
+At the top of `src/content/interceptor.ts`, add:
+
+```typescript
+import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
+```
+
+- [ ] **Step 2: Replace raw intensity with escalated intensity in `runFrictionFlow`**
+
+Find line 1702:
+```typescript
+  const intensity = settings.frictionIntensity ?? 'low';
+```
+
+Replace with (`runFrictionFlow` already receives `tracker` as its third parameter — reuse it, don't reload):
+```typescript
+  const maxPercent = computeMaxCapPercent(settings, tracker);
+  const intensity = computeEscalatedIntensity(
+    settings.frictionIntensity ?? 'low',
+    maxPercent,
+    settings.intensityLocked ?? false,
+  );
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `npm run build`
+Expected: Build succeeds. Interceptor now uses escalated intensity.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "feat: wire escalated intensity into friction flow"
+```
+
+---
+
+### Task 9: Wire Escalation UI into Popup
+
+**Files:**
+- Modify: `src/popup/popup.html` (add lock toggle + info icon to both intensity controls, add escalation label)
+- Modify: `src/popup/popup.css` (lock toggle styles, escalation indicator styles)
+- Modify: `src/popup/sections/stats.ts` (lock toggle handling, escalation visual)
+- Modify: `src/popup/sections/friction.ts` (lock toggle handling, escalation visual)
+- Modify: `src/popup/popup.ts` (compute and pass escalation state on render)
+
+- [ ] **Step 1: Add lock toggle + info icon to Stats intensity control in popup.html**
+
+In the Stats section, after the `#stats-intensity` segmented div (line 126), within the same `.hc-row`, add:
+
+```html
+          <label class="toggle-wrap toggle-wrap--lock" title="Lock intensity — prevents auto-escalation">
+            <input type="checkbox" id="stats-intensity-lock" />
+            <span class="toggle-track"></span>
+            <span class="lock-label">🔒</span>
+          </label>
+          <span class="escalation-info" tabindex="0" aria-describedby="tooltip-escalation">ⓘ</span>
+          <span class="stat-tooltip" id="tooltip-escalation" role="tooltip">Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level.</span>
+```
+
+- [ ] **Step 2: Add lock toggle to Friction intensity control in popup.html**
+
+In the Friction section, after the `#friction-intensity` segmented div (line 150), within the same `.hc-row`, add:
+
+```html
+          <label class="toggle-wrap toggle-wrap--lock" title="Lock intensity — prevents auto-escalation">
+            <input type="checkbox" id="friction-intensity-lock" />
+            <span class="toggle-track"></span>
+            <span class="lock-label">🔒</span>
+          </label>
+```
+
+- [ ] **Step 3: Add escalation indicator label to both sections**
+
+After each intensity `.hc-row` (in both Stats and Friction), add:
+
+```html
+        <div class="escalation-indicator" id="stats-escalation-indicator" hidden>
+          <span class="escalation-text"></span>
+        </div>
+```
+
+And for Friction:
+
+```html
+        <div class="escalation-indicator" id="friction-escalation-indicator" hidden>
+          <span class="escalation-text"></span>
+        </div>
+```
+
+- [ ] **Step 4: Add CSS styles for lock toggle and escalation indicator**
+
+In `src/popup/popup.css`, add after the toggle styles section:
+
+```css
+/* ─── Lock toggle (compact, inline with segmented) ───────── */
+.toggle-wrap--lock {
+  gap: 4px;
+  margin-left: 4px;
+}
+.lock-label {
+  font-size: 11px;
+}
+
+/* ─── Escalation indicator ──────────────────────────────── */
+.escalation-indicator {
+  padding: 2px 0 2px 140px; /* aligns with content after label column */
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.escalation-indicator .escalation-text {
+  color: #f59e0b;
+  font-weight: 500;
+}
+
+/* ─── Escalation info icon (reuses stat-tooltip pattern) ── */
+.escalation-info {
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: help;
+  position: relative;
+}
+
+/* Escalated segmented button highlight */
+.seg-btn.escalated {
+  border-color: #f59e0b;
+  color: #f59e0b;
+  font-weight: 600;
+}
+.seg-btn.base-indicator::after {
+  content: '';
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin: 2px auto 0;
+}
+```
+
+- [ ] **Step 5: Update stats.ts — add lock toggle handling and escalation display**
+
+In `src/popup/sections/stats.ts`:
+
+Add element references:
+```typescript
+  const lockEl = el.querySelector<HTMLInputElement>('#stats-intensity-lock')!;
+  const escalationIndicatorEl = el.querySelector<HTMLElement>('#stats-escalation-indicator')!;
+```
+
+Wire lock toggle:
+```typescript
+  lockEl.addEventListener('change', () => {
+    setPendingField('intensityLocked', lockEl.checked);
+    // Sync the friction section lock
+    const frictionLock = document.querySelector<HTMLInputElement>('#friction-intensity-lock');
+    if (frictionLock) frictionLock.checked = lockEl.checked;
+  });
+```
+
+Add a method to display escalation state. Extend `StatsController` interface:
+```typescript
+export interface StatsController {
+  render(settings: UserSettings): void;
+  refreshStats(): Promise<void>;
+  showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void;
+}
+```
+
+Implement `showEscalation`:
+```typescript
+  function showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void {
+    const isEscalated = base !== effective;
+    escalationIndicatorEl.hidden = !isEscalated;
+    if (isEscalated) {
+      const textEl = escalationIndicatorEl.querySelector('.escalation-text')!;
+      textEl.textContent = `↑ Auto-escalated from ${base.charAt(0).toUpperCase() + base.slice(1)}`;
+      // Highlight escalated button, mark base button
+      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+        btn.classList.remove('escalated', 'base-indicator');
+        btn.classList.toggle('active', btn.dataset.value === effective);
+        if (btn.dataset.value === base) btn.classList.add('base-indicator');
+        if (btn.dataset.value === effective) btn.classList.add('escalated');
+      });
+    } else {
+      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+        btn.classList.remove('escalated', 'base-indicator');
+      });
+    }
+  }
+```
+
+Update `render()`:
+```typescript
+  function render(settings: UserSettings): void {
+    renderSegmented(intensityEl, settings.frictionIntensity);
+    renderOverride(settings);
+    lockEl.checked = settings.intensityLocked ?? false;
+  }
+```
+
+**Update the return statement** from `return { render, refreshStats };` to `return { render, refreshStats, showEscalation };`.
+
+- [ ] **Step 6: Update friction.ts — add lock toggle handling and escalation display**
+
+Mirror the same pattern as stats.ts:
+
+Add element references:
+```typescript
+  const lockEl = el.querySelector<HTMLInputElement>('#friction-intensity-lock')!;
+  const escalationIndicatorEl = el.querySelector<HTMLElement>('#friction-escalation-indicator')!;
+```
+
+Wire lock toggle (syncs with stats lock):
+```typescript
+  lockEl.addEventListener('change', () => {
+    setPendingField('intensityLocked', lockEl.checked);
+    const statsLock = document.querySelector<HTMLInputElement>('#stats-intensity-lock');
+    if (statsLock) statsLock.checked = lockEl.checked;
+  });
+```
+
+Extend `FrictionController` interface to add `showEscalation`:
+```typescript
+export interface FrictionController {
+  render(settings: UserSettings): void;
+  showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void;
+}
+```
+
+Implement `showEscalation` (same pattern as stats.ts). **Update the return statement** from `return { render };` to `return { render, showEscalation };`.
+
+Update `render()` to set lock state:
+```typescript
+    lockEl.checked = settings.intensityLocked ?? false;
+```
+
+- [ ] **Step 7: Update popup.ts — compute escalation on load and pass to sections**
+
+In `src/popup/popup.ts`, add imports:
+```typescript
+import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
+import { SpendingTracker, DEFAULT_SPENDING_TRACKER } from '../shared/types';
+```
+
+After `limits.refreshTracker()` (line 248), add escalation computation:
+
+```typescript
+  // Compute escalation state from tracker + settings
+  async function updateEscalation(): Promise<void> {
+    const trackerResult = await chrome.storage.local.get('hcSpending');
+    const tracker: SpendingTracker = { ...DEFAULT_SPENDING_TRACKER, ...trackerResult['hcSpending'] };
+    const s = getPending();
+    const maxPercent = computeMaxCapPercent(s, tracker);
+    const effective = computeEscalatedIntensity(s.frictionIntensity, maxPercent, s.intensityLocked);
+    stats.showEscalation(s.frictionIntensity, effective);
+    friction.showEscalation(s.frictionIntensity, effective);
+  }
+  await updateEscalation();
+```
+
+- [ ] **Step 8: Build and verify**
+
+Run: `npm run build`
+Expected: Build succeeds. Lock toggle appears on both intensity controls. When caps are enabled and tracker shows spending approaching a threshold, escalation indicator appears.
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `npx jest -v`
+Expected: All tests PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/popup/popup.html src/popup/popup.css src/popup/popup.ts src/popup/sections/stats.ts src/popup/sections/friction.ts
+git commit -m "feat: wire escalation UI with lock toggle, info icon, and escalation indicator"
+```
+
+---
+
+## Chunk 6: Wizard Default Update & Version Bump (Task 10)
+
+### Task 10: Update Wizard Defaults, Bump Version, Update TODO
+
+**Files:**
+- Modify: `src/popup/popup.html` (wizard friction default)
+- Modify: `src/popup/popup.ts:150` (wizard fallback)
+- Modify: `manifest.json` (version bump)
+- Modify: `package.json` (version bump)
+- Modify: `HypeControl-TODO.md` (post-work update)
+
+- [ ] **Step 1: Update wizard friction default in popup.html**
+
+Move `active` class from Medium to Low button (line 64):
+```html
+            <button class="hc-wizard-seg-btn active" data-value="low">Low</button>
+            <button class="hc-wizard-seg-btn" data-value="medium">Medium</button>
+```
+
+Update skip-confirmation text (line 26 area). Change:
+```
+Medium friction
+```
+To:
+```
+Low friction
+```
+
+Update the default `wizard-friction-desc` text (line 68):
+```html
+          <p class="hc-wizard-friction-desc" id="wizard-friction-desc">Main overlay only — one click to cancel</p>
+```
+
+- [ ] **Step 2: Update wizard fallback in popup.ts**
+
+At line 150, change the fallback from `'medium'` to `'low'`:
+```typescript
+    const frictionIntensity = (activeBtn?.dataset.value ?? 'low') as UserSettings['frictionIntensity'];
+```
+
+- [ ] **Step 3: Bump version in manifest.json and package.json**
+
+Determine current version (should be 0.4.23), bump to 0.4.24.
+
+In `manifest.json`:
+```json
+  "version": "0.4.24",
+```
+
+In `package.json`:
+```json
+  "version": "0.4.24",
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: Build succeeds with version 0.4.24.
+
+- [ ] **Step 5: Update HypeControl-TODO.md**
+
+Add the following changes:
+- Update header: `Current Version: 0.4.24`, `Updated: 2026-03-16`
+- In the "In-Scope" add-on section, note that the maintenance pass is complete
+- Update the footer timestamp
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/popup/popup.html src/popup/popup.ts manifest.json package.json HypeControl-TODO.md
+git commit -m "feat: update wizard defaults to Low intensity, bump version to 0.4.24"
+```
+
+---
+
+## Subagent Briefing Notes
+
+**IMPORTANT — Do NOT bump versions.** Version bump happens only in Task 10. If you are a subagent working on Tasks 1–9, skip any version bump steps.
+
+**Build note:** `npm run build` may fail due to shell/path issues on Windows (known issue). If the build fails, skip the build step and note it for the user to run manually.
+
+**Test note:** Tests use Jest with ts-jest. Run with `npx jest -v`. The chrome API is not available in test context — only test pure functions (types, escalation, pendingState), not DOM/chrome-dependent code.

--- a/docs/superpowers/plans/2026-03-16-spending-history-view.md
+++ b/docs/superpowers/plans/2026-03-16-spending-history-view.md
@@ -1,0 +1,1256 @@
+# Spending History View — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a full-tab spending history page showing a filterable, sortable table of InterceptEvents with a 6-metric summary bar, accessed via a new popup button.
+
+**Architecture:** Three new files (`history.html`, `history.ts`, `history.css`) follow the existing logs page pattern — a webpack entry point, CopyPlugin HTML copy, and CSS import at the top of the TS file. All data comes from the existing `readInterceptEvents()` in `interceptLogger.ts`. Filtering, sorting, and aggregation are client-side. The popup gets a new button wired identically to the existing "View Activity Logs" pattern.
+
+**Tech Stack:** TypeScript, webpack (MiniCssExtractPlugin + CopyPlugin), Chrome Extension APIs (`chrome.storage.sync`, `chrome.storage.local`, `chrome.tabs.create`), Space Grotesk font.
+
+**Subagent briefing:** Do NOT bump versions in `manifest.json` or `package.json`. Version bumping happens once at the end, not per-task.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/history/history.html` | Page shell — head, font links, summary bar, filter controls, table container, empty states |
+| Create | `src/history/history.ts` | All page logic — load events, filter, sort, render summary, render table, expand/collapse rows, theme init |
+| Create | `src/history/history.css` | All page styles — layout, summary bar, filters, table, row detail, empty states, light mode overrides |
+| Modify | `webpack.config.js` | Add `history` entry point + CopyPlugin pattern for `history.html` |
+| Modify | `src/popup/popup.html` | Add "View Spending History" button adjacent to "View Activity Logs" |
+| Modify | `src/popup/sections/settings-section.ts` | Wire new button to `chrome.tabs.create({ url: 'history.html' })` |
+| Modify | `manifest.json` | Version bump (final task only) |
+| Modify | `package.json` | Version bump (final task only) |
+| Modify | `HypeControl-TODO.md` | Mark Add-on 2 complete, update header |
+
+---
+
+## Chunk 1: Infrastructure & Page Shell
+
+### Task 1: Webpack Configuration
+
+**Files:**
+- Modify: `webpack.config.js:6-12` (entry points) and `:38-53` (CopyPlugin patterns)
+
+- [ ] **Step 1: Add history entry point to webpack config**
+
+In `webpack.config.js`, add the `history` entry alongside the existing entries:
+
+```js
+entry: {
+  content: './src/content/index.ts',
+  history: './src/history/history.ts',   // ← add this line
+  logs: './src/logs/logs.ts',
+  popup: './src/popup/popup.ts',
+  serviceWorker: './src/background/serviceWorker.ts',
+},
+```
+
+- [ ] **Step 2: Add CopyPlugin pattern for history.html**
+
+In the `CopyPlugin` patterns array (after the `logs.html` entry), add:
+
+```js
+{ from: 'src/history/history.html', to: 'history.html' },
+```
+
+The patterns array should now include:
+```js
+{ from: 'src/logs/logs.html', to: 'logs.html' },
+{ from: 'src/history/history.html', to: 'history.html' },
+{ from: 'src/popup/popup.html', to: 'popup.html' },
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webpack.config.js
+git commit -m "feat: add history page webpack entry point and copy pattern"
+```
+
+---
+
+### Task 2: History HTML Page
+
+**Files:**
+- Create: `src/history/history.html`
+
+- [ ] **Step 1: Create the history HTML page**
+
+Create `src/history/history.html` with the full page structure. This follows the same pattern as `logs.html` — standalone page that loads its own CSS and JS bundle:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Spending History — Hype Control</title>
+  <link rel="stylesheet" href="history.css">
+</head>
+<body>
+  <div class="history-wrapper">
+    <h1 class="history-title">
+      <img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="40" height="40" alt="Hype Control">
+      Spending History
+    </h1>
+
+    <!-- Summary Bar -->
+    <div class="summary-bar" id="summary-bar">
+      <div class="summary-metric" id="metric-spent">
+        <span class="metric-value">$0.00</span>
+        <span class="metric-label">Total Spent</span>
+      </div>
+      <div class="summary-metric" id="metric-saved">
+        <span class="metric-value">$0.00</span>
+        <span class="metric-label">Total Saved</span>
+      </div>
+      <div class="summary-metric" id="metric-cancel-rate">
+        <span class="metric-value">0.0%</span>
+        <span class="metric-label">Cancel Rate</span>
+      </div>
+      <div class="summary-metric" id="metric-count">
+        <span class="metric-value">0</span>
+        <span class="metric-label">Events</span>
+      </div>
+      <div class="summary-metric" id="metric-top-step">
+        <span class="metric-value">—</span>
+        <span class="metric-label">Top Cancel Step</span>
+      </div>
+      <div class="summary-metric" id="metric-top-reason">
+        <span class="metric-value">—</span>
+        <span class="metric-label">Top Reason</span>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="filter-bar" id="filter-bar">
+      <div class="filter-group">
+        <label class="filter-label" for="filter-start">From</label>
+        <input type="date" id="filter-start" class="filter-input">
+      </div>
+      <div class="filter-group">
+        <label class="filter-label" for="filter-end">To</label>
+        <input type="date" id="filter-end" class="filter-input">
+      </div>
+      <div class="filter-group">
+        <label class="filter-label" for="filter-channel">Channel</label>
+        <select id="filter-channel" class="filter-select">
+          <option value="">All Channels</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label class="filter-label">Outcome</label>
+        <div class="outcome-toggle" id="outcome-toggle" role="group" aria-label="Outcome filter">
+          <button class="outcome-btn active" data-value="all">All</button>
+          <button class="outcome-btn" data-value="cancelled">Cancelled</button>
+          <button class="outcome-btn" data-value="proceeded">Proceeded</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Table -->
+    <div class="table-container">
+      <table class="history-table" id="history-table">
+        <thead>
+          <tr>
+            <th class="sortable active" data-sort="timestamp">Date/Time <span class="sort-arrow">▼</span></th>
+            <th class="sortable" data-sort="channel">Channel <span class="sort-arrow"></span></th>
+            <th class="sortable" data-sort="amount">Amount <span class="sort-arrow"></span></th>
+            <th class="sortable" data-sort="outcome">Outcome <span class="sort-arrow"></span></th>
+            <th class="sortable" data-sort="saved">Saved <span class="sort-arrow"></span></th>
+          </tr>
+        </thead>
+        <tbody id="history-tbody">
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Empty states -->
+    <div class="empty-state" id="empty-no-data" hidden>
+      No spending activity recorded yet. HypeControl will log purchases as you browse Twitch.
+    </div>
+    <div class="empty-state" id="empty-no-match" hidden>
+      No events match your filters. Try adjusting the date range or clearing filters.
+    </div>
+  </div>
+
+  <script src="history.js"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/history/history.html
+git commit -m "feat: add spending history page HTML shell"
+```
+
+---
+
+### Task 3: History CSS — Base Styles
+
+**Files:**
+- Create: `src/history/history.css`
+
+- [ ] **Step 1: Create the history CSS file with all styles**
+
+Create `src/history/history.css`. This reuses the same CSS variable system as `logs.css` (same `@font-face` declarations, same `:root` variables, same `[data-theme="light"]` overrides). The page-specific styles cover: layout, summary bar, filter bar, table, expandable row detail, and empty states.
+
+```css
+/* ─── Font faces (same as logs.css) ─────────────────────── */
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-SemiBold.woff2') format('woff2');
+  font-weight: 600;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Space Grotesk';
+  src: url('assets/fonts/SpaceGrotesk-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-display: swap;
+}
+
+/* ─── Variables (same token system as logs.css) ─────────── */
+:root {
+  --bg-primary:    #18181b;
+  --bg-secondary:  #1f1f23;
+  --bg-input:      #0e0e10;
+  --border-color:  #2a2a2e;
+  --accent:        #9147ff;
+  --accent-hover:  #772ce8;
+  --accent-rgb:    145, 71, 255;
+  --text-primary:  #efeff1;
+  --text-secondary:#adadb8;
+  --text-muted:    #666;
+  --danger:        #e91916;
+  --danger-rgb:    233, 25, 22;
+  --success:       #22C55E;
+  --success-light: #16A34A;
+  --outcome-proceeded: #adadb8;
+  --outcome-proceeded-light: #53535f;
+  --radius:        4px;
+  --font:          'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono:     'Space Grotesk', 'Consolas', 'Monaco', monospace;
+}
+
+/* ─── Light mode overrides ───────────────────────────────── */
+[data-theme="light"] {
+  --bg-primary:    #ffffff;
+  --bg-secondary:  #f4f4f5;
+  --bg-input:      #e9e9ec;
+  --border-color:  #d4d4d8;
+  --text-primary:  #18181b;
+  --text-secondary:#3f3f46;
+  --text-muted:    #71717a;
+  --accent:        #7c3aed;
+  --accent-hover:  #6d28d9;
+  --accent-rgb:    124, 58, 237;
+  --danger:        #e91916;
+  --success:       #16A34A;
+  --outcome-proceeded: #53535f;
+}
+
+/* ─── Reset ──────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ─── Base ───────────────────────────────────────────────── */
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font);
+  font-size: 14px;
+  padding: 24px;
+}
+
+/* ─── Layout ─────────────────────────────────────────────── */
+.history-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* ─── Heading ────────────────────────────────────────────── */
+.history-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+/* ─── Summary Bar ────────────────────────────────────────── */
+.summary-bar {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.summary-metric {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 14px 12px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric-value {
+  font-family: var(--font-mono);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.metric-label {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+/* Color-code the saved metric */
+#metric-saved .metric-value {
+  color: var(--success);
+}
+
+/* ─── Filter Bar ─────────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  gap: 16px;
+  align-items: flex-end;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.filter-input,
+.filter-select {
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+  font-family: var(--font);
+  font-size: 13px;
+}
+
+.filter-input:focus,
+.filter-select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ─── Outcome Toggle ─────────────────────────────────────── */
+.outcome-toggle {
+  display: flex;
+  gap: 2px;
+}
+
+.outcome-btn {
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  font-family: var(--font);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+
+.outcome-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.outcome-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.outcome-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ─── Table ──────────────────────────────────────────────── */
+.table-container {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.history-table th {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+  user-select: none;
+}
+
+.history-table th.sortable {
+  cursor: pointer;
+}
+
+.history-table th.sortable:hover {
+  color: var(--text-primary);
+}
+
+.history-table th.active {
+  color: var(--accent);
+}
+
+.sort-arrow {
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+.history-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 13px;
+  vertical-align: top;
+}
+
+.history-table tbody tr {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.history-table tbody tr:hover {
+  background: var(--bg-secondary);
+}
+
+.history-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Column widths */
+.history-table th:nth-child(1),
+.history-table td:nth-child(1) { width: 26%; }
+.history-table th:nth-child(2),
+.history-table td:nth-child(2) { width: 20%; }
+.history-table th:nth-child(3),
+.history-table td:nth-child(3) { width: 14%; font-family: var(--font-mono); }
+.history-table th:nth-child(4),
+.history-table td:nth-child(4) { width: 16%; }
+.history-table th:nth-child(5),
+.history-table td:nth-child(5) { width: 14%; font-family: var(--font-mono); }
+
+/* Outcome colors */
+.outcome-cancelled {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.outcome-proceeded {
+  color: var(--outcome-proceeded);
+}
+
+/* Saved column */
+.saved-value {
+  color: var(--success);
+  font-weight: 600;
+}
+
+/* ─── Expandable Row Detail ──────────────────────────────── */
+.detail-row td {
+  padding: 0 12px 12px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-input);
+}
+
+.detail-row:hover {
+  background: var(--bg-input) !important;
+}
+
+.detail-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px 24px;
+  padding: 12px 0;
+}
+
+.detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.detail-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.detail-field-value {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+/* ─── Empty States ───────────────────────────────────────── */
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 48px 24px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .summary-bar {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .filter-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/history/history.css
+git commit -m "feat: add spending history page styles"
+```
+
+---
+
+### Task 4: History TypeScript — Scaffold with Theme Init
+
+**Files:**
+- Create: `src/history/history.ts`
+
+- [ ] **Step 1: Create the history TS file with imports and theme initialization**
+
+Create `src/history/history.ts` with the CSS import (for webpack extraction), theme initialization (copied from `logs.ts` pattern), and the `DOMContentLoaded` entry point. This task creates the scaffold; subsequent tasks add the logic.
+
+```typescript
+/**
+ * Hype Control — Spending History page
+ * Full-tab view of InterceptEvents with filtering, sorting, and summary metrics.
+ */
+
+import './history.css';
+import { InterceptEvent } from '../shared/types';
+import { readInterceptEvents } from '../shared/interceptLogger';
+
+// ─── State ──────────────────────────────────────────────────
+let allEvents: InterceptEvent[] = [];
+let filteredEvents: InterceptEvent[] = [];
+let sortColumn: 'timestamp' | 'channel' | 'amount' | 'outcome' | 'saved' = 'timestamp';
+let sortAsc = false; // default: newest first (descending)
+let expandedRowId: string | null = null;
+
+// ─── Theme ──────────────────────────────────────────────────
+async function initTheme(): Promise<void> {
+  try {
+    const result = await chrome.storage.sync.get('hcSettings');
+    const theme = result?.hcSettings?.theme;
+    if (theme === 'light') {
+      document.documentElement.setAttribute('data-theme', 'light');
+    } else if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: light)').matches) {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  } catch {
+    // non-extension context — ignore
+  }
+}
+
+// ─── Formatting helpers ─────────────────────────────────────
+function formatCurrency(value: number | null | undefined): string {
+  if (value == null) return '—';
+  return '$' + value.toFixed(2);
+}
+
+function formatDate(timestamp: number): string {
+  const d = new Date(timestamp);
+  return d.toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+  }) + ' ' + d.toLocaleTimeString('en-US', {
+    hour: 'numeric', minute: '2-digit', hour12: true,
+  });
+}
+
+function toDateInputValue(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// ─── Placeholder functions (filled in by subsequent tasks) ──
+function applyFilters(): void { /* Task 6 */ }
+function computeSummary(): void { /* Task 7 */ }
+function renderTable(): void { /* Task 8 */ }
+function setupFilters(): void { /* Task 6 */ }
+function setupSort(): void { /* Task 8 */ }
+
+// ─── Entry point ────────────────────────────────────────────
+async function main(): Promise<void> {
+  await initTheme();
+  allEvents = await readInterceptEvents();
+
+  setupFilters();
+  setupSort();
+  applyFilters();
+}
+
+document.addEventListener('DOMContentLoaded', () => { main(); });
+```
+
+- [ ] **Step 2: Verify the build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds. `dist/history.js`, `dist/history.css`, and `dist/history.html` all exist.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/history/history.ts
+git commit -m "feat: add spending history page scaffold with theme init"
+```
+
+---
+
+## Chunk 2: Core Logic — Filters, Summary, Table, Row Detail
+
+### Task 5: Popup Button — "View Spending History"
+
+**Files:**
+- Modify: `src/popup/popup.html:351` (Settings section, adjacent to View Activity Logs button)
+- Modify: `src/popup/sections/settings-section.ts:16,28-30`
+
+- [ ] **Step 1: Add the button to popup HTML**
+
+In `src/popup/popup.html`, in the Settings section, add a new row BEFORE the "View Activity Logs" row (line ~351):
+
+```html
+        <div class="hc-row">
+          <button class="btn-secondary" id="btn-view-history">View Spending History</button>
+        </div>
+```
+
+The Settings section should now have:
+```html
+        <div class="hc-row">
+          <button class="btn-secondary" id="btn-view-history">View Spending History</button>
+        </div>
+        <div class="hc-row">
+          <button class="btn-secondary" id="btn-view-logs">View Activity Logs</button>
+        </div>
+```
+
+- [ ] **Step 2: Wire the button in settings-section.ts**
+
+In `src/popup/sections/settings-section.ts`, add a query for the new button and its click handler, following the exact pattern used for the logs button:
+
+After line 16 (`const logsBtn = ...`), add:
+```typescript
+  const historyBtn = el.querySelector<HTMLButtonElement>('#btn-view-history')!;
+```
+
+After the `logsBtn.addEventListener('click', ...)` block (after line 30), add:
+```typescript
+  historyBtn.addEventListener('click', () => {
+    chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
+  });
+```
+
+- [ ] **Step 3: Verify the build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/popup/popup.html src/popup/sections/settings-section.ts
+git commit -m "feat: add View Spending History button to popup settings"
+```
+
+---
+
+### Task 6: Filter Logic
+
+**Files:**
+- Modify: `src/history/history.ts` (replace placeholder `setupFilters` and `applyFilters`)
+
+- [ ] **Step 1: Implement setupFilters and applyFilters**
+
+Replace the placeholder `setupFilters` and `applyFilters` functions in `history.ts` with the full implementations. Also remove the placeholder comment lines for these functions.
+
+Replace the `setupFilters` placeholder:
+
+```typescript
+function setupFilters(): void {
+  const startEl = document.getElementById('filter-start') as HTMLInputElement;
+  const endEl = document.getElementById('filter-end') as HTMLInputElement;
+  const channelEl = document.getElementById('filter-channel') as HTMLSelectElement;
+  const outcomeToggle = document.getElementById('outcome-toggle')!;
+
+  // Default date range: last 30 days
+  const today = new Date();
+  const thirtyAgo = new Date(today);
+  thirtyAgo.setDate(thirtyAgo.getDate() - 30);
+  startEl.value = toDateInputValue(thirtyAgo);
+  endEl.value = toDateInputValue(today);
+
+  // Wire date inputs
+  startEl.addEventListener('change', () => applyFilters());
+  endEl.addEventListener('change', () => applyFilters());
+
+  // Wire channel select
+  channelEl.addEventListener('change', () => applyFilters());
+
+  // Wire outcome toggle
+  outcomeToggle.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest('.outcome-btn') as HTMLButtonElement | null;
+    if (!btn) return;
+    outcomeToggle.querySelectorAll('.outcome-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    applyFilters();
+  });
+}
+```
+
+Replace the `applyFilters` placeholder:
+
+```typescript
+function applyFilters(): void {
+  const startEl = document.getElementById('filter-start') as HTMLInputElement;
+  const endEl = document.getElementById('filter-end') as HTMLInputElement;
+  const channelEl = document.getElementById('filter-channel') as HTMLSelectElement;
+  const outcomeToggle = document.getElementById('outcome-toggle')!;
+  const activeOutcome = outcomeToggle.querySelector('.outcome-btn.active') as HTMLButtonElement;
+  const outcomeFilter = activeOutcome?.dataset.value ?? 'all';
+
+  // Parse date range — start of startDate to end of endDate
+  const startDate = startEl.value ? new Date(startEl.value + 'T00:00:00') : null;
+  const endDate = endEl.value ? new Date(endEl.value + 'T23:59:59.999') : null;
+
+  // Filter events
+  filteredEvents = allEvents.filter(event => {
+    // Date range
+    if (startDate && event.timestamp < startDate.getTime()) return false;
+    if (endDate && event.timestamp > endDate.getTime()) return false;
+
+    // Channel
+    if (channelEl.value && event.channel !== channelEl.value) return false;
+
+    // Outcome
+    if (outcomeFilter !== 'all' && event.outcome !== outcomeFilter) return false;
+
+    return true;
+  });
+
+  // Update channel dropdown (only channels in current date range)
+  updateChannelDropdown(channelEl);
+
+  // Sort and render
+  sortEvents();
+  computeSummary();
+  renderTable();
+  updateEmptyStates();
+}
+```
+
+- [ ] **Step 2: Add the updateChannelDropdown and updateEmptyStates helpers**
+
+Add these functions above `applyFilters`:
+
+```typescript
+function updateChannelDropdown(channelEl: HTMLSelectElement): void {
+  const startEl = document.getElementById('filter-start') as HTMLInputElement;
+  const endEl = document.getElementById('filter-end') as HTMLInputElement;
+  const startDate = startEl.value ? new Date(startEl.value + 'T00:00:00') : null;
+  const endDate = endEl.value ? new Date(endEl.value + 'T23:59:59.999') : null;
+
+  // Get unique channels in the date range
+  const channelsInRange = new Set<string>();
+  for (const event of allEvents) {
+    if (startDate && event.timestamp < startDate.getTime()) continue;
+    if (endDate && event.timestamp > endDate.getTime()) continue;
+    channelsInRange.add(event.channel);
+  }
+
+  const previousValue = channelEl.value;
+  channelEl.innerHTML = '';
+
+  const allOption = document.createElement('option');
+  allOption.value = '';
+  allOption.textContent = 'All Channels';
+  channelEl.appendChild(allOption);
+
+  const sorted = [...channelsInRange].sort((a, b) => a.localeCompare(b));
+  for (const ch of sorted) {
+    const opt = document.createElement('option');
+    opt.value = ch;
+    opt.textContent = ch;
+    channelEl.appendChild(opt);
+  }
+
+  // Restore selection if still valid; otherwise reset to All
+  if (channelsInRange.has(previousValue)) {
+    channelEl.value = previousValue;
+  } else {
+    channelEl.value = '';
+  }
+}
+
+function updateEmptyStates(): void {
+  const noDataEl = document.getElementById('empty-no-data')!;
+  const noMatchEl = document.getElementById('empty-no-match')!;
+  const tableContainer = document.querySelector('.table-container') as HTMLElement;
+
+  if (allEvents.length === 0) {
+    noDataEl.removeAttribute('hidden');
+    noMatchEl.setAttribute('hidden', '');
+    tableContainer.style.display = 'none';
+  } else if (filteredEvents.length === 0) {
+    noDataEl.setAttribute('hidden', '');
+    noMatchEl.removeAttribute('hidden');
+    tableContainer.style.display = 'none';
+  } else {
+    noDataEl.setAttribute('hidden', '');
+    noMatchEl.setAttribute('hidden', '');
+    tableContainer.style.display = '';
+  }
+}
+```
+
+- [ ] **Step 3: Add the sortEvents helper**
+
+Add above `applyFilters`:
+
+```typescript
+function sortEvents(): void {
+  filteredEvents.sort((a, b) => {
+    let cmp = 0;
+    switch (sortColumn) {
+      case 'timestamp':
+        cmp = a.timestamp - b.timestamp;
+        break;
+      case 'channel':
+        cmp = a.channel.localeCompare(b.channel);
+        break;
+      case 'amount':
+        cmp = (a.priceWithTax ?? 0) - (b.priceWithTax ?? 0);
+        break;
+      case 'outcome':
+        cmp = a.outcome.localeCompare(b.outcome);
+        break;
+      case 'saved':
+        cmp = (a.savedAmount ?? 0) - (b.savedAmount ?? 0);
+        break;
+    }
+    return sortAsc ? cmp : -cmp;
+  });
+}
+```
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/history/history.ts
+git commit -m "feat: implement filter and sort logic for spending history"
+```
+
+---
+
+### Task 7: Summary Bar Computation
+
+**Files:**
+- Modify: `src/history/history.ts` (replace placeholder `computeSummary`)
+
+- [ ] **Step 1: Implement computeSummary**
+
+Replace the `computeSummary` placeholder with the full implementation. All 6 metrics are computed from `filteredEvents`. Currency math uses `Math.round(value * 100) / 100`.
+
+```typescript
+function computeSummary(): void {
+  const proceeded = filteredEvents.filter(e => e.outcome === 'proceeded');
+  const cancelled = filteredEvents.filter(e => e.outcome === 'cancelled');
+
+  // Total Spent — sum of priceWithTax for proceeded events
+  const totalSpent = Math.round(
+    proceeded.reduce((sum, e) => sum + (e.priceWithTax ?? 0), 0) * 100
+  ) / 100;
+
+  // Total Saved — sum of savedAmount for cancelled events
+  const totalSaved = Math.round(
+    cancelled.reduce((sum, e) => sum + (e.savedAmount ?? 0), 0) * 100
+  ) / 100;
+
+  // Cancel Rate
+  const cancelRate = filteredEvents.length === 0
+    ? 0
+    : Math.round((cancelled.length / filteredEvents.length) * 1000) / 10;
+
+  // Event Count
+  const eventCount = filteredEvents.length;
+
+  // Top Cancel Step — step with highest cancel frequency, lowest step wins ties
+  const stepCounts: Record<number, number> = {};
+  for (const e of cancelled) {
+    if (e.cancelledAtStep !== undefined) {
+      stepCounts[e.cancelledAtStep] = (stepCounts[e.cancelledAtStep] ?? 0) + 1;
+    }
+  }
+  let topStep: number | null = null;
+  let maxStepCount = 0;
+  for (const [step, count] of Object.entries(stepCounts)) {
+    const stepNum = Number(step);
+    if (count > maxStepCount || (count === maxStepCount && topStep !== null && stepNum < topStep)) {
+      maxStepCount = count;
+      topStep = stepNum;
+    }
+  }
+
+  // Top Reason — most common purchaseReason among proceeded events
+  const reasonCounts: Record<string, number> = {};
+  for (const e of proceeded) {
+    if (e.purchaseReason) {
+      reasonCounts[e.purchaseReason] = (reasonCounts[e.purchaseReason] ?? 0) + 1;
+    }
+  }
+  let topReason: string | null = null;
+  let topReasonCount = 0;
+  for (const [reason, count] of Object.entries(reasonCounts)) {
+    if (count > topReasonCount) {
+      topReasonCount = count;
+      topReason = reason;
+    }
+  }
+
+  // Update DOM
+  setMetricValue('metric-spent', formatCurrency(totalSpent));
+  setMetricValue('metric-saved', formatCurrency(totalSaved));
+  setMetricValue('metric-cancel-rate', cancelRate.toFixed(1) + '%');
+  setMetricValue('metric-count', String(eventCount));
+  setMetricValue('metric-top-step', topStep !== null ? `Step ${topStep}` : '—');
+  setMetricValue('metric-top-reason',
+    topReason ? `${topReason} (${topReasonCount}x)` : '—'
+  );
+}
+
+function setMetricValue(metricId: string, value: string): void {
+  const el = document.getElementById(metricId);
+  if (!el) return;
+  const valueEl = el.querySelector('.metric-value');
+  if (valueEl) valueEl.textContent = value;
+}
+```
+
+- [ ] **Step 2: Verify the build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/history/history.ts
+git commit -m "feat: implement summary bar computation for spending history"
+```
+
+---
+
+### Task 8: Table Rendering, Sorting, and Expandable Row Detail
+
+**Files:**
+- Modify: `src/history/history.ts` (replace placeholder `renderTable` and `setupSort`)
+
+- [ ] **Step 1: Implement renderTable with expandable row detail**
+
+Replace the `renderTable` placeholder. Each row is built with DOM construction (no innerHTML). Clicking a row toggles an expandable detail panel below it. Only one row expanded at a time.
+
+```typescript
+function renderTable(): void {
+  const tbody = document.getElementById('history-tbody')!;
+  tbody.innerHTML = '';
+
+  for (const event of filteredEvents) {
+    // Main data row
+    const tr = document.createElement('tr');
+    tr.dataset.eventId = event.id;
+
+    const tdDate = document.createElement('td');
+    tdDate.textContent = formatDate(event.timestamp);
+    tr.appendChild(tdDate);
+
+    const tdChannel = document.createElement('td');
+    tdChannel.textContent = event.channel;
+    tr.appendChild(tdChannel);
+
+    const tdAmount = document.createElement('td');
+    tdAmount.textContent = formatCurrency(event.priceWithTax);
+    tr.appendChild(tdAmount);
+
+    const tdOutcome = document.createElement('td');
+    tdOutcome.textContent = event.outcome === 'cancelled' ? 'Cancelled' : 'Proceeded';
+    tdOutcome.className = event.outcome === 'cancelled' ? 'outcome-cancelled' : 'outcome-proceeded';
+    tr.appendChild(tdOutcome);
+
+    const tdSaved = document.createElement('td');
+    if (event.outcome === 'cancelled' && event.savedAmount != null) {
+      tdSaved.textContent = formatCurrency(event.savedAmount);
+      tdSaved.className = 'saved-value';
+    } else {
+      tdSaved.textContent = '—';
+    }
+    tr.appendChild(tdSaved);
+
+    // Click to expand/collapse
+    tr.addEventListener('click', () => toggleDetail(event, tr));
+    tbody.appendChild(tr);
+
+    // If this row was expanded, re-expand it
+    if (expandedRowId === event.id) {
+      appendDetailRow(event, tr);
+    }
+  }
+}
+
+function toggleDetail(event: InterceptEvent, tr: HTMLTableRowElement): void {
+  const tbody = document.getElementById('history-tbody')!;
+
+  // Remove any existing detail row
+  const existingDetail = tbody.querySelector('.detail-row');
+  if (existingDetail) existingDetail.remove();
+
+  if (expandedRowId === event.id) {
+    // Collapse
+    expandedRowId = null;
+    return;
+  }
+
+  // Expand
+  expandedRowId = event.id;
+  appendDetailRow(event, tr);
+}
+
+function appendDetailRow(event: InterceptEvent, afterRow: HTMLTableRowElement): void {
+  const detailTr = document.createElement('tr');
+  detailTr.className = 'detail-row';
+
+  const detailTd = document.createElement('td');
+  detailTd.colSpan = 5;
+
+  const panel = document.createElement('div');
+  panel.className = 'detail-panel';
+
+  // Purchase Type
+  if (event.purchaseType) {
+    panel.appendChild(makeDetailField('Purchase Type', event.purchaseType));
+  }
+
+  // Raw Price
+  if (event.rawPrice) {
+    panel.appendChild(makeDetailField('Raw Price', event.rawPrice));
+  }
+
+  // Price with Tax
+  if (event.priceWithTax != null) {
+    panel.appendChild(makeDetailField('Price with Tax', formatCurrency(event.priceWithTax)));
+  }
+
+  // Cancelled at Step (only for cancelled events)
+  if (event.outcome === 'cancelled' && event.cancelledAtStep !== undefined) {
+    panel.appendChild(makeDetailField('Cancelled at Step', `Step ${event.cancelledAtStep}`));
+  }
+
+  // Purchase Reason (only if set)
+  if (event.purchaseReason) {
+    panel.appendChild(makeDetailField('Purchase Reason', event.purchaseReason));
+  }
+
+  detailTd.appendChild(panel);
+  detailTr.appendChild(detailTd);
+  afterRow.after(detailTr);
+}
+
+function makeDetailField(label: string, value: string): HTMLElement {
+  const field = document.createElement('div');
+  field.className = 'detail-field';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'detail-field-label';
+  labelEl.textContent = label;
+  field.appendChild(labelEl);
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'detail-field-value';
+  valueEl.textContent = value;
+  field.appendChild(valueEl);
+
+  return field;
+}
+```
+
+- [ ] **Step 2: Implement setupSort**
+
+Replace the `setupSort` placeholder. Clicking a column header toggles sort direction. Active column gets highlighted.
+
+```typescript
+function setupSort(): void {
+  const headers = document.querySelectorAll<HTMLTableCellElement>('.history-table th.sortable');
+
+  headers.forEach(th => {
+    th.addEventListener('click', () => {
+      const column = th.dataset.sort as typeof sortColumn;
+      if (sortColumn === column) {
+        sortAsc = !sortAsc;
+      } else {
+        sortColumn = column;
+        sortAsc = column === 'channel'; // alpha defaults ascending; everything else descending
+      }
+
+      // Update header visual state
+      headers.forEach(h => {
+        h.classList.remove('active');
+        const arrow = h.querySelector('.sort-arrow');
+        if (arrow) arrow.textContent = '';
+      });
+      th.classList.add('active');
+      const arrow = th.querySelector('.sort-arrow');
+      if (arrow) arrow.textContent = sortAsc ? '▲' : '▼';
+
+      sortEvents();
+      renderTable();
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Remove the placeholder comment lines**
+
+Delete the lines:
+```
+function applyFilters(): void { /* Task 6 */ }
+function computeSummary(): void { /* Task 7 */ }
+function renderTable(): void { /* Task 8 */ }
+function setupFilters(): void { /* Task 6 */ }
+function setupSort(): void { /* Task 8 */ }
+```
+
+These were the scaffolding placeholders and are now replaced by the real implementations from Tasks 6, 7, and 8.
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds. Open `dist/history.html` — page renders (data requires extension context).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/history/history.ts
+git commit -m "feat: implement table rendering, sorting, and expandable row detail"
+```
+
+---
+
+## Chunk 3: Version Bump, Build, and Post-Work Updates
+
+### Task 9: Version Bump, Build, and Post-Work Updates
+
+**Files:**
+- Modify: `manifest.json` — bump version to `0.4.23`
+- Modify: `package.json` — bump version to `0.4.23`
+- Modify: `HypeControl-TODO.md` — mark Add-on 2 complete, update header
+
+- [ ] **Step 1: Bump version in both files**
+
+In `manifest.json`, change `"version"` from `"0.4.22"` to `"0.4.23"`.
+In `package.json`, change `"version"` from `"0.4.22"` to `"0.4.23"`.
+
+- [ ] **Step 2: Run the build**
+
+Run: `npm run build`
+Expected: Build succeeds. All files present in `dist/`: `history.js`, `history.css`, `history.html`, plus all existing files.
+
+If the build fails, **stop and tell the user** to run `npm run build` manually. Do not retry.
+
+- [ ] **Step 3: Update HypeControl-TODO.md**
+
+Update the header:
+- `**Updated:** 2026-03-16` → `**Updated:** 2026-03-16` (keep if same day, update otherwise)
+- `**Current Version:** 0.4.22` → `**Current Version:** 0.4.23`
+
+Update the Quick Summary table:
+- `| Add-on 2 — Spending History View         | 🔲 Not Started    |` → `| Add-on 2 — Spending History View         | ✅ Complete       |`
+
+In the "In-Scope (Still To Build)" section, mark Add-on 2 as complete:
+- `- [ ] **Add-on 2 — Spending Tracker (History View)** ⭐⭐` → `- [x] **Add-on 2 — Spending Tracker (History View)** ⭐⭐`
+
+Update the footer timestamp to reflect the current date and version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add manifest.json package.json HypeControl-TODO.md
+git commit -m "maint: bump version to 0.4.23, mark Add-on 2 complete"
+```
+
+- [ ] **Step 5: Final verification**
+
+Run: `npm run build`
+Expected: Clean build. `dist/manifest.json` shows version `0.4.23`.

--- a/docs/superpowers/specs/2026-03-16-popup-polish-and-escalation-design.md
+++ b/docs/superpowers/specs/2026-03-16-popup-polish-and-escalation-design.md
@@ -1,0 +1,146 @@
+# Popup Polish & Dynamic Intensity Escalation
+
+**Date:** 2026-03-16
+**Branch:** `maint/popup-polish-and-escalation`
+**Status:** Approved
+
+---
+
+## Summary
+
+Maintenance pass bundling 6 fixes: toggle alignment, tour button relocation, weekly reset day preference, history summary centering, dynamic intensity escalation based on spending thresholds, and history metric color parity with popup stats. Also changes the default friction intensity from Medium to Low to complement the new escalation system.
+
+---
+
+## Fix 1 — Toggle Vertical Alignment (CSS)
+
+**Problem:** Toggle switches across Friction, Limits, and Channels sections don't align vertically because `.hc-label` uses `min-width: 110px`, which is too narrow for longer labels like "Spending cooldown".
+
+**Solution:** Increase `.hc-label` `min-width` from `110px` to `140px` in `popup.css`. This accommodates the longest current label plus ~10px buffer, ensuring all toggles snap to the same vertical column.
+
+**Files:** `src/popup/popup.css`
+
+---
+
+## Fix 2 — Relocate Replay Tour Button
+
+**Problem:** The "Replay setup tour" button exists in two places (footer link + Settings section button), is squeezed between Bug/Ideas links and Save Settings, and competes visually with more important actions.
+
+**Solution:**
+- Remove `<a id="footer-replay-tour">↺ Tour</a>` from the footer in `popup.html`
+- Remove `<div class="hc-row hc-row--replay">` and its button from the Settings section
+- Add a single `↺ Replay Setup Tour` button as the **last element** inside `.hc-content`, below the Credits section
+- Style subdued: secondary button, smaller font, generous `margin-top` (~24px) and `padding-bottom` so it breathes away from Credits
+- Remove `.hc-row--replay` and `.btn-replay-tour` CSS rules; add new `.btn-replay-bottom` styles
+- In `popup.ts`, remove the old `footer-replay-tour` click handler; wire the new button ID
+
+**Files:** `src/popup/popup.html`, `src/popup/popup.css`, `src/popup/popup.ts`
+
+---
+
+## Fix 3 — Weekly Reset Day Preference
+
+**Problem:** Weekly spending cap reset is hardcoded to Monday. Some users think in Sunday-start weeks.
+
+**Solution:**
+- Add `weeklyResetDay: 'monday' | 'sunday'` to `UserSettings` in `types.ts`, default `'monday'`
+- Add migration in `migrateSettings()` for existing users (set to `'monday'`)
+- Add a segmented control (Mon / Sun) in the Limits section of `popup.html`, visible when weekly cap is enabled (alongside the weekly cap amount input)
+- Bind the control in `popup.ts` to pending state
+- Update `getCurrentWeekStart()` in `src/content/interceptor.ts` to accept the reset day preference and compute either Monday-start or Sunday-start weeks
+- Update the `weeklyStartDate` comment in `types.ts` (currently says "Monday") to reflect that it could be Sunday depending on preference
+
+**Files:** `src/shared/types.ts`, `src/popup/popup.html`, `src/popup/popup.ts`, `src/popup/popup.css` (reuses `.segmented` styles, may need conditional visibility rule), `src/content/interceptor.ts`
+
+---
+
+## Fix 4 — History Summary Bar True-Center
+
+**Problem:** The 6 metric cards in the spending history summary bar are horizontally centered (`text-align: center`) but not vertically centered. Cards with different value lengths (e.g., "0" vs "$1,234.56") look uneven.
+
+**Solution:**
+- Add `justify-content: center` and `align-items: center` to `.summary-metric` in `history.css`
+- Add a consistent `min-height` (e.g., `80px`) so all cards are the same height and content is dead-center on both axes
+
+**Files:** `src/history/history.css`
+
+---
+
+## Fix 5 — Dynamic Intensity Escalation
+
+**Problem:** Friction intensity is static — users pick a level and it never changes regardless of how close they are to their spending limits. This means a user on Low gets the same friction at 5% of their cap as at 99%.
+
+**Solution:** Intensity auto-escalates based on the highest threshold percentage across all active caps (daily/weekly/monthly):
+
+| Threshold Range | Color  | Escalated Intensity |
+|----------------|--------|-------------------- |
+| Under 60%      | Green  | No change (base)    |
+| 60–79%         | Yellow | Medium              |
+| 80–99%         | Orange | High                |
+| 100%+          | Red    | Extreme             |
+
+**Rules:**
+- Escalation only goes **up** from the user's base intensity, never below it
+- The **highest %** across all active caps determines the tier
+- When any spending period resets (daily/weekly/monthly), intensity resets to the user's base setting
+- When **no caps are enabled**, no escalation occurs — the user's base intensity is used as-is
+- A **lock toggle** on the right side of the Intensity segmented control prevents all auto-escalation when engaged
+- An **info icon** (ⓘ) next to the lock explains the feature on hover: "Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level."
+
+**New settings fields:**
+- `intensityLocked: boolean` — default `false`
+- Add `intensityLocked` to `migrateSettings()` with default `false` for existing users
+- Existing `frictionIntensity` serves as the user's base/floor
+
+**Default intensity change:**
+- `DEFAULT_SETTINGS.frictionIntensity` changes from `'medium'` to `'low'`
+- Onboarding wizard: move `active` class from `data-value="medium"` to `data-value="low"` button
+- Onboarding wizard: update skip-confirmation text from "Medium friction" to "Low friction"
+- Onboarding wizard: update `wizard-friction-desc` default text to match Low description
+- Existing users are NOT migrated — their chosen intensity is preserved
+
+**UI treatment for escalated state:**
+Both Intensity segmented controls (Stats `#stats-intensity` and Friction `#friction-intensity`) need to reflect escalated state:
+- When escalation is active, the **escalated level** button gets a distinct highlight (e.g., pulsing border or different accent color like the threshold tier color) while the **user's base level** retains a subtle underline or dot indicator
+- A small label appears below the control: "↑ Auto-escalated from Low" (showing the base level)
+- When locked, the lock icon is filled/highlighted and no escalation visual appears
+- Both controls must stay in sync — changing intensity on either updates both + the pending state
+
+**Implementation:**
+- New function `computeEscalatedIntensity(baseIntensity, maxPercent, locked)` in `src/content/interceptor.ts` alongside existing spending logic
+- After computing max % across all active caps, this function returns the effective intensity
+- The popup and overlay both read the effective intensity (not the raw setting) when determining friction level
+- The escalated intensity is NOT written back to `UserSettings` — it's computed on the fly so the user's base preference is never overwritten
+
+**Files:** `src/shared/types.ts`, `src/content/interceptor.ts`, `src/popup/popup.html`, `src/popup/popup.ts`, `src/popup/popup.css`
+
+---
+
+## Fix 6 — History Summary Metric Colors Match Popup Stats
+
+**Problem:** The spending history summary bar only colors the "Total Saved" metric green. The other metrics (Cancel Rate, Top Cancel Step, etc.) use default text color, while the popup stat tiles have distinct colors for each: Saved = green, Cancel Rate = amber, Best Step = purple, Blocked = default.
+
+**Solution:** Add color overrides to `history.css` matching the popup's stat tile scheme:
+- `#metric-saved .metric-value` — `var(--success)` (already done)
+- `#metric-cancel-rate .metric-value` — `#f59e0b` (amber, matches `.stat-tile--rate`)
+- `#metric-top-step .metric-value` — `var(--accent)` (purple, matches `.stat-tile--step`)
+- `#metric-spent .metric-value` — `var(--danger)` (red — spent money is the "warning" counterpart to saved)
+- `#metric-count .metric-value` and `#metric-top-reason .metric-value` — keep default (no direct popup equivalent)
+
+**Files:** `src/history/history.css`
+
+---
+
+## Files Summary
+
+| File | Fixes |
+|------|-------|
+| `src/popup/popup.css` | 1, 2, 3, 5 |
+| `src/popup/popup.html` | 2, 3, 5 |
+| `src/popup/popup.ts` | 2, 3, 5 |
+| `src/shared/types.ts` | 3, 5 |
+| `src/content/interceptor.ts` | 3, 5 |
+| `src/history/history.css` | 4, 6 |
+| `manifest.json` | version bump |
+| `package.json` | version bump |
+| `HypeControl-TODO.md` | post-work update |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -41,14 +41,20 @@ function formatLocalDate(d: Date): string {
 }
 
 /**
- * Get the Monday that starts the current ISO week as YYYY-MM-DD.
- * ISO weeks start on Monday (day 1) and end on Sunday (day 7).
+ * Get the start of the current week as YYYY-MM-DD.
+ * Supports Monday-start (ISO default) or Sunday-start weeks.
  */
-function getCurrentWeekStart(date: Date = new Date()): string {
+function getCurrentWeekStart(date: Date = new Date(), resetDay: 'monday' | 'sunday' = 'monday'): string {
   const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
-  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-  d.setDate(d.getDate() + mondayOffset);
+  if (resetDay === 'sunday') {
+    // Sunday = 0, so offset is just -dayOfWeek
+    d.setDate(d.getDate() - dayOfWeek);
+  } else {
+    // Monday start (ISO): Sunday needs -6, others need 1-dayOfWeek
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    d.setDate(d.getDate() + mondayOffset);
+  }
   return formatLocalDate(d);
 }
 
@@ -73,7 +79,7 @@ async function loadSettings(): Promise<UserSettings> {
   }
 }
 
-async function loadSpendingTracker(): Promise<SpendingTracker> {
+async function loadSpendingTracker(settings: UserSettings): Promise<SpendingTracker> {
   try {
     const result = await chrome.storage.local.get(SPENDING_KEY);
     const tracker: SpendingTracker = result[SPENDING_KEY] || { ...DEFAULT_SPENDING_TRACKER };
@@ -90,8 +96,8 @@ async function loadSpendingTracker(): Promise<SpendingTracker> {
       tracker.dailyDate = today;
     }
 
-    // Weekly reset: calendar-aligned to Monday
-    const currentWeekStart = getCurrentWeekStart();
+    // Weekly reset: calendar-aligned to Monday or Sunday per user preference
+    const currentWeekStart = getCurrentWeekStart(new Date(), settings.weeklyResetDay ?? 'monday');
     if (tracker.weeklyStartDate !== currentWeekStart) {
       tracker.weeklyTotal = 0;
       tracker.weeklyStartDate = currentWeekStart;
@@ -1893,7 +1899,7 @@ async function handleClick(event: MouseEvent): Promise<void> {
     return;
   }
 
-  const tracker = await loadSpendingTracker();
+  const tracker = await loadSpendingTracker(settings);
 
   // Update session channel
   if (tracker.sessionChannel !== attempt.channel) {

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -14,6 +14,7 @@ import { shouldBypassFriction } from './streamingMode';
 import { applyThemeToOverlay } from './themeManager';
 import { log, debug } from '../shared/logger';
 import { writeInterceptEvent } from '../shared/interceptLogger';
+import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
 
 /** Result returned by runFrictionFlow */
 interface FrictionResult {
@@ -1705,7 +1706,12 @@ async function runFrictionFlow(
   // The subsequent steps (cooldown, type-to-confirm, math) expect the overlay to
   // already be in the DOM (they only set innerHTML and apply theme).
   // So after reason selection proceeds we must re-append before the next step.
-  const intensity = settings.frictionIntensity ?? 'low';
+  const maxPercent = computeMaxCapPercent(settings, tracker);
+  const intensity = computeEscalatedIntensity(
+    settings.frictionIntensity ?? 'low',
+    maxPercent,
+    settings.intensityLocked ?? false,
+  );
 
   if (intensity === 'medium' || intensity === 'high' || intensity === 'extreme') {
     // Create the shared overlay element for intensity steps

--- a/src/history/history.css
+++ b/src/history/history.css
@@ -305,6 +305,11 @@ body {
   color: var(--outcome-proceeded);
 }
 
+.amount-proceeded {
+  color: var(--danger);
+  font-weight: 600;
+}
+
 .saved-value {
   color: var(--success);
   font-weight: 600;

--- a/src/history/history.css
+++ b/src/history/history.css
@@ -109,7 +109,10 @@ body {
   text-align: center;
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  align-items: center;
   gap: 4px;
+  min-height: 80px;
 }
 
 .metric-value {
@@ -129,6 +132,18 @@ body {
 
 #metric-saved .metric-value {
   color: var(--success);
+}
+
+#metric-spent .metric-value {
+  color: var(--danger);
+}
+
+#metric-cancel-rate .metric-value {
+  color: #f59e0b;
+}
+
+#metric-top-step .metric-value {
+  color: var(--accent);
 }
 
 /* ─── Filter Bar ─────────────────────────────────────────── */

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -332,6 +332,9 @@ function renderTable(): void {
 
     const tdAmount = document.createElement('td');
     tdAmount.textContent = formatCurrency(event.priceWithTax);
+    if (event.outcome === 'proceeded') {
+      tdAmount.className = 'amount-proceeded';
+    }
     tr.appendChild(tdAmount);
 
     const tdOutcome = document.createElement('td');

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -982,6 +982,9 @@ async function getFormSettings(): Promise<UserSettings> {
     // Weekly/monthly caps are managed in popup, preserve current values
     weeklyCap: cachedSettings?.weeklyCap ?? DEFAULT_SETTINGS.weeklyCap,
     monthlyCap: cachedSettings?.monthlyCap ?? DEFAULT_SETTINGS.monthlyCap,
+    // Popup-managed fields — preserve current values
+    weeklyResetDay: cachedSettings?.weeklyResetDay ?? DEFAULT_SETTINGS.weeklyResetDay,
+    intensityLocked: cachedSettings?.intensityLocked ?? DEFAULT_SETTINGS.intensityLocked,
   };
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -723,7 +723,7 @@ body {
   font-family: inherit;
   font-size: 13px;
   padding: 5px 8px;
-  width: 100%;
+  width: 120px;
   min-width: 0;
 }
 .hc-wizard-input:focus {
@@ -743,7 +743,8 @@ body {
 .hc-wizard-hint a:hover { text-decoration: underline; }
 
 .hc-wizard-calc-toggle {
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--accent);
   text-decoration: none;
   align-self: flex-start;
@@ -847,13 +848,26 @@ body {
   cursor: help;
   position: relative;
 }
-.escalation-info:hover + .stat-tooltip,
-.escalation-info:focus + .stat-tooltip {
-  display: block;
-  left: auto;
+.escalation-tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
   right: 0;
-  transform: none;
   width: 200px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  padding: 6px 8px;
+  z-index: 10;
+  text-align: center;
+  pointer-events: none;
+}
+.escalation-info:hover .escalation-tooltip,
+.escalation-info:focus .escalation-tooltip {
+  display: block;
 }
 
 /* Escalated segmented button highlight */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -658,13 +658,15 @@ body {
   margin: 0;
 }
 
-.hc-wizard-skip {
-  font-size: 11px;
-  color: var(--text-muted);
-  text-decoration: none;
-  align-self: flex-start;
+.hc-wizard-skip-row {
+  display: flex;
+  justify-content: flex-end;
 }
-.hc-wizard-skip:hover { color: var(--text-primary); text-decoration: underline; }
+.hc-wizard-skip-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
 
 .hc-wizard-skip-confirm {
   background: var(--bg-secondary);
@@ -821,6 +823,24 @@ body {
   width: 100%;
 }
 
+/* ─── Salary calculator (Friction section) ───────────────── */
+.salary-calc-toggle {
+  font-size: 12px;
+  color: var(--accent);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.salary-calc-toggle:hover { text-decoration: underline; }
+
+.salary-calc-panel {
+  padding: 8px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+  margin-bottom: 4px;
+}
+.salary-calc-panel[hidden] { display: none; }
+
 /* ─── Lock toggle (compact, inline with segmented) ───────── */
 .toggle-wrap--lock {
   gap: 4px;
@@ -848,11 +868,13 @@ body {
   cursor: help;
   position: relative;
 }
-.escalation-tooltip {
+/* Right-facing tooltip used by escalation info + session total */
+.info-tooltip-right {
   display: none;
   position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  top: 50%;
+  left: calc(100% + 8px);
+  transform: translateY(-50%);
   width: 200px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
@@ -862,11 +884,12 @@ body {
   line-height: 1.4;
   padding: 6px 8px;
   z-index: 10;
-  text-align: center;
+  text-align: left;
   pointer-events: none;
+  white-space: normal;
 }
-.escalation-info:hover .escalation-tooltip,
-.escalation-info:focus .escalation-tooltip {
+.escalation-info:hover .info-tooltip-right,
+.escalation-info:focus .info-tooltip-right {
   display: block;
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -820,15 +820,15 @@ body {
   width: 100%;
 }
 
-/* Replay button in settings section */
-.hc-row--replay {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border-color);
-}
-
-.btn-replay-tour {
+/* Replay tour button — lives below Credits at the very bottom */
+.btn-replay-bottom {
+  display: block;
+  margin: 24px auto 16px;
   font-size: 12px;
+  opacity: 0.7;
+}
+.btn-replay-bottom:hover {
+  opacity: 1;
 }
 
 /* NOTE: .hc-demo-badge is intentionally NOT defined here.

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -840,12 +840,20 @@ body {
   font-weight: 500;
 }
 
-/* ─── Escalation info icon (reuses stat-tooltip pattern) ── */
+/* ─── Escalation info icon ────────────────────────────────── */
 .escalation-info {
   font-size: 12px;
   color: var(--text-muted);
   cursor: help;
   position: relative;
+}
+.escalation-info:hover + .stat-tooltip,
+.escalation-info:focus + .stat-tooltip {
+  display: block;
+  left: auto;
+  right: 0;
+  transform: none;
+  width: 200px;
 }
 
 /* Escalated segmented button highlight */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -216,7 +216,7 @@ body {
 }
 .hc-label {
   flex: 0 0 auto;
-  min-width: 110px;
+  min-width: 140px;
   color: var(--text-secondary);
   font-size: 12px;
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -820,6 +820,50 @@ body {
   width: 100%;
 }
 
+/* ─── Lock toggle (compact, inline with segmented) ───────── */
+.toggle-wrap--lock {
+  gap: 4px;
+  margin-left: 4px;
+}
+.lock-label {
+  font-size: 11px;
+}
+
+/* ─── Escalation indicator ──────────────────────────────── */
+.escalation-indicator {
+  padding: 2px 0 2px 140px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.escalation-indicator .escalation-text {
+  color: #f59e0b;
+  font-weight: 500;
+}
+
+/* ─── Escalation info icon (reuses stat-tooltip pattern) ── */
+.escalation-info {
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: help;
+  position: relative;
+}
+
+/* Escalated segmented button highlight */
+.seg-btn.escalated {
+  border-color: #f59e0b;
+  color: #f59e0b;
+  font-weight: 600;
+}
+.seg-btn.base-indicator::after {
+  content: '';
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin: 2px auto 0;
+}
+
 /* Replay tour button — lives below Credits at the very bottom */
 .btn-replay-bottom {
   display: block;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -16,15 +16,20 @@
     <div id="hc-wizard" class="hc-wizard" hidden>
       <div class="hc-wizard-header">
         <img src="assets/icons/ChromeWebStore/HC_icon_48px.png" width="28" height="28" alt="">
-        <h2 class="hc-wizard-title">Welcome to Hype Control</h2>
+        <h2 class="hc-wizard-title">Hype Control Tutorial</h2>
       </div>
 
-      <a class="hc-wizard-skip" id="wizard-skip" href="#">Skip setup, I'll configure it myself →</a>
+      <div class="hc-wizard-skip-row">
+        <button class="btn-secondary btn-sm" id="wizard-skip">Good with defaults?</button>
+      </div>
 
       <!-- Skip confirmation (shown after skip click) -->
       <div id="wizard-skip-confirm" class="hc-wizard-skip-confirm" hidden>
-        <p class="hc-wizard-defaults-msg">You're all set with defaults: <strong>$20/hr wage · 7% sales tax · Low friction · Preset comparison items enabled.</strong> Update these in Settings anytime.</p>
-        <button class="btn-primary" id="wizard-got-it">Got it →</button>
+        <p class="hc-wizard-defaults-msg"><strong>$20/hr wage · 7% sales tax · Low friction · Preset comparison items.</strong> You can update these anytime.</p>
+        <div class="hc-wizard-skip-actions">
+          <button class="btn-sm" id="wizard-skip-back">No, take me back</button>
+          <button class="btn-primary btn-sm" id="wizard-skip-yes">Yes</button>
+        </div>
       </div>
 
       <!-- Main wizard form -->
@@ -40,7 +45,7 @@
           <div id="wizard-salary-calc" class="hc-wizard-salary-calc" hidden>
             <div class="hc-wizard-input-row">
               <span class="hc-wizard-prefix">$</span>
-              <input type="number" id="wizard-annual-salary" class="hc-wizard-input" placeholder="Annual salary" min="1">
+              <input type="text" inputmode="numeric" id="wizard-annual-salary" class="hc-wizard-input" placeholder="Annual salary">
             </div>
             <div class="hc-wizard-input-row">
               <input type="number" id="wizard-hours-per-week" class="hc-wizard-input" placeholder="Hours/week" value="40" min="1" max="168">
@@ -73,12 +78,7 @@
           <div class="hc-wizard-chips" id="wizard-chips">
             <!-- Populated by popup.ts from PRESET_COMPARISON_ITEMS -->
           </div>
-          <p class="hc-wizard-hint">These are your default comparisons. <a href="#" id="wizard-customize-link"><strong>Customize in Settings →</strong></a></p>
-          <div id="wizard-customize-confirm" class="hc-wizard-skip-confirm" hidden>
-            <p class="hc-wizard-defaults-msg">Exit the tour and go to Comparisons? You can replay the tour anytime from the bottom of the page, under Credits.</p>
-            <button class="btn-primary btn-sm" id="wizard-customize-yes">Yes, customize now</button>
-            <button class="btn-sm" id="wizard-customize-cancel">Cancel</button>
-          </div>
+          <p class="hc-wizard-hint">These are your default comparisons — customize them later in <strong>Comparisons</strong>.</p>
         </div>
 
         <button class="btn-primary hc-wizard-continue" id="wizard-continue">Continue →</button>
@@ -128,6 +128,17 @@
         <div class="hc-row">
           <label class="hc-label" for="friction-hourly-rate">Hourly rate ($/hr)</label>
           <input type="number" id="friction-hourly-rate" min="0.01" step="0.01" class="hc-input hc-input--sm" />
+          <a class="salary-calc-toggle" id="friction-calc-toggle" href="#">Calculate from salary →</a>
+        </div>
+        <div id="friction-salary-calc" class="salary-calc-panel" hidden>
+          <div class="hc-row">
+            <label class="hc-label" for="friction-annual-salary">Annual salary ($)</label>
+            <input type="text" inputmode="numeric" id="friction-annual-salary" class="hc-input hc-input--sm" placeholder="e.g. 52,000" />
+          </div>
+          <div class="hc-row">
+            <label class="hc-label" for="friction-hours-per-week">Hours / week</label>
+            <input type="number" id="friction-hours-per-week" min="1" max="168" value="40" class="hc-input hc-input--sm" />
+          </div>
         </div>
         <div class="hc-row">
           <label class="hc-label" for="friction-tax-rate">Tax rate (%)</label>
@@ -148,7 +159,7 @@
               <span class="lock-label">🔒</span>
             </label>
             <span class="escalation-info" tabindex="0" aria-describedby="tooltip-escalation">ⓘ
-              <span class="escalation-tooltip" id="tooltip-escalation" role="tooltip">Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level.</span>
+              <span class="info-tooltip-right" id="tooltip-escalation" role="tooltip">Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level.</span>
             </span>
           </fieldset>
         </div>
@@ -280,7 +291,11 @@
             <span class="tracker-value" id="tracker-daily">—</span>
           </div>
           <div class="hc-row">
-            <span class="hc-label">Session total</span>
+            <span class="hc-label">Session total
+              <span class="escalation-info" tabindex="0">ⓘ
+                <span class="info-tooltip-right" role="tooltip">Spending on the current channel this browsing session. Resets when you switch channels.</span>
+              </span>
+            </span>
             <span class="tracker-value" id="tracker-session">—</span>
           </div>
           <div class="hc-row" id="tracker-weekly-row" hidden>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -73,7 +73,12 @@
           <div class="hc-wizard-chips" id="wizard-chips">
             <!-- Populated by popup.ts from PRESET_COMPARISON_ITEMS -->
           </div>
-          <p class="hc-wizard-hint">These are your default comparisons. <a href="#" id="wizard-customize-link">Customize in Settings →</a></p>
+          <p class="hc-wizard-hint">These are your default comparisons. <a href="#" id="wizard-customize-link"><strong>Customize in Settings →</strong></a></p>
+          <div id="wizard-customize-confirm" class="hc-wizard-skip-confirm" hidden>
+            <p class="hc-wizard-defaults-msg">Exit the tour and go to Comparisons? You can replay the tour anytime from the bottom of the page, under Credits.</p>
+            <button class="btn-primary btn-sm" id="wizard-customize-yes">Yes, customize now</button>
+            <button class="btn-sm" id="wizard-customize-cancel">Cancel</button>
+          </div>
         </div>
 
         <button class="btn-primary hc-wizard-continue" id="wizard-continue">Continue →</button>
@@ -115,27 +120,6 @@
           <span class="override-status" id="override-status">No active override</span>
           <button class="btn-secondary" id="btn-override">Stream Override (2 hr)</button>
         </div>
-        <div class="hc-row">
-          <fieldset class="hc-fieldset">
-            <legend class="hc-label">Intensity</legend>
-            <div class="segmented" id="stats-intensity" data-pending-field="frictionIntensity">
-              <button class="seg-btn" data-value="low">Low</button>
-              <button class="seg-btn" data-value="medium">Med</button>
-              <button class="seg-btn" data-value="high">High</button>
-              <button class="seg-btn" data-value="extreme">Extreme</button>
-            </div>
-            <label class="toggle-wrap toggle-wrap--lock" title="Lock intensity — prevents auto-escalation">
-              <input type="checkbox" id="stats-intensity-lock" />
-              <span class="toggle-track"></span>
-              <span class="lock-label">🔒</span>
-            </label>
-            <span class="escalation-info" tabindex="0" aria-describedby="tooltip-escalation">ⓘ</span>
-            <span class="stat-tooltip" id="tooltip-escalation" role="tooltip">Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level.</span>
-          </fieldset>
-        </div>
-        <div class="escalation-indicator" id="stats-escalation-indicator" hidden>
-          <span class="escalation-text"></span>
-        </div>
       </section>
 
       <!-- Section 2: Friction -->
@@ -163,6 +147,9 @@
               <span class="toggle-track"></span>
               <span class="lock-label">🔒</span>
             </label>
+            <span class="escalation-info" tabindex="0" aria-describedby="tooltip-escalation">ⓘ
+              <span class="escalation-tooltip" id="tooltip-escalation" role="tooltip">Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level.</span>
+            </span>
           </fieldset>
         </div>
         <div class="escalation-indicator" id="friction-escalation-indicator" hidden>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -353,9 +353,6 @@
         <div class="hc-row">
           <button class="btn-secondary" id="btn-view-logs">View Activity Logs</button>
         </div>
-        <div class="hc-row hc-row--replay">
-          <button class="btn-secondary btn-replay-tour" id="btn-replay-tour">↺ Replay setup tour</button>
-        </div>
       </section>
 
       <!-- Section 7: Credits -->
@@ -371,6 +368,8 @@
         </div>
         <p class="credits-byline">Created by <a class="credits-link" href="http://www.ktulue.com/" target="_blank" rel="noopener">Ktulue</a> | The Water Father 🌊</p>
       </section>
+
+    <button class="btn-secondary btn-replay-bottom" id="btn-replay-bottom">↺ Replay Setup Tour</button>
 
     </div><!-- /.hc-content -->
 
@@ -390,7 +389,6 @@
     <div class="footer-links">
       <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
       <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
-      <a class="footer-link" href="#" id="footer-replay-tour">↺ Tour</a>
     </div>
     <button class="btn-save" id="btn-save">💾 Save Settings</button>
     <span class="footer-version" id="footer-version"></span>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -23,7 +23,7 @@
 
       <!-- Skip confirmation (shown after skip click) -->
       <div id="wizard-skip-confirm" class="hc-wizard-skip-confirm" hidden>
-        <p class="hc-wizard-defaults-msg">You're all set with defaults: <strong>$20/hr wage · 7% sales tax · Medium friction · Preset comparison items enabled.</strong> Update these in Settings anytime.</p>
+        <p class="hc-wizard-defaults-msg">You're all set with defaults: <strong>$20/hr wage · 7% sales tax · Low friction · Preset comparison items enabled.</strong> Update these in Settings anytime.</p>
         <button class="btn-primary" id="wizard-got-it">Got it →</button>
       </div>
 
@@ -60,12 +60,12 @@
         <div class="hc-wizard-field">
           <span class="hc-wizard-label">Friction Level</span>
           <div class="hc-wizard-seg" id="wizard-friction-seg" role="group" aria-label="Friction level">
-            <button class="hc-wizard-seg-btn" data-value="low">Low</button>
-            <button class="hc-wizard-seg-btn active" data-value="medium">Medium</button>
+            <button class="hc-wizard-seg-btn active" data-value="low">Low</button>
+            <button class="hc-wizard-seg-btn" data-value="medium">Medium</button>
             <button class="hc-wizard-seg-btn" data-value="high">High</button>
             <button class="hc-wizard-seg-btn" data-value="extreme">Extreme</button>
           </div>
-          <p class="hc-wizard-friction-desc" id="wizard-friction-desc">Overlay + reason selection</p>
+          <p class="hc-wizard-friction-desc" id="wizard-friction-desc">Main overlay only — one click to cancel</p>
         </div>
 
         <div class="hc-wizard-field">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -124,7 +124,17 @@
               <button class="seg-btn" data-value="high">High</button>
               <button class="seg-btn" data-value="extreme">Extreme</button>
             </div>
+            <label class="toggle-wrap toggle-wrap--lock" title="Lock intensity — prevents auto-escalation">
+              <input type="checkbox" id="stats-intensity-lock" />
+              <span class="toggle-track"></span>
+              <span class="lock-label">🔒</span>
+            </label>
+            <span class="escalation-info" tabindex="0" aria-describedby="tooltip-escalation">ⓘ</span>
+            <span class="stat-tooltip" id="tooltip-escalation" role="tooltip">Intensity auto-adjusts as you approach your spending limits. Lock to keep your chosen level.</span>
           </fieldset>
+        </div>
+        <div class="escalation-indicator" id="stats-escalation-indicator" hidden>
+          <span class="escalation-text"></span>
         </div>
       </section>
 
@@ -148,7 +158,15 @@
               <button class="seg-btn" data-value="high">High</button>
               <button class="seg-btn" data-value="extreme">Extreme</button>
             </div>
+            <label class="toggle-wrap toggle-wrap--lock" title="Lock intensity — prevents auto-escalation">
+              <input type="checkbox" id="friction-intensity-lock" />
+              <span class="toggle-track"></span>
+              <span class="lock-label">🔒</span>
+            </label>
           </fieldset>
+        </div>
+        <div class="escalation-indicator" id="friction-escalation-indicator" hidden>
+          <span class="escalation-text"></span>
         </div>
         <div class="hc-row">
           <label class="hc-label" for="delay-enabled">Delay timer</label>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -242,6 +242,13 @@
           </label>
           <input type="number" id="weekly-cap-amount" min="0" step="0.01" class="hc-input hc-input--sm" hidden />
         </div>
+        <div class="hc-row" id="weekly-reset-day-row" hidden>
+          <label class="hc-label">Week starts</label>
+          <div class="segmented" id="weekly-reset-day" data-pending-field="weeklyResetDay">
+            <button class="seg-btn" data-value="monday">Mon</button>
+            <button class="seg-btn" data-value="sunday">Sun</button>
+          </div>
+        </div>
         <div class="hc-row">
           <label class="hc-label" for="monthly-cap-enabled">Monthly cap</label>
           <label class="toggle-wrap">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -204,6 +204,24 @@ async function main(): Promise<void> {
   const channelsEl = document.getElementById('section-channels')!;
   const settingsEl = document.getElementById('section-settings')!;
 
+  // Escalation state — updated on load and when relevant settings change
+  let escalationUpdatePending = false;
+  async function updateEscalation(): Promise<void> {
+    if (escalationUpdatePending) return;
+    escalationUpdatePending = true;
+    try {
+      const trackerResult = await chrome.storage.local.get('hcSpending');
+      const tracker: SpendingTracker = { ...DEFAULT_SPENDING_TRACKER, ...trackerResult['hcSpending'] };
+      const s = getPending();
+      const maxPercent = computeMaxCapPercent(s, tracker);
+      const effective = computeEscalatedIntensity(s.frictionIntensity, maxPercent, s.intensityLocked);
+      stats.showEscalation(s.frictionIntensity, effective);
+      friction.showEscalation(s.frictionIntensity, effective);
+    } finally {
+      escalationUpdatePending = false;
+    }
+  }
+
   // Init section controllers with bidirectional sync callbacks
   const friction = initFriction(frictionEl, {
     onIntensityChange: (v) => {
@@ -211,10 +229,12 @@ async function main(): Promise<void> {
       statsEl.querySelectorAll<HTMLButtonElement>('#stats-intensity .seg-btn').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.value === v);
       });
+      updateEscalation();
     },
+    onLockChange: () => updateEscalation(),
   });
 
-  const limits = initLimits(limitsEl);
+  const limits = initLimits(limitsEl, { onCapChange: () => updateEscalation() });
 
   const stats = initStats(statsEl, {
     onIntensityChange: (v) => {
@@ -222,7 +242,9 @@ async function main(): Promise<void> {
       frictionEl.querySelectorAll<HTMLButtonElement>('#friction-intensity .seg-btn').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.value === v);
       });
+      updateEscalation();
     },
+    onLockChange: () => updateEscalation(),
   });
 
   const comparisons = initComparisons(comparisonsEl);
@@ -248,16 +270,7 @@ async function main(): Promise<void> {
   stats.refreshStats();
   limits.refreshTracker();
 
-  // Compute escalation state from tracker + settings
-  async function updateEscalation(): Promise<void> {
-    const trackerResult = await chrome.storage.local.get('hcSpending');
-    const tracker: SpendingTracker = { ...DEFAULT_SPENDING_TRACKER, ...trackerResult['hcSpending'] };
-    const s = getPending();
-    const maxPercent = computeMaxCapPercent(s, tracker);
-    const effective = computeEscalatedIntensity(s.frictionIntensity, maxPercent, s.intensityLocked);
-    stats.showEscalation(s.frictionIntensity, effective);
-    friction.showEscalation(s.frictionIntensity, effective);
-  }
+  // Initial escalation computation
   await updateEscalation();
 
   // Scroll-spy

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -148,7 +148,7 @@ function showWizard(onComplete: () => void): void {
     const hourlyRate = parseFloat(hourlyInput.value) || 20;
     const taxRate = parseFloat(taxInput.value) || 7;
     const activeBtn = frictionSeg.querySelector<HTMLButtonElement>('.hc-wizard-seg-btn.active');
-    const frictionIntensity = (activeBtn?.dataset.value ?? 'medium') as UserSettings['frictionIntensity'];
+    const frictionIntensity = (activeBtn?.dataset.value ?? 'low') as UserSettings['frictionIntensity'];
 
     // Load current settings (handles reinstall case — prefills from existing)
     const result = await chrome.storage.sync.get('hcSettings');

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -14,6 +14,30 @@ import { settingsLog, setVersion } from '../shared/logger';
 
 const SETTINGS_KEY = 'hcSettings';
 
+/** Parse a numeric string that may contain locale formatting (commas, periods) */
+function parseLocaleNumber(str: string): number {
+  return parseFloat(str.replace(/[^0-9.\-]/g, '')) || 0;
+}
+
+/** Format a number with locale-aware grouping (e.g. 52000 → "52,000") */
+function formatLocaleSalary(value: number): string {
+  if (!value || value <= 0) return '';
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+}
+
+/** Wire locale formatting on a text input: format on blur, strip on focus */
+function wireLocaleSalaryInput(input: HTMLInputElement, onInput: () => void): void {
+  input.addEventListener('input', onInput);
+  input.addEventListener('blur', () => {
+    const val = parseLocaleNumber(input.value);
+    if (val > 0) input.value = formatLocaleSalary(val);
+  });
+  input.addEventListener('focus', () => {
+    const val = parseLocaleNumber(input.value);
+    if (val > 0) input.value = String(val);
+  });
+}
+
 let activeMql: MediaQueryList | null = null;
 let mqlHandler: (() => void) | null = null;
 
@@ -49,9 +73,10 @@ const FRICTION_DESCRIPTIONS: Record<string, string> = {
 function showWizard(onComplete: () => void): void {
   const wizard = document.getElementById('hc-wizard')!;
   const form = document.getElementById('wizard-form')!;
-  const skipLink = document.getElementById('wizard-skip')!;
+  const skipBtn = document.getElementById('wizard-skip')!;
   const skipConfirm = document.getElementById('wizard-skip-confirm')!;
-  const gotItBtn = document.getElementById('wizard-got-it')!;
+  const skipBack = document.getElementById('wizard-skip-back')!;
+  const skipYes = document.getElementById('wizard-skip-yes')!;
   const hourlyInput = document.getElementById('wizard-hourly-rate') as HTMLInputElement;
   const taxInput = document.getElementById('wizard-tax-rate') as HTMLInputElement;
   const calcToggle = document.getElementById('wizard-calc-toggle')!;
@@ -62,7 +87,6 @@ function showWizard(onComplete: () => void): void {
   const frictionDesc = document.getElementById('wizard-friction-desc')!;
   const chips = document.getElementById('wizard-chips')!;
   const continueBtn = document.getElementById('wizard-continue')!;
-  const customizeLink = document.getElementById('wizard-customize-link')!;
 
   // Show wizard, hide main content
   wizard.removeAttribute('hidden');
@@ -96,13 +120,13 @@ function showWizard(onComplete: () => void): void {
 
   // Salary calculator: auto-compute hourly rate
   function updateHourlyFromSalary(): void {
-    const salary = parseFloat(salaryInput.value);
+    const salary = parseLocaleNumber(salaryInput.value);
     const hours = parseFloat(hoursInput.value) || 40;
     if (salary > 0 && hours > 0) {
       hourlyInput.value = (salary / 52 / hours).toFixed(2);
     }
   }
-  salaryInput.addEventListener('input', updateHourlyFromSalary);
+  wireLocaleSalaryInput(salaryInput, updateHourlyFromSalary);
   hoursInput.addEventListener('input', updateHourlyFromSalary);
 
   // Friction segmented control
@@ -114,49 +138,21 @@ function showWizard(onComplete: () => void): void {
     frictionDesc.textContent = FRICTION_DESCRIPTIONS[btn.dataset.value ?? 'medium'] ?? '';
   });
 
-  // Skip path
-  skipLink.addEventListener('click', async (e) => {
-    e.preventDefault();
-    // Write defaults to storage
-    await chrome.storage.sync.set({ hcSettings: DEFAULT_SETTINGS });
-    // Clear wizard pending flag; leave phase2 pending
-    await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
-    // Show skip confirmation
+  // Skip path — "Good with defaults?" → confirmation
+  skipBtn.addEventListener('click', () => {
     form.setAttribute('hidden', '');
-    skipLink.setAttribute('hidden', '');
+    skipBtn.parentElement!.setAttribute('hidden', '');
     skipConfirm.removeAttribute('hidden');
-    // "Got it" button closes the wizard (no auto-close timer — let user read at their pace)
-    gotItBtn.addEventListener('click', () => {
-      closeWizard();
-    });
   });
-
-  // Customize link — confirm before exiting wizard
-  const customizeConfirm = document.getElementById('wizard-customize-confirm')!;
-  const customizeYes = document.getElementById('wizard-customize-yes')!;
-  const customizeCancel = document.getElementById('wizard-customize-cancel')!;
-
-  customizeLink.addEventListener('click', (e) => {
-    e.preventDefault();
-    customizeConfirm.removeAttribute('hidden');
+  skipBack.addEventListener('click', () => {
+    skipConfirm.setAttribute('hidden', '');
+    form.removeAttribute('hidden');
+    skipBtn.parentElement!.removeAttribute('hidden');
   });
-  customizeCancel.addEventListener('click', () => {
-    customizeConfirm.setAttribute('hidden', '');
-  });
-  customizeYes.addEventListener('click', async () => {
-    // Save wizard values before closing (prevents theme flip on reload)
-    const hourlyRate = parseFloat(hourlyInput.value) || 20;
-    const taxRate = parseFloat(taxInput.value) || 7;
-    const activeBtn = frictionSeg.querySelector<HTMLButtonElement>('.hc-wizard-seg-btn.active');
-    const frictionIntensity = (activeBtn?.dataset.value ?? 'low') as UserSettings['frictionIntensity'];
-    const result = await chrome.storage.sync.get('hcSettings');
-    const current = migrateSettings(result.hcSettings ?? {});
-    await chrome.storage.sync.set({ hcSettings: { ...current, hourlyRate, taxRate, frictionIntensity } });
+  skipYes.addEventListener('click', async () => {
+    await chrome.storage.sync.set({ hcSettings: DEFAULT_SETTINGS });
     await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
     closeWizard();
-    setTimeout(() => {
-      document.getElementById('section-comparisons')?.scrollIntoView({ behavior: 'smooth' });
-    }, 50);
   });
 
   // Continue button

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -125,19 +125,35 @@ function showWizard(onComplete: () => void): void {
     form.setAttribute('hidden', '');
     skipLink.setAttribute('hidden', '');
     skipConfirm.removeAttribute('hidden');
-    // Auto-close after 3s fallback
-    const autoClose = setTimeout(() => closeWizard(), 3000);
+    // "Got it" button closes the wizard (no auto-close timer — let user read at their pace)
     gotItBtn.addEventListener('click', () => {
-      clearTimeout(autoClose);
       closeWizard();
     });
   });
 
-  // Customize link — close wizard and navigate to Comparisons section
+  // Customize link — confirm before exiting wizard
+  const customizeConfirm = document.getElementById('wizard-customize-confirm')!;
+  const customizeYes = document.getElementById('wizard-customize-yes')!;
+  const customizeCancel = document.getElementById('wizard-customize-cancel')!;
+
   customizeLink.addEventListener('click', (e) => {
     e.preventDefault();
+    customizeConfirm.removeAttribute('hidden');
+  });
+  customizeCancel.addEventListener('click', () => {
+    customizeConfirm.setAttribute('hidden', '');
+  });
+  customizeYes.addEventListener('click', async () => {
+    // Save wizard values before closing (prevents theme flip on reload)
+    const hourlyRate = parseFloat(hourlyInput.value) || 20;
+    const taxRate = parseFloat(taxInput.value) || 7;
+    const activeBtn = frictionSeg.querySelector<HTMLButtonElement>('.hc-wizard-seg-btn.active');
+    const frictionIntensity = (activeBtn?.dataset.value ?? 'low') as UserSettings['frictionIntensity'];
+    const result = await chrome.storage.sync.get('hcSettings');
+    const current = migrateSettings(result.hcSettings ?? {});
+    await chrome.storage.sync.set({ hcSettings: { ...current, hourlyRate, taxRate, frictionIntensity } });
+    await chrome.storage.local.set({ [ONBOARDING_KEYS.wizardPending]: false });
     closeWizard();
-    // Scroll to comparisons section
     setTimeout(() => {
       document.getElementById('section-comparisons')?.scrollIntoView({ behavior: 'smooth' });
     }, 50);
@@ -215,37 +231,21 @@ async function main(): Promise<void> {
       const s = getPending();
       const maxPercent = computeMaxCapPercent(s, tracker);
       const effective = computeEscalatedIntensity(s.frictionIntensity, maxPercent, s.intensityLocked);
-      stats.showEscalation(s.frictionIntensity, effective);
       friction.showEscalation(s.frictionIntensity, effective);
     } finally {
       escalationUpdatePending = false;
     }
   }
 
-  // Init section controllers with bidirectional sync callbacks
+  // Init section controllers
   const friction = initFriction(frictionEl, {
-    onIntensityChange: (v) => {
-      // Stats intensity mirror — re-render Stats intensity control
-      statsEl.querySelectorAll<HTMLButtonElement>('#stats-intensity .seg-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.value === v);
-      });
-      updateEscalation();
-    },
+    onIntensityChange: () => updateEscalation(),
     onLockChange: () => updateEscalation(),
   });
 
   const limits = initLimits(limitsEl, { onCapChange: () => updateEscalation() });
 
-  const stats = initStats(statsEl, {
-    onIntensityChange: (v) => {
-      // Friction intensity mirror — re-render Friction intensity control
-      frictionEl.querySelectorAll<HTMLButtonElement>('#friction-intensity .seg-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.value === v);
-      });
-      updateEscalation();
-    },
-    onLockChange: () => updateEscalation(),
-  });
+  const stats = initStats(statsEl);
 
   const comparisons = initComparisons(comparisonsEl);
   const channels = initChannels(channelsEl);

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,6 +1,7 @@
 // src/popup/popup.ts
 import './popup.css';
-import { migrateSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS, UserSettings } from '../shared/types';
+import { migrateSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS, UserSettings, SpendingTracker, DEFAULT_SPENDING_TRACKER } from '../shared/types';
+import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
 import { initPending, getPending, setPendingField } from './pendingState';
 import { initScrollSpy, ScrollSpyItem } from './scrollSpy';
 import { initStats } from './sections/stats';
@@ -246,6 +247,18 @@ async function main(): Promise<void> {
   // Async data that doesn't come from pending state
   stats.refreshStats();
   limits.refreshTracker();
+
+  // Compute escalation state from tracker + settings
+  async function updateEscalation(): Promise<void> {
+    const trackerResult = await chrome.storage.local.get('hcSpending');
+    const tracker: SpendingTracker = { ...DEFAULT_SPENDING_TRACKER, ...trackerResult['hcSpending'] };
+    const s = getPending();
+    const maxPercent = computeMaxCapPercent(s, tracker);
+    const effective = computeEscalatedIntensity(s.frictionIntensity, maxPercent, s.intensityLocked);
+    stats.showEscalation(s.frictionIntensity, effective);
+    friction.showEscalation(s.frictionIntensity, effective);
+  }
+  await updateEscalation();
 
   // Scroll-spy
   const contentEl = document.getElementById('hc-content')!;

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -289,12 +289,8 @@ async function main(): Promise<void> {
     }
   });
 
-  // Replay tour triggers
-  document.getElementById('footer-replay-tour')?.addEventListener('click', async (e) => {
-    e.preventDefault();
-    await triggerReplay();
-  });
-  document.getElementById('btn-replay-tour')?.addEventListener('click', async () => {
+  // Replay tour trigger
+  document.getElementById('btn-replay-bottom')?.addEventListener('click', async () => {
     await triggerReplay();
   });
 }

--- a/src/popup/sections/friction.ts
+++ b/src/popup/sections/friction.ts
@@ -55,8 +55,6 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
 
   lockEl.addEventListener('change', () => {
     setPendingField('intensityLocked', lockEl.checked);
-    const statsLock = document.querySelector<HTMLInputElement>('#stats-intensity-lock');
-    if (statsLock) statsLock.checked = lockEl.checked;
     callbacks.onLockChange?.();
   });
 

--- a/src/popup/sections/friction.ts
+++ b/src/popup/sections/friction.ts
@@ -1,6 +1,15 @@
 import { UserSettings, FrictionIntensity, DelayTimerConfig, FrictionThresholds, DEFAULT_SETTINGS } from '../../shared/types';
 import { setPendingField, getPending } from '../pendingState';
 
+function parseLocaleNumber(str: string): number {
+  return parseFloat(str.replace(/[^0-9.\-]/g, '')) || 0;
+}
+
+function formatLocaleSalary(value: number): string {
+  if (!value || value <= 0) return '';
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+}
+
 export interface FrictionCallbacks {
   onIntensityChange: (value: FrictionIntensity) => void;
   onLockChange?: () => void;
@@ -24,6 +33,10 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
   const nudgeStepsEl = el.querySelector<HTMLInputElement>('#threshold-nudge-steps')!;
   const lockEl = el.querySelector<HTMLInputElement>('#friction-intensity-lock')!;
   const escalationIndicatorEl = el.querySelector<HTMLElement>('#friction-escalation-indicator')!;
+  const calcToggle = el.querySelector<HTMLAnchorElement>('#friction-calc-toggle')!;
+  const salaryCalcPanel = el.querySelector<HTMLElement>('#friction-salary-calc')!;
+  const annualSalaryEl = el.querySelector<HTMLInputElement>('#friction-annual-salary')!;
+  const hoursPerWeekEl = el.querySelector<HTMLInputElement>('#friction-hours-per-week')!;
 
   let currentSettings: UserSettings = { ...DEFAULT_SETTINGS };
 
@@ -37,6 +50,39 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
   hourlyRateEl.addEventListener('input', () => {
     setPendingField('hourlyRate', parseFloat(hourlyRateEl.value) || DEFAULT_SETTINGS.hourlyRate);
   });
+
+  // Salary calculator toggle + auto-compute
+  calcToggle.addEventListener('click', (e) => {
+    e.preventDefault();
+    const isHidden = salaryCalcPanel.hasAttribute('hidden');
+    if (isHidden) {
+      salaryCalcPanel.removeAttribute('hidden');
+      calcToggle.textContent = 'Hide calculator ↑';
+    } else {
+      salaryCalcPanel.setAttribute('hidden', '');
+      calcToggle.textContent = 'Calculate from salary →';
+    }
+  });
+
+  function updateHourlyFromSalary(): void {
+    const salary = parseLocaleNumber(annualSalaryEl.value);
+    const hours = parseFloat(hoursPerWeekEl.value) || 40;
+    if (salary > 0 && hours > 0) {
+      const computed = Math.round(salary / 52 / hours * 100) / 100;
+      hourlyRateEl.value = String(computed);
+      setPendingField('hourlyRate', computed);
+    }
+  }
+  annualSalaryEl.addEventListener('input', updateHourlyFromSalary);
+  annualSalaryEl.addEventListener('blur', () => {
+    const val = parseLocaleNumber(annualSalaryEl.value);
+    if (val > 0) annualSalaryEl.value = formatLocaleSalary(val);
+  });
+  annualSalaryEl.addEventListener('focus', () => {
+    const val = parseLocaleNumber(annualSalaryEl.value);
+    if (val > 0) annualSalaryEl.value = String(val);
+  });
+  hoursPerWeekEl.addEventListener('input', updateHourlyFromSalary);
 
   // Tax rate
   taxRateEl.addEventListener('input', () => {

--- a/src/popup/sections/friction.ts
+++ b/src/popup/sections/friction.ts
@@ -3,6 +3,7 @@ import { setPendingField, getPending } from '../pendingState';
 
 export interface FrictionCallbacks {
   onIntensityChange: (value: FrictionIntensity) => void;
+  onLockChange?: () => void;
 }
 
 export interface FrictionController {
@@ -56,6 +57,7 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
     setPendingField('intensityLocked', lockEl.checked);
     const statsLock = document.querySelector<HTMLInputElement>('#stats-intensity-lock');
     if (statsLock) statsLock.checked = lockEl.checked;
+    callbacks.onLockChange?.();
   });
 
   // Delay timer toggle

--- a/src/popup/sections/friction.ts
+++ b/src/popup/sections/friction.ts
@@ -7,6 +7,7 @@ export interface FrictionCallbacks {
 
 export interface FrictionController {
   render(settings: UserSettings): void;
+  showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void;
 }
 
 export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): FrictionController {
@@ -20,6 +21,8 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
   const floorEl = el.querySelector<HTMLInputElement>('#threshold-floor')!;
   const ceilingEl = el.querySelector<HTMLInputElement>('#threshold-ceiling')!;
   const nudgeStepsEl = el.querySelector<HTMLInputElement>('#threshold-nudge-steps')!;
+  const lockEl = el.querySelector<HTMLInputElement>('#friction-intensity-lock')!;
+  const escalationIndicatorEl = el.querySelector<HTMLElement>('#friction-escalation-indicator')!;
 
   let currentSettings: UserSettings = { ...DEFAULT_SETTINGS };
 
@@ -47,6 +50,12 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
       callbacks.onIntensityChange(val);
       renderSegmented(intensityEl, val);
     });
+  });
+
+  lockEl.addEventListener('change', () => {
+    setPendingField('intensityLocked', lockEl.checked);
+    const statsLock = document.querySelector<HTMLInputElement>('#stats-intensity-lock');
+    if (statsLock) statsLock.checked = lockEl.checked;
   });
 
   // Delay timer toggle
@@ -86,6 +95,25 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
   ceilingEl.addEventListener('input', updateThresholds);
   nudgeStepsEl.addEventListener('input', updateThresholds);
 
+  function showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void {
+    const isEscalated = base !== effective;
+    escalationIndicatorEl.hidden = !isEscalated;
+    if (isEscalated) {
+      const textEl = escalationIndicatorEl.querySelector('.escalation-text')!;
+      textEl.textContent = `↑ Auto-escalated from ${base.charAt(0).toUpperCase() + base.slice(1)}`;
+      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+        btn.classList.remove('escalated', 'base-indicator');
+        btn.classList.toggle('active', btn.dataset.value === effective);
+        if (btn.dataset.value === base) btn.classList.add('base-indicator');
+        if (btn.dataset.value === effective) btn.classList.add('escalated');
+      });
+    } else {
+      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+        btn.classList.remove('escalated', 'base-indicator');
+      });
+    }
+  }
+
   function render(settings: UserSettings): void {
     currentSettings = settings;
     nudgeStepsEl.max = String(settings.comparisonItems.length);
@@ -100,7 +128,8 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
     floorEl.value = String(settings.frictionThresholds.thresholdFloor);
     ceilingEl.value = String(settings.frictionThresholds.thresholdCeiling);
     nudgeStepsEl.value = String(settings.frictionThresholds.softNudgeSteps);
+    lockEl.checked = settings.intensityLocked ?? false;
   }
 
-  return { render };
+  return { render, showEscalation };
 }

--- a/src/popup/sections/limits.ts
+++ b/src/popup/sections/limits.ts
@@ -8,7 +8,11 @@ export interface LimitsController {
   refreshTracker(): Promise<void>;
 }
 
-export function initLimits(el: HTMLElement): LimitsController {
+export interface LimitsCallbacks {
+  onCapChange?: () => void;
+}
+
+export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): LimitsController {
   const dailyCapEnabledEl = el.querySelector<HTMLInputElement>('#daily-cap-enabled')!;
   const dailyCapAmountEl = el.querySelector<HTMLInputElement>('#daily-cap-amount')!;
   const cooldownEnabledEl = el.querySelector<HTMLInputElement>('#cooldown-enabled')!;
@@ -35,12 +39,14 @@ export function initLimits(el: HTMLElement): LimitsController {
     const enabled = dailyCapEnabledEl.checked;
     dailyCapAmountEl.hidden = !enabled;
     setPendingField('dailyCap', { ...getPending().dailyCap, enabled });
+    callbacks.onCapChange?.();
   });
   dailyCapAmountEl.addEventListener('input', () => {
     setPendingField('dailyCap', {
       ...getPending().dailyCap,
       amount: parseFloat(dailyCapAmountEl.value) || 0,
     });
+    callbacks.onCapChange?.();
   });
 
   // Weekly cap
@@ -49,12 +55,14 @@ export function initLimits(el: HTMLElement): LimitsController {
     weeklyCapAmountEl.hidden = !enabled;
     weeklyResetDayRowEl.hidden = !enabled;
     setPendingField('weeklyCap', { ...getPending().weeklyCap, enabled });
+    callbacks.onCapChange?.();
   });
   weeklyCapAmountEl.addEventListener('input', () => {
     setPendingField('weeklyCap', {
       ...getPending().weeklyCap,
       amount: parseFloat(weeklyCapAmountEl.value) || 0,
     });
+    callbacks.onCapChange?.();
   });
 
   // Weekly reset day
@@ -73,12 +81,14 @@ export function initLimits(el: HTMLElement): LimitsController {
     const enabled = monthlyCapEnabledEl.checked;
     monthlyCapAmountEl.hidden = !enabled;
     setPendingField('monthlyCap', { ...getPending().monthlyCap, enabled });
+    callbacks.onCapChange?.();
   });
   monthlyCapAmountEl.addEventListener('input', () => {
     setPendingField('monthlyCap', {
       ...getPending().monthlyCap,
       amount: parseFloat(monthlyCapAmountEl.value) || 0,
     });
+    callbacks.onCapChange?.();
   });
 
   // Cooldown

--- a/src/popup/sections/limits.ts
+++ b/src/popup/sections/limits.ts
@@ -21,6 +21,8 @@ export function initLimits(el: HTMLElement): LimitsController {
   const resetCancelBtnEl = el.querySelector<HTMLButtonElement>('#btn-reset-cancel')!;
   const weeklyCapEnabledEl = el.querySelector<HTMLInputElement>('#weekly-cap-enabled')!;
   const weeklyCapAmountEl = el.querySelector<HTMLInputElement>('#weekly-cap-amount')!;
+  const weeklyResetDayRowEl = el.querySelector<HTMLElement>('#weekly-reset-day-row')!;
+  const weeklyResetDayEl = el.querySelector<HTMLElement>('#weekly-reset-day')!;
   const monthlyCapEnabledEl = el.querySelector<HTMLInputElement>('#monthly-cap-enabled')!;
   const monthlyCapAmountEl = el.querySelector<HTMLInputElement>('#monthly-cap-amount')!;
   const trackerWeeklyEl = el.querySelector<HTMLElement>('#tracker-weekly')!;
@@ -45,12 +47,24 @@ export function initLimits(el: HTMLElement): LimitsController {
   weeklyCapEnabledEl.addEventListener('change', () => {
     const enabled = weeklyCapEnabledEl.checked;
     weeklyCapAmountEl.hidden = !enabled;
+    weeklyResetDayRowEl.hidden = !enabled;
     setPendingField('weeklyCap', { ...getPending().weeklyCap, enabled });
   });
   weeklyCapAmountEl.addEventListener('input', () => {
     setPendingField('weeklyCap', {
       ...getPending().weeklyCap,
       amount: parseFloat(weeklyCapAmountEl.value) || 0,
+    });
+  });
+
+  // Weekly reset day
+  weeklyResetDayEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const val = btn.dataset.value as 'monday' | 'sunday';
+      setPendingField('weeklyResetDay', val);
+      weeklyResetDayEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.value === val);
+      });
     });
   });
 
@@ -132,6 +146,10 @@ export function initLimits(el: HTMLElement): LimitsController {
     weeklyCapEnabledEl.checked = settings.weeklyCap.enabled;
     weeklyCapAmountEl.hidden = !settings.weeklyCap.enabled;
     weeklyCapAmountEl.value = String(settings.weeklyCap.amount);
+    weeklyResetDayRowEl.hidden = !settings.weeklyCap.enabled;
+    weeklyResetDayEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.value === settings.weeklyResetDay);
+    });
     monthlyCapEnabledEl.checked = settings.monthlyCap.enabled;
     monthlyCapAmountEl.hidden = !settings.monthlyCap.enabled;
     monthlyCapAmountEl.value = String(settings.monthlyCap.amount);

--- a/src/popup/sections/stats.ts
+++ b/src/popup/sections/stats.ts
@@ -6,6 +6,7 @@ const SETTINGS_KEY = 'hcSettings';
 
 export interface StatsCallbacks {
   onIntensityChange: (value: UserSettings['frictionIntensity']) => void;
+  onLockChange?: () => void;
 }
 
 export interface StatsController {
@@ -60,6 +61,7 @@ export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsCont
     setPendingField('intensityLocked', lockEl.checked);
     const frictionLock = document.querySelector<HTMLInputElement>('#friction-intensity-lock');
     if (frictionLock) frictionLock.checked = lockEl.checked;
+    callbacks.onLockChange?.();
   });
 
   // Wire override button (immediate save — bypasses pending state)

--- a/src/popup/sections/stats.ts
+++ b/src/popup/sections/stats.ts
@@ -1,5 +1,5 @@
 import { computePopupStats } from '../../shared/interceptLogger';
-import { UserSettings } from '../../shared/types';
+import { UserSettings, FrictionIntensity } from '../../shared/types';
 import { setPendingField } from '../pendingState';
 
 const SETTINGS_KEY = 'hcSettings';
@@ -11,6 +11,7 @@ export interface StatsCallbacks {
 export interface StatsController {
   render(settings: UserSettings): void;
   refreshStats(): Promise<void>;
+  showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void;
 }
 
 export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsController {
@@ -21,6 +22,8 @@ export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsCont
   const overrideStatusEl = el.querySelector<HTMLElement>('#override-status')!;
   const overrideBtnEl = el.querySelector<HTMLButtonElement>('#btn-override')!;
   const intensityEl = el.querySelector<HTMLElement>('#stats-intensity')!;
+  const lockEl = el.querySelector<HTMLInputElement>('#stats-intensity-lock')!;
+  const escalationIndicatorEl = el.querySelector<HTMLElement>('#stats-escalation-indicator')!;
   function renderSegmented(container: HTMLElement, value: string): void {
     container.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
       btn.classList.toggle('active', btn.dataset.value === value);
@@ -51,6 +54,12 @@ export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsCont
       callbacks.onIntensityChange(val);
       renderSegmented(intensityEl, val);
     });
+  });
+
+  lockEl.addEventListener('change', () => {
+    setPendingField('intensityLocked', lockEl.checked);
+    const frictionLock = document.querySelector<HTMLInputElement>('#friction-intensity-lock');
+    if (frictionLock) frictionLock.checked = lockEl.checked;
   });
 
   // Wire override button (immediate save — bypasses pending state)
@@ -85,10 +94,30 @@ export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsCont
       : '—';
   }
 
+  function showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void {
+    const isEscalated = base !== effective;
+    escalationIndicatorEl.hidden = !isEscalated;
+    if (isEscalated) {
+      const textEl = escalationIndicatorEl.querySelector('.escalation-text')!;
+      textEl.textContent = `↑ Auto-escalated from ${base.charAt(0).toUpperCase() + base.slice(1)}`;
+      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+        btn.classList.remove('escalated', 'base-indicator');
+        btn.classList.toggle('active', btn.dataset.value === effective);
+        if (btn.dataset.value === base) btn.classList.add('base-indicator');
+        if (btn.dataset.value === effective) btn.classList.add('escalated');
+      });
+    } else {
+      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+        btn.classList.remove('escalated', 'base-indicator');
+      });
+    }
+  }
+
   function render(settings: UserSettings): void {
     renderSegmented(intensityEl, settings.frictionIntensity);
     renderOverride(settings);
+    lockEl.checked = settings.intensityLocked ?? false;
   }
 
-  return { render, refreshStats };
+  return { render, refreshStats, showEscalation };
 }

--- a/src/popup/sections/stats.ts
+++ b/src/popup/sections/stats.ts
@@ -1,35 +1,20 @@
 import { computePopupStats } from '../../shared/interceptLogger';
-import { UserSettings, FrictionIntensity } from '../../shared/types';
-import { setPendingField } from '../pendingState';
+import { UserSettings } from '../../shared/types';
 
 const SETTINGS_KEY = 'hcSettings';
-
-export interface StatsCallbacks {
-  onIntensityChange: (value: UserSettings['frictionIntensity']) => void;
-  onLockChange?: () => void;
-}
 
 export interface StatsController {
   render(settings: UserSettings): void;
   refreshStats(): Promise<void>;
-  showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void;
 }
 
-export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsController {
+export function initStats(el: HTMLElement): StatsController {
   const savedEl = el.querySelector<HTMLElement>('#stat-saved')!;
   const blockedEl = el.querySelector<HTMLElement>('#stat-blocked')!;
   const rateEl = el.querySelector<HTMLElement>('#stat-rate')!;
   const stepEl = el.querySelector<HTMLElement>('#stat-step')!;
   const overrideStatusEl = el.querySelector<HTMLElement>('#override-status')!;
   const overrideBtnEl = el.querySelector<HTMLButtonElement>('#btn-override')!;
-  const intensityEl = el.querySelector<HTMLElement>('#stats-intensity')!;
-  const lockEl = el.querySelector<HTMLInputElement>('#stats-intensity-lock')!;
-  const escalationIndicatorEl = el.querySelector<HTMLElement>('#stats-escalation-indicator')!;
-  function renderSegmented(container: HTMLElement, value: string): void {
-    container.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
-      btn.classList.toggle('active', btn.dataset.value === value);
-    });
-  }
 
   function renderOverride(settings: Partial<UserSettings>): void {
     const override = settings.streamingOverride;
@@ -46,23 +31,6 @@ export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsCont
     }
     overrideBtnEl.textContent = isActive ? 'Cancel Override' : 'Stream Override (2 hr)';
   }
-
-  // Wire intensity segmented control
-  intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const val = btn.dataset.value as UserSettings['frictionIntensity'];
-      setPendingField('frictionIntensity', val);
-      callbacks.onIntensityChange(val);
-      renderSegmented(intensityEl, val);
-    });
-  });
-
-  lockEl.addEventListener('change', () => {
-    setPendingField('intensityLocked', lockEl.checked);
-    const frictionLock = document.querySelector<HTMLInputElement>('#friction-intensity-lock');
-    if (frictionLock) frictionLock.checked = lockEl.checked;
-    callbacks.onLockChange?.();
-  });
 
   // Wire override button (immediate save — bypasses pending state)
   overrideBtnEl.addEventListener('click', async () => {
@@ -96,30 +64,9 @@ export function initStats(el: HTMLElement, callbacks: StatsCallbacks): StatsCont
       : '—';
   }
 
-  function showEscalation(base: FrictionIntensity, effective: FrictionIntensity): void {
-    const isEscalated = base !== effective;
-    escalationIndicatorEl.hidden = !isEscalated;
-    if (isEscalated) {
-      const textEl = escalationIndicatorEl.querySelector('.escalation-text')!;
-      textEl.textContent = `↑ Auto-escalated from ${base.charAt(0).toUpperCase() + base.slice(1)}`;
-      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
-        btn.classList.remove('escalated', 'base-indicator');
-        btn.classList.toggle('active', btn.dataset.value === effective);
-        if (btn.dataset.value === base) btn.classList.add('base-indicator');
-        if (btn.dataset.value === effective) btn.classList.add('escalated');
-      });
-    } else {
-      intensityEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
-        btn.classList.remove('escalated', 'base-indicator');
-      });
-    }
-  }
-
   function render(settings: UserSettings): void {
-    renderSegmented(intensityEl, settings.frictionIntensity);
     renderOverride(settings);
-    lockEl.checked = settings.intensityLocked ?? false;
   }
 
-  return { render, refreshStats, showEscalation };
+  return { render, refreshStats };
 }

--- a/src/shared/escalation.ts
+++ b/src/shared/escalation.ts
@@ -1,0 +1,62 @@
+import { FrictionIntensity, UserSettings, SpendingTracker } from './types';
+
+/** Ordered intensity levels from lowest to highest */
+const INTENSITY_ORDER: FrictionIntensity[] = ['low', 'medium', 'high', 'extreme'];
+
+/**
+ * Compute the highest spending percentage across all active caps.
+ * Returns 0 when no caps are enabled.
+ */
+export function computeMaxCapPercent(settings: UserSettings, tracker: SpendingTracker): number {
+  const percentages: number[] = [];
+
+  if (settings.dailyCap.enabled && settings.dailyCap.amount > 0) {
+    percentages.push(Math.round(tracker.dailyTotal / settings.dailyCap.amount * 10000) / 100);
+  }
+  if (settings.weeklyCap.enabled && settings.weeklyCap.amount > 0) {
+    percentages.push(Math.round(tracker.weeklyTotal / settings.weeklyCap.amount * 10000) / 100);
+  }
+  if (settings.monthlyCap.enabled && settings.monthlyCap.amount > 0) {
+    percentages.push(Math.round(tracker.monthlyTotal / settings.monthlyCap.amount * 10000) / 100);
+  }
+
+  return percentages.length === 0 ? 0 : Math.max(...percentages);
+}
+
+/**
+ * Compute the effective friction intensity based on spending threshold escalation.
+ *
+ * Escalation tiers:
+ * - Under 60%: no change (base)
+ * - 60-79%: Medium
+ * - 80-99%: High
+ * - 100%+: Extreme
+ *
+ * Rules:
+ * - Only escalates UP from base, never down
+ * - Returns base immediately if locked
+ * - Returns base if maxPercent is 0 (no caps enabled)
+ */
+export function computeEscalatedIntensity(
+  base: FrictionIntensity,
+  maxPercent: number,
+  locked: boolean,
+): FrictionIntensity {
+  if (locked || maxPercent === 0) return base;
+
+  let tier: FrictionIntensity;
+  if (maxPercent >= 100) {
+    tier = 'extreme';
+  } else if (maxPercent >= 80) {
+    tier = 'high';
+  } else if (maxPercent >= 60) {
+    tier = 'medium';
+  } else {
+    return base; // Under 60% — no escalation
+  }
+
+  // Only escalate up: if base is already higher than tier, keep base
+  const baseIndex = INTENSITY_ORDER.indexOf(base);
+  const tierIndex = INTENSITY_ORDER.indexOf(tier);
+  return tierIndex > baseIndex ? tier : base;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -114,6 +114,8 @@ export interface UserSettings {
   toastDurationSeconds: number;
   whitelistedChannels: WhitelistEntry[];
   theme: ThemePreference;
+  weeklyResetDay: 'monday' | 'sunday';
+  intensityLocked: boolean;
   streamingOverride?: { expiresAt: number };
 }
 
@@ -178,7 +180,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
     thresholdCeiling: 25,
     softNudgeSteps: 1,
   },
-  frictionIntensity: 'medium',
+  frictionIntensity: 'low',
   delayTimer: {
     enabled: false,
     seconds: 10,
@@ -192,6 +194,8 @@ export const DEFAULT_SETTINGS: UserSettings = {
   toastDurationSeconds: 15,
   whitelistedChannels: [],
   theme: 'auto',
+  weeklyResetDay: 'monday',
+  intensityLocked: false,
 };
 
 /** Transient spending data — stored in chrome.storage.local */
@@ -202,7 +206,7 @@ export interface SpendingTracker {
   sessionTotal: number;
   sessionChannel: string;
   weeklyTotal: number;
-  weeklyStartDate: string;   // ISO date of the Monday that starts the current week (YYYY-MM-DD)
+  weeklyStartDate: string;   // ISO date of the day that starts the current week (Monday or Sunday, YYYY-MM-DD)
   monthlyTotal: number;
   monthlyMonth: string;      // YYYY-MM format
 }
@@ -311,6 +315,8 @@ export function migrateSettings(saved: Partial<UserSettings>): UserSettings {
       behavior: (e.behavior as string) === 'track-only' ? 'full' as WhitelistBehavior : e.behavior,
     })),
     theme: saved.theme ?? DEFAULT_SETTINGS.theme,
+    weeklyResetDay: saved.weeklyResetDay ?? DEFAULT_SETTINGS.weeklyResetDay,
+    intensityLocked: saved.intensityLocked ?? DEFAULT_SETTINGS.intensityLocked,
   };
 }
 

--- a/tests/popup/pendingState.test.ts
+++ b/tests/popup/pendingState.test.ts
@@ -15,7 +15,7 @@ describe('pendingState', () => {
   test('getPending returns a copy of initialized settings', () => {
     mod.initPending({ ...DEFAULT_SETTINGS });
     const p = mod.getPending();
-    expect(p.frictionIntensity).toBe('medium');
+    expect(p.frictionIntensity).toBe('low');
   });
 
   test('setPendingField updates the pending copy', () => {
@@ -35,7 +35,7 @@ describe('pendingState', () => {
     mod.initPending({ ...DEFAULT_SETTINGS });
     mod.setPendingField('frictionIntensity', 'extreme');
     mod.resetPending({ ...DEFAULT_SETTINGS });
-    expect(mod.getPending().frictionIntensity).toBe('medium');
+    expect(mod.getPending().frictionIntensity).toBe('low');
   });
 
   test('isDirty returns false when nothing changed', () => {

--- a/tests/shared/escalation.test.ts
+++ b/tests/shared/escalation.test.ts
@@ -1,0 +1,90 @@
+import { computeEscalatedIntensity, computeMaxCapPercent } from '../../src/shared/escalation';
+import { DEFAULT_SETTINGS, DEFAULT_SPENDING_TRACKER } from '../../src/shared/types';
+
+describe('computeMaxCapPercent', () => {
+  const baseSettings = { ...DEFAULT_SETTINGS };
+  const baseTracker = { ...DEFAULT_SPENDING_TRACKER };
+
+  test('returns 0 when no caps are enabled', () => {
+    expect(computeMaxCapPercent(baseSettings, baseTracker)).toBe(0);
+  });
+
+  test('returns daily cap percentage when only daily cap enabled', () => {
+    const settings = { ...baseSettings, dailyCap: { enabled: true, amount: 100 } };
+    const tracker = { ...baseTracker, dailyTotal: 60 };
+    expect(computeMaxCapPercent(settings, tracker)).toBe(60);
+  });
+
+  test('returns highest percentage across multiple caps', () => {
+    const settings = {
+      ...baseSettings,
+      dailyCap: { enabled: true, amount: 100 },
+      weeklyCap: { enabled: true, amount: 200 },
+      monthlyCap: { enabled: true, amount: 1000 },
+    };
+    const tracker = { ...baseTracker, dailyTotal: 30, weeklyTotal: 180, monthlyTotal: 100 };
+    expect(computeMaxCapPercent(settings, tracker)).toBe(90);
+  });
+
+  test('returns percentage above 100 when cap exceeded', () => {
+    const settings = { ...baseSettings, dailyCap: { enabled: true, amount: 50 } };
+    const tracker = { ...baseTracker, dailyTotal: 75 };
+    expect(computeMaxCapPercent(settings, tracker)).toBe(150);
+  });
+
+  test('ignores disabled caps', () => {
+    const settings = {
+      ...baseSettings,
+      dailyCap: { enabled: false, amount: 10 },
+      weeklyCap: { enabled: true, amount: 200 },
+    };
+    const tracker = { ...baseTracker, dailyTotal: 100, weeklyTotal: 50 };
+    expect(computeMaxCapPercent(settings, tracker)).toBe(25);
+  });
+});
+
+describe('computeEscalatedIntensity', () => {
+  test('returns base intensity when no caps enabled (maxPercent=0)', () => {
+    expect(computeEscalatedIntensity('low', 0, false)).toBe('low');
+  });
+
+  test('returns base intensity when under 60%', () => {
+    expect(computeEscalatedIntensity('low', 59, false)).toBe('low');
+  });
+
+  test('escalates to medium at 60%', () => {
+    expect(computeEscalatedIntensity('low', 60, false)).toBe('medium');
+  });
+
+  test('escalates to high at 80%', () => {
+    expect(computeEscalatedIntensity('low', 80, false)).toBe('high');
+  });
+
+  test('escalates to extreme at 100%', () => {
+    expect(computeEscalatedIntensity('low', 100, false)).toBe('extreme');
+  });
+
+  test('escalates to extreme above 100%', () => {
+    expect(computeEscalatedIntensity('low', 150, false)).toBe('extreme');
+  });
+
+  test('does not escalate below base intensity', () => {
+    expect(computeEscalatedIntensity('high', 65, false)).toBe('high');
+  });
+
+  test('does not escalate when locked', () => {
+    expect(computeEscalatedIntensity('low', 95, true)).toBe('low');
+  });
+
+  test('does not escalate when locked even at 100%+', () => {
+    expect(computeEscalatedIntensity('low', 150, true)).toBe('low');
+  });
+
+  test('medium base at 80% escalates to high', () => {
+    expect(computeEscalatedIntensity('medium', 80, false)).toBe('high');
+  });
+
+  test('medium base at 65% stays medium (already at that tier)', () => {
+    expect(computeEscalatedIntensity('medium', 65, false)).toBe('medium');
+  });
+});

--- a/tests/shared/types.test.ts
+++ b/tests/shared/types.test.ts
@@ -1,0 +1,37 @@
+import { migrateSettings, DEFAULT_SETTINGS, UserSettings } from '../../src/shared/types';
+
+describe('migrateSettings', () => {
+  test('adds weeklyResetDay with default monday for existing users', () => {
+    const saved: Partial<UserSettings> = { hourlyRate: 25 };
+    const result = migrateSettings(saved);
+    expect(result.weeklyResetDay).toBe('monday');
+  });
+
+  test('preserves existing weeklyResetDay value', () => {
+    const saved: Partial<UserSettings> = { weeklyResetDay: 'sunday' } as any;
+    const result = migrateSettings(saved);
+    expect(result.weeklyResetDay).toBe('sunday');
+  });
+
+  test('adds intensityLocked with default false for existing users', () => {
+    const saved: Partial<UserSettings> = { hourlyRate: 25 };
+    const result = migrateSettings(saved);
+    expect(result.intensityLocked).toBe(false);
+  });
+
+  test('preserves existing intensityLocked value', () => {
+    const saved: Partial<UserSettings> = { intensityLocked: true } as any;
+    const result = migrateSettings(saved);
+    expect(result.intensityLocked).toBe(true);
+  });
+
+  test('DEFAULT_SETTINGS has frictionIntensity set to low', () => {
+    expect(DEFAULT_SETTINGS.frictionIntensity).toBe('low');
+  });
+
+  test('does not overwrite existing frictionIntensity on migration', () => {
+    const saved: Partial<UserSettings> = { frictionIntensity: 'high' };
+    const result = migrateSettings(saved);
+    expect(result.frictionIntensity).toBe('high');
+  });
+});


### PR DESCRIPTION
## Summary

- **Toggle alignment** — widened label min-width to 140px for consistent vertical alignment across all toggle rows
- **Tour button relocation** — single "Replay Setup Tour" button below Credits section, removed duplicates from footer and Settings
- **Weekly reset day** — Mon/Sun preference in Limits section, parameterized `getCurrentWeekStart()`
- **History summary** — true-centered metric cards, color parity with popup stat tiles (spent=red, saved=green, cancel rate=amber, top step=purple), proceeded amounts shown in red in table
- **Dynamic intensity escalation** — new `src/shared/escalation.ts` module; intensity auto-ratchets based on spending cap thresholds (60%→Medium, 80%→High, 100%→Extreme); lock toggle + info tooltip in Friction section; live re-computation on settings change
- **Default intensity → Low** — complements the escalation system; wizard updated
- **Wizard UX overhaul** — title changed to "Hype Control Tutorial"; skip flow replaced with "Good with defaults?" → Yes/No confirmation; removed redundant "Customize in Settings" link; shortened inputs, enlarged calc link
- **Salary calculator in Friction section** — collapsible toggle, identical to wizard, with locale-aware formatting
- **Tooltips** — session total gets info tooltip; escalation info tooltip pops right to avoid cutoff
- **Intensity deduplication** — removed from Stats section, lives only in Friction
- **Theme flip fix** — wizard customize path saves settings before closing

## Test plan

- [ ] Verify toggle alignment across Friction, Limits, Channels sections
- [ ] Test weekly reset day toggle (Mon/Sun) appears when weekly cap enabled
- [ ] Verify escalation: enable a daily cap, set spending close to limit, confirm intensity escalates
- [ ] Test lock toggle prevents escalation
- [ ] Verify escalation tooltip displays on hover (pops right)
- [ ] Test "Good with defaults?" skip flow in wizard
- [ ] Test salary calculator in both wizard and Friction section
- [ ] Verify history summary metric colors match popup stat tiles
- [ ] Verify proceeded amounts show in red in history table
- [ ] Run `npx jest --verbose` — 49 tests passing

Generated with [Claude Code](https://claude.com/claude-code)