### PR TITLE
fix: spending history, logs copy, reset tracker UX (v0.4.26)

### DIFF
--- a/HC-Project-Document.md
+++ b/HC-Project-Document.md
@@ -1197,20 +1197,22 @@ This is simpler than the multi-step cooldown - it's a single timer that applies 
 
 ---
 
-## Add-on 2: Spending Tracker (History View)
+## Add-on 2: Spending Tracker (History View) — COMPLETE
 
-**Complexity:** ⭐⭐ Medium  
-**Estimated Time:** 1-1.5 hours  
-**Dependencies:** MVP Part 4b (Analytics)  
+**Complexity:** ⭐⭐ Medium
+**Estimated Time:** 1-1.5 hours
+**Dependencies:** MVP Part 4b (Analytics)
 **Goal:** Show detailed spending history in a dedicated page.
 
 ### Features
 
-- [ ] Full-page view of all tracked purchases
-- [ ] Filter by: date range, channel, outcome
-- [ ] Sort by: date, amount, channel
-- [ ] Show totals: spent, blocked, saved
+- [x] Full-page view of all tracked purchases
+- [x] Filter by: date range, channel, outcome
+- [x] Sort by: date, amount, channel
+- [x] Show totals: spent, blocked, saved
 - [ ] Exportable to CSV
+
+**Bug fix (v0.4.26):** Purchases that bypassed friction (cap-bypass, no-friction, whitelist-skip, whitelist-reduced) were not being recorded in spending history via `writeInterceptEvent()`. All bypass paths now correctly write intercept events so the history view is complete and accurate.
 
 ---
 
@@ -1539,6 +1541,11 @@ Seven UX issues addressed from Round 2 feedback:
 
 Enhancement 8: All 4 stat tiles (Saved, Blocked, Cancel Rate, Best Step) now show a ⓘ icon in the bottom-right corner. Hovering or focusing the tile reveals a tooltip explaining the stat. CSS-only implementation — no JS required.
 
+### v0.4.26 — Bypass Recording Fix & Logs Copy All (2026-03-19)
+
+1. **Spending history bypass-recording fix** — Purchases that bypassed friction (cap-bypass, no-friction, whitelist-skip, whitelist-reduced) were not calling `writeInterceptEvent()`, so they never appeared in spending history. All bypass paths now correctly record intercept events.
+2. **Logs — Copy All button** — Added a "Copy All" button to the logs page that copies all visible log entries to the clipboard for easy sharing and debugging.
+
 ## Links & Resources
 
 - **Chrome Extension Docs:** https://developer.chrome.com/docs/extensions/
@@ -1548,6 +1555,6 @@ Enhancement 8: All 4 stat tiles (Saved, Blocked, Cancel Rate, Best Step) now sho
 
 ---
 
-**Document Version:** 1.2
-**Last Updated:** 2026-03-13
+**Document Version:** 1.3
+**Last Updated:** 2026-03-19
 **Ready for:** Software Saturdays Stream Series

--- a/HypeControl-TODO.md
+++ b/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-03-16
-**Current Version:** 0.4.25
+**Updated:** 2026-03-19
+**Current Version:** 0.4.26
 **Based On:** MTS-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -324,4 +324,11 @@ All items in the input validation hardening pass are complete:
 
 ---
 
-_Last updated 2026-03-16 against the v0.4.25 codebase. Input validation hardening complete — defense-in-depth sanitizers on all storage read/write paths, XSS fix, detector hardening._
+## BUG FIX & LOGS ENHANCEMENT — v0.4.26 (2026-03-19)
+
+- [x] **Spending history bypass-recording fix** — Purchases that bypassed friction (cap-bypass, no-friction, whitelist-skip, whitelist-reduced) were not being recorded in spending history via `writeInterceptEvent()`. Now all bypass paths correctly write intercept events so spending history is complete.
+- [x] **Logs Copy All button** — Added a "Copy All" button to the logs page that copies all visible log entries to the clipboard.
+
+---
+
+_Last updated 2026-03-19 against the v0.4.26 codebase. Bypass-recording bug fix ensures all purchase paths write to spending history; Copy All button added to logs page._

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1920,7 +1920,15 @@ async function handleClick(event: MouseEvent): Promise<void> {
 
     if (whitelistEntry.behavior === 'skip') {
       log(`Purchase on whitelisted channel — silently logged (${attempt.rawPrice ?? 'price unknown'})`);
+      const priceWithTax = Math.round((attempt.priceValue ?? 0) * (1 + settings.taxRate / 100) * 100) / 100;
       await recordPurchase(attempt.priceValue, settings, tracker);
+      await writeInterceptEvent({
+        channel: attempt.channel,
+        purchaseType: attempt.type,
+        rawPrice: attempt.rawPrice,
+        priceWithTax,
+        outcome: 'proceeded',
+      });
       allowNextClick(actualButton);
       return;
     }
@@ -1928,7 +1936,15 @@ async function handleClick(event: MouseEvent): Promise<void> {
     if (whitelistEntry.behavior === 'reduced') {
       const priceDisplay = attempt.rawPrice || 'purchase';
       log(`Purchase on whitelisted channel — toast displayed (${priceDisplay})`);
+      const priceWithTax = Math.round((attempt.priceValue ?? 0) * (1 + settings.taxRate / 100) * 100) / 100;
       await recordPurchase(attempt.priceValue, settings, tracker);
+      await writeInterceptEvent({
+        channel: attempt.channel,
+        purchaseType: attempt.type,
+        rawPrice: attempt.rawPrice,
+        priceWithTax,
+        outcome: 'proceeded',
+      });
       showWhitelistReducedToast(attempt.channel, priceDisplay, settings.toastDurationSeconds * 1000);
       allowNextClick(actualButton);
       return;
@@ -1956,13 +1972,28 @@ async function handleClick(event: MouseEvent): Promise<void> {
     log(`Cap bypass — proceeding silently`);
     showBudgetToast(settings, tracker, priceWithTax, settings.toastDurationSeconds * 1000);
     await recordPurchase(attempt.priceValue, settings, tracker);
+    await writeInterceptEvent({
+      channel: attempt.channel,
+      purchaseType: attempt.type,
+      rawPrice: attempt.rawPrice,
+      priceWithTax,
+      outcome: 'proceeded',
+    });
     allowNextClick(actualButton);
     return;
   }
 
   // No friction: track silently and let through
   if (frictionLevel === 'none') {
+    const priceWithTax = Math.round((attempt.priceValue ?? 0) * (1 + settings.taxRate / 100) * 100) / 100;
     await recordPurchase(attempt.priceValue, settings, tracker);
+    await writeInterceptEvent({
+      channel: attempt.channel,
+      purchaseType: attempt.type,
+      rawPrice: attempt.rawPrice,
+      priceWithTax,
+      outcome: 'proceeded',
+    });
     allowNextClick(actualButton);
     return;
   }

--- a/src/logs/logs.html
+++ b/src/logs/logs.html
@@ -30,6 +30,7 @@
       </div>
 
       <div class="actions">
+        <button class="btn" id="btn-copy">Copy All</button>
         <button class="btn" id="btn-refresh">↻ Refresh</button>
         <button class="btn danger" id="btn-clear">Clear Log</button>
       </div>

--- a/src/logs/logs.ts
+++ b/src/logs/logs.ts
@@ -85,8 +85,29 @@ function setupTabs(): void {
   });
 }
 
+function formatLogsAsText(entries: LogEntry[]): string {
+  const reversed = [...entries].reverse();
+  return reversed.map(e => {
+    const parts = [e.timestamp, levelLabel(e.level), e.message];
+    if (e.data !== undefined) parts.push(JSON.stringify(e.data));
+    return parts.join('\t');
+  }).join('\n');
+}
+
 function setupControls(): void {
   document.getElementById('btn-refresh')?.addEventListener('click', loadAndRender);
+
+  document.getElementById('btn-copy')?.addEventListener('click', async () => {
+    const entries = activeTab === 'extension'
+      ? await getExtensionLogs()
+      : await getSettingsLogs();
+    const text = formatLogsAsText(entries);
+    await navigator.clipboard.writeText(text);
+    const btn = document.getElementById('btn-copy')!;
+    const original = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = original; }, 1500);
+  });
 
   document.getElementById('btn-clear')?.addEventListener('click', async () => {
     if (!confirm(`Clear the ${activeTab} log?`)) return;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1154,6 +1154,7 @@ function showTrackerStatus(message: string, type: 'success' | 'error'): void {
  * Reset the spending tracker stored in local storage
  */
 async function handleResetTracker(): Promise<void> {
+  if (!confirm('Reset all spending totals (daily, session, weekly, monthly) to $0?')) return;
   await chrome.storage.local.remove('hcSpending');
   showTrackerStatus('✅ Spending tracker reset', 'success');
   const dataEl = document.getElementById('tracker-data') as HTMLPreElement;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -524,10 +524,19 @@ body {
 /* ─── Confirm reset ──────────────────────────────────────── */
 .confirm-reset {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 6px;
   font-size: 11px;
   color: var(--text-secondary);
+}
+.reset-summary {
+  color: var(--danger);
+  font-weight: 500;
+  line-height: 1.4;
+}
+.reset-actions {
+  display: flex;
+  gap: 6px;
 }
 .tracker-value {
   font-size: 12px;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -306,13 +306,15 @@
             <span class="hc-label">Monthly total</span>
             <span class="tracker-value" id="tracker-monthly">—</span>
           </div>
-          <div class="hc-row">
+          <div class="hc-row reset-row">
             <button class="btn-danger btn-sm" id="btn-reset-tracker">Reset Tracker</button>
-            <span class="confirm-reset" id="confirm-reset" hidden>
-              Are you sure?
-              <button class="btn-danger btn-sm" id="btn-reset-confirm">Yes, reset</button>
-              <button class="btn-sm" id="btn-reset-cancel">Cancel</button>
-            </span>
+            <div class="confirm-reset" id="confirm-reset" hidden>
+              <p class="reset-summary" id="reset-summary"></p>
+              <div class="reset-actions">
+                <button class="btn-danger btn-sm" id="btn-reset-confirm">Wipe it</button>
+                <button class="btn-sm" id="btn-reset-cancel">Nevermind</button>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/src/popup/sections/limits.ts
+++ b/src/popup/sections/limits.ts
@@ -104,8 +104,29 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
     });
   });
 
-  // Reset tracker (inline confirmation)
-  resetBtnEl.addEventListener('click', () => {
+  // Reset tracker (inline confirmation with dynamic summary)
+  const resetSummaryEl = el.querySelector<HTMLElement>('#reset-summary')!;
+
+  resetBtnEl.addEventListener('click', async () => {
+    const result = await chrome.storage.local.get(TRACKER_KEY);
+    const tracker = result[TRACKER_KEY];
+    const parts: string[] = [];
+    const daily = tracker?.dailyTotal ?? 0;
+    const session = tracker?.sessionTotal ?? 0;
+    const weekly = tracker?.weeklyTotal ?? 0;
+    const monthly = tracker?.monthlyTotal ?? 0;
+
+    if (daily > 0) parts.push(`daily $${daily.toFixed(2)}`);
+    if (session > 0) parts.push(`session $${session.toFixed(2)}`);
+    if (weekly > 0) parts.push(`weekly $${weekly.toFixed(2)}`);
+    if (monthly > 0) parts.push(`monthly $${monthly.toFixed(2)}`);
+
+    if (parts.length === 0) {
+      resetSummaryEl.textContent = 'All totals are already $0. Reset anyway?';
+    } else {
+      resetSummaryEl.textContent = `This wipes ${parts.join(', ')} back to $0. Cooldown timer resets too.`;
+    }
+
     resetBtnEl.hidden = true;
     confirmResetEl.hidden = false;
   });


### PR DESCRIPTION
## Summary

- **Spending history missing entries:** Purchases that bypassed friction (cap-bypass, no-friction, whitelist-skip, whitelist-reduced) were tracked in daily/weekly/monthly totals but never written to `InterceptEvent` storage — so they never appeared in the spending history page. Added `writeInterceptEvent()` calls to all four silent-proceed paths.
- **Logs copy button:** Added "Copy All" button to the logs page toolbar. Formats all visible log entries as tab-delimited text and copies to clipboard with brief "Copied!" confirmation.
- **Reset tracker UX:** The "Are you sure?" confirmation now shows a dynamic summary of the actual amounts being wiped (e.g., "This wipes daily $21.45, weekly $21.45 back to $0. Cooldown timer resets too."). Buttons renamed to "Wipe it / Nevermind". Added `confirm()` guard to the options page reset handler as defense-in-depth.

## Test plan

- [ ] Make a purchase that stays under daily cap (cap-bypass path) — verify it appears in spending history
- [ ] Make a purchase below friction threshold floor (no-friction path) — verify it appears in spending history
- [ ] Open logs page — verify "Copy All" button appears and copies log text to clipboard
- [ ] Click "Reset Tracker" in popup — verify dynamic summary shows current totals before confirming
- [ ] Click "Nevermind" — verify reset is cancelled
- [ ] Click "Wipe it" — verify all totals reset to $0

Generated with [Claude Code](https://claude.com/claude-code)