### PR TITLE
fix: tracker reset fix and session removal

### DIFF
--- a/HypeControl-TODO.md
+++ b/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-03-19
-**Current Version:** 0.4.27
+**Updated:** 2026-03-20
+**Current Version:** 0.4.28
 **Based On:** MTS-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -343,4 +343,14 @@ All items in the input validation hardening pass are complete:
 
 ---
 
-_Last updated 2026-03-19 against the v0.4.27 codebase. Savings calendar feature complete with motivational messaging, keyboard navigation, and 90-day rolling window._
+## TRACKER RESET FIX & SESSION REMOVAL — v0.4.28 (2026-03-20)
+
+- [x] **Shared spendingTracker module** — Extracted `loadSpendingTracker()`, `saveSpendingTracker()`, `recordPurchase()`, and date helpers into `src/shared/spendingTracker.ts`. Both the popup and content script now use the same loader with automatic period reset checks.
+- [x] **Daily/weekly/monthly reset fix** — Reset logic (date comparison → zero out) now runs whenever the tracker is read, not just in the content script. Popup displays fresh totals even without navigating Twitch first.
+- [x] **Auto-save on reset** — `loadSpendingTracker()` now auto-saves to storage when any period reset occurs, so the reset persists immediately.
+- [x] **Session total removed** — `sessionTotal` and `sessionChannel` removed from `SpendingTracker` type, UI, overlay, and all code paths. Daily/weekly/monthly cover the useful ranges.
+- [x] **Shared SPENDING_KEY constant** — All files now import the storage key from the shared module instead of using raw strings.
+
+---
+
+_Last updated 2026-03-20 against the v0.4.28 codebase. Tracker reset fix and session removal complete._

--- a/docs/superpowers/plans/2026-03-20-tracker-reset-fix.md
+++ b/docs/superpowers/plans/2026-03-20-tracker-reset-fix.md
@@ -1,0 +1,578 @@
+# Tracker Reset Fix & Session Removal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix stale spending totals in the popup by extracting tracker load/save/reset logic into a shared module, and remove the obsolete `sessionTotal` metric.
+
+**Architecture:** Create `src/shared/spendingTracker.ts` as the single source of truth for all tracker reads/writes. Both the content script and popup import from it. The shared `loadSpendingTracker()` runs daily/weekly/monthly reset checks and auto-saves if any resets occurred. `sessionTotal` and `sessionChannel` are removed from the type system entirely.
+
+**Tech Stack:** TypeScript, Chrome Extension MV3, Jest (ts-jest)
+
+**Spec:** `docs/superpowers/specs/2026-03-20-tracker-reset-fix-design.md`
+
+**Important:** Do NOT bump versions. The orchestrator handles versioning at the end.
+
+---
+
+### Task 1: Remove session fields from types
+
+**Files:**
+- Modify: `src/shared/types.ts:202-224` (SpendingTracker interface and DEFAULT_SPENDING_TRACKER)
+- Modify: `src/shared/types.ts:494-525` (sanitizeTracker)
+- Test: `tests/shared/types.test.ts`
+
+- [ ] **Step 1: Write failing test — sanitizeTracker strips unknown session fields**
+
+Add to `tests/shared/types.test.ts`:
+
+```typescript
+import { sanitizeTracker, DEFAULT_SPENDING_TRACKER, SpendingTracker } from '../../src/shared/types';
+
+describe('sanitizeTracker', () => {
+  test('returns valid tracker with correct defaults', () => {
+    const result = sanitizeTracker({ ...DEFAULT_SPENDING_TRACKER });
+    expect(result.dailyTotal).toBe(0);
+    expect(result.weeklyTotal).toBe(0);
+    expect(result.monthlyTotal).toBe(0);
+    expect(result.lastProceedTimestamp).toBeNull();
+    expect(result).not.toHaveProperty('sessionTotal');
+    expect(result).not.toHaveProperty('sessionChannel');
+  });
+
+  test('strips legacy sessionTotal/sessionChannel from old storage', () => {
+    const oldData = {
+      ...DEFAULT_SPENDING_TRACKER,
+      sessionTotal: 42.50,
+      sessionChannel: 'xqc',
+    } as any;
+    const result = sanitizeTracker(oldData);
+    expect(result).not.toHaveProperty('sessionTotal');
+    expect(result).not.toHaveProperty('sessionChannel');
+  });
+
+  test('clamps negative totals to 0', () => {
+    const bad = { ...DEFAULT_SPENDING_TRACKER, dailyTotal: -5 } as any;
+    expect(sanitizeTracker(bad).dailyTotal).toBe(0);
+  });
+
+  test('rounds totals to 2 decimal places', () => {
+    const t = { ...DEFAULT_SPENDING_TRACKER, dailyTotal: 1.999 } as any;
+    expect(sanitizeTracker(t).dailyTotal).toBe(2.00);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest tests/shared/types.test.ts --verbose`
+Expected: FAIL — `sessionTotal` and `sessionChannel` still exist on the type and return object.
+
+- [ ] **Step 3: Remove session fields from SpendingTracker interface**
+
+In `src/shared/types.ts`, remove from the `SpendingTracker` interface (lines 206-207):
+```typescript
+// REMOVE these two lines:
+  sessionTotal: number;
+  sessionChannel: string;
+```
+
+- [ ] **Step 4: Remove session fields from DEFAULT_SPENDING_TRACKER**
+
+In `src/shared/types.ts`, remove from `DEFAULT_SPENDING_TRACKER` (lines 218-219):
+```typescript
+// REMOVE these two lines:
+  sessionTotal: 0,
+  sessionChannel: '',
+```
+
+- [ ] **Step 5: Remove session fields from sanitizeTracker return object**
+
+In `src/shared/types.ts` `sanitizeTracker()`, remove lines 518-519 from the return object:
+```typescript
+// REMOVE these two lines:
+    sessionTotal: sanitizeTotal(t.sessionTotal),
+    sessionChannel: typeof t.sessionChannel === 'string' ? t.sessionChannel : '',
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx jest tests/shared/types.test.ts --verbose`
+Expected: PASS — all tests green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shared/types.ts tests/shared/types.test.ts
+git commit -m "maint: remove sessionTotal/sessionChannel from SpendingTracker type"
+```
+
+---
+
+### Task 2: Create shared spendingTracker module
+
+**Files:**
+- Create: `src/shared/spendingTracker.ts`
+- Test: `tests/shared/spendingTracker.test.ts`
+
+- [ ] **Step 1: Write failing tests for the shared module**
+
+Create `tests/shared/spendingTracker.test.ts`:
+
+```typescript
+import {
+  formatLocalDate,
+  getCurrentWeekStart,
+  getCurrentMonth,
+} from '../../src/shared/spendingTracker';
+
+describe('formatLocalDate', () => {
+  test('formats date as YYYY-MM-DD', () => {
+    const d = new Date(2026, 2, 20); // March 20, 2026
+    expect(formatLocalDate(d)).toBe('2026-03-20');
+  });
+
+  test('zero-pads single-digit month and day', () => {
+    const d = new Date(2026, 0, 5); // Jan 5
+    expect(formatLocalDate(d)).toBe('2026-01-05');
+  });
+});
+
+describe('getCurrentWeekStart', () => {
+  test('returns Monday for monday reset on a Wednesday', () => {
+    const wed = new Date(2026, 2, 18); // Wed Mar 18
+    expect(getCurrentWeekStart(wed, 'monday')).toBe('2026-03-16');
+  });
+
+  test('returns Sunday for sunday reset on a Wednesday', () => {
+    const wed = new Date(2026, 2, 18); // Wed Mar 18
+    expect(getCurrentWeekStart(wed, 'sunday')).toBe('2026-03-15');
+  });
+
+  test('returns same day when date IS the reset day (Monday)', () => {
+    const mon = new Date(2026, 2, 16); // Mon Mar 16
+    expect(getCurrentWeekStart(mon, 'monday')).toBe('2026-03-16');
+  });
+
+  test('returns same day when date IS the reset day (Sunday)', () => {
+    const sun = new Date(2026, 2, 15); // Sun Mar 15
+    expect(getCurrentWeekStart(sun, 'sunday')).toBe('2026-03-15');
+  });
+});
+
+describe('getCurrentMonth', () => {
+  test('returns YYYY-MM format', () => {
+    const d = new Date(2026, 2, 20);
+    expect(getCurrentMonth(d)).toBe('2026-03');
+  });
+
+  test('zero-pads single-digit month', () => {
+    const d = new Date(2026, 0, 1);
+    expect(getCurrentMonth(d)).toBe('2026-01');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest tests/shared/spendingTracker.test.ts --verbose`
+Expected: FAIL — module does not exist yet.
+
+- [ ] **Step 3: Create the shared module**
+
+Create `src/shared/spendingTracker.ts` with the pure helper functions extracted from `src/content/interceptor.ts` lines 28, 37-69:
+
+```typescript
+import { UserSettings, SpendingTracker, DEFAULT_SPENDING_TRACKER, sanitizeTracker } from './types';
+import { log, debug } from './logger';
+
+export const SPENDING_KEY = 'hcSpending';
+
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function getCurrentWeekStart(date: Date = new Date(), resetDay: 'monday' | 'sunday' = 'monday'): string {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  if (resetDay === 'sunday') {
+    // Sunday = 0, so offset is just -dayOfWeek
+    d.setDate(d.getDate() - dayOfWeek);
+  } else {
+    // Monday start (ISO): Sunday needs -6, others need 1-dayOfWeek
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    d.setDate(d.getDate() + mondayOffset);
+  }
+  return formatLocalDate(d);
+}
+
+export function getCurrentMonth(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest tests/shared/spendingTracker.test.ts --verbose`
+Expected: PASS — all pure function tests green.
+
+- [ ] **Step 5: Add chrome-dependent functions to the shared module**
+
+Append to `src/shared/spendingTracker.ts` — these are the load/save/record functions extracted from `interceptor.ts` lines 83-142, with session logic removed and auto-save on reset added:
+
+```typescript
+export async function loadSpendingTracker(settings: UserSettings): Promise<SpendingTracker> {
+  try {
+    const result = await chrome.storage.local.get(SPENDING_KEY);
+    const tracker: SpendingTracker = sanitizeTracker(result[SPENDING_KEY] || { ...DEFAULT_SPENDING_TRACKER });
+
+    // Backfill new fields for existing installs
+    if (tracker.weeklyTotal === undefined) tracker.weeklyTotal = 0;
+    if (!tracker.weeklyStartDate) tracker.weeklyStartDate = '';
+    if (tracker.monthlyTotal === undefined) tracker.monthlyTotal = 0;
+    if (!tracker.monthlyMonth) tracker.monthlyMonth = '';
+
+    let dirty = false;
+
+    const today = formatLocalDate(new Date());
+    if (tracker.dailyDate !== today) {
+      tracker.dailyTotal = 0;
+      tracker.dailyDate = today;
+      dirty = true;
+    }
+
+    const currentWeekStart = getCurrentWeekStart(new Date(), settings.weeklyResetDay ?? 'monday');
+    if (tracker.weeklyStartDate !== currentWeekStart) {
+      tracker.weeklyTotal = 0;
+      tracker.weeklyStartDate = currentWeekStart;
+      dirty = true;
+    }
+
+    const currentMonth = getCurrentMonth();
+    if (tracker.monthlyMonth !== currentMonth) {
+      tracker.monthlyTotal = 0;
+      tracker.monthlyMonth = currentMonth;
+      dirty = true;
+    }
+
+    if (dirty) {
+      await saveSpendingTracker(tracker);
+    }
+
+    return tracker;
+  } catch (e) {
+    debug('Failed to load spending tracker:', e);
+    return { ...DEFAULT_SPENDING_TRACKER };
+  }
+}
+
+export async function saveSpendingTracker(tracker: SpendingTracker): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [SPENDING_KEY]: sanitizeTracker(tracker) });
+  } catch (e) {
+    debug('Failed to save spending tracker:', e);
+  }
+}
+
+export async function recordPurchase(
+  priceValue: number | null,
+  settings: UserSettings,
+  tracker: SpendingTracker,
+): Promise<void> {
+  if (priceValue && priceValue > 0) {
+    const priceWithTax = Math.round(priceValue * (1 + settings.taxRate / 100) * 100) / 100;
+    const before = tracker.dailyTotal;
+    tracker.dailyTotal = Math.round((tracker.dailyTotal + priceWithTax) * 100) / 100;
+    tracker.weeklyTotal = Math.round((tracker.weeklyTotal + priceWithTax) * 100) / 100;
+    tracker.monthlyTotal = Math.round((tracker.monthlyTotal + priceWithTax) * 100) / 100;
+    tracker.dailyDate = formatLocalDate(new Date());
+    log(`recordPurchase: +$${priceWithTax.toFixed(2)} (raw=$${priceValue.toFixed(2)}, tax=${settings.taxRate}%) — daily $${before.toFixed(2)} → $${tracker.dailyTotal.toFixed(2)}, weekly $${tracker.weeklyTotal.toFixed(2)}, monthly $${tracker.monthlyTotal.toFixed(2)}`);
+  }
+  tracker.lastProceedTimestamp = Date.now();
+  await saveSpendingTracker(tracker);
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/spendingTracker.ts tests/shared/spendingTracker.test.ts
+git commit -m "feat: create shared spendingTracker module with reset logic"
+```
+
+---
+
+### Task 3: Update interceptor to use shared module
+
+**Files:**
+- Modify: `src/content/interceptor.ts:28` (remove SPENDING_KEY)
+- Modify: `src/content/interceptor.ts:37-69` (remove helper functions)
+- Modify: `src/content/interceptor.ts:83-142` (remove loadSpendingTracker, saveSpendingTracker, recordPurchase)
+- Modify: `src/content/interceptor.ts:430-433,443` (remove sessionInfo overlay block)
+- Modify: `src/content/interceptor.ts:1910-1914` (remove channel-switch session reset)
+
+- [ ] **Step 1: Add import for shared module**
+
+At the top of `src/content/interceptor.ts`, add import (near other imports):
+
+```typescript
+import { loadSpendingTracker, saveSpendingTracker, recordPurchase, formatLocalDate, getCurrentWeekStart, getCurrentMonth, SPENDING_KEY } from '../shared/spendingTracker';
+```
+
+- [ ] **Step 2: Remove local SPENDING_KEY constant**
+
+Remove line 28: `const SPENDING_KEY = 'hcSpending';`
+
+- [ ] **Step 3: Remove local helper functions**
+
+Remove `formatLocalDate` (lines 37-42), `getCurrentWeekStart` (lines 48-60), `getCurrentMonth` (lines 65-69).
+
+- [ ] **Step 4: Remove local loadSpendingTracker, saveSpendingTracker, recordPurchase**
+
+Remove lines 83-142 (the `loadSpendingTracker`, `saveSpendingTracker`, and `recordPurchase` functions). These are now imported from the shared module.
+
+- [ ] **Step 5: Remove sessionInfo overlay block**
+
+Remove lines 430-433 (the `sessionInfo` variable and conditional) and the `${sessionInfo}` reference in the overlay template at line 443.
+
+- [ ] **Step 6: Remove channel-switch session reset block**
+
+Remove lines 1910-1914:
+```typescript
+// REMOVE:
+  if (tracker.sessionChannel !== attempt.channel) {
+    tracker.sessionTotal = 0;
+    tracker.sessionChannel = attempt.channel;
+  }
+```
+
+- [ ] **Step 7: Verify build compiles**
+
+Run: `npx webpack --mode production`
+Expected: Build succeeds with no TypeScript errors about missing session fields or duplicate identifiers. If build fails, do NOT retry — report the error.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "maint: interceptor uses shared spendingTracker module, session logic removed"
+```
+
+---
+
+### Task 4: Update popup to use shared loader and remove session UI
+
+**Files:**
+- Modify: `src/popup/popup.html:289-296` (remove session row)
+- Modify: `src/popup/sections/limits.ts:5,21-23,62,115-121,158-182` (use shared loader, remove session refs)
+- Modify: `src/popup/popup.ts:225-226` (use shared loader in updateEscalation)
+
+- [ ] **Step 1: Remove session total row from popup.html**
+
+Remove lines 289-296 from `src/popup/popup.html`:
+```html
+<!-- REMOVE this entire hc-row div: -->
+        <div class="hc-row">
+          <span class="hc-label">Session total
+            <span class="escalation-info" tabindex="0">ⓘ
+              <span class="info-tooltip-right" role="tooltip">Spending on the current channel this browsing session. Resets when you switch channels.</span>
+            </span>
+          </span>
+          <span class="tracker-value" id="tracker-session">—</span>
+        </div>
+```
+
+- [ ] **Step 2: Update limits.ts — imports and constant**
+
+In `src/popup/sections/limits.ts`:
+- Add import: `import { loadSpendingTracker, SPENDING_KEY } from '../../shared/spendingTracker';`
+- Remove line 5: `const TRACKER_KEY = 'hcSpending';`
+- Replace all remaining references to `TRACKER_KEY` with `SPENDING_KEY` (occurs at lines 112, 139, and 159 — the reset button handler, reset confirm handler, and refreshTracker)
+
+- [ ] **Step 3: Update limits.ts — remove session element references**
+
+Remove `trackerSessionEl` declaration (line 22):
+```typescript
+// REMOVE:
+  const trackerSessionEl = el.querySelector<HTMLElement>('#tracker-session')!;
+```
+
+- [ ] **Step 4: Update limits.ts — remove session from reset summary**
+
+In the reset button click handler (around lines 115-121), remove the session total from the summary:
+```typescript
+// REMOVE these lines:
+    const session = tracker?.sessionTotal ?? 0;
+    if (session > 0) parts.push(`session $${session.toFixed(2)}`);
+```
+
+- [ ] **Step 5: Update limits.ts — replace refreshTracker with shared loader**
+
+Replace the `refreshTracker()` function (lines 158-182) with:
+
+```typescript
+  async function refreshTracker(): Promise<void> {
+    const settingsResult = await chrome.storage.sync.get('hcSettings');
+    const userSettings = migrateSettings(settingsResult['hcSettings'] || {});
+    const tracker = await loadSpendingTracker(userSettings);
+
+    trackerDailyEl.textContent = `$${(tracker.dailyTotal ?? 0).toFixed(2)}`;
+
+    trackerWeeklyEl.textContent = `$${(tracker.weeklyTotal ?? 0).toFixed(2)}`;
+    trackerMonthlyEl.textContent = `$${(tracker.monthlyTotal ?? 0).toFixed(2)}`;
+
+    const weeklyEnabled = userSettings.weeklyCap?.enabled ?? false;
+    const monthlyEnabled = userSettings.monthlyCap?.enabled ?? false;
+    trackerWeeklyRowEl.hidden = !weeklyEnabled;
+    trackerMonthlyRowEl.hidden = !monthlyEnabled;
+  }
+```
+
+- [ ] **Step 6: Update popup.ts — use shared loader in updateEscalation**
+
+In `src/popup/popup.ts`, add import:
+```typescript
+import { loadSpendingTracker } from '../shared/spendingTracker';
+```
+
+Replace lines 225-226 in `updateEscalation()`:
+```typescript
+// BEFORE:
+      const trackerResult = await chrome.storage.local.get('hcSpending');
+      const tracker: SpendingTracker = { ...DEFAULT_SPENDING_TRACKER, ...trackerResult['hcSpending'] };
+
+// AFTER:
+      const settingsResult = await chrome.storage.sync.get('hcSettings');
+      const settings = migrateSettings(settingsResult['hcSettings'] || {});
+      const tracker = await loadSpendingTracker(settings);
+```
+
+Note: `migrateSettings` is already imported in popup.ts (line 3).
+
+- [ ] **Step 7: Clean up dead imports in popup.ts**
+
+After the change, `DEFAULT_SPENDING_TRACKER` is no longer used in `popup.ts`. Remove it from the import on line 3. Check if `SpendingTracker` is still needed (the `tracker` variable is now inferred from `loadSpendingTracker`'s return type) — if not, remove it too.
+
+- [ ] **Step 8: Verify build compiles**
+
+Run: `npx webpack --mode production`
+Expected: Build succeeds. If build fails, do NOT retry — report the error.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/popup/popup.html src/popup/sections/limits.ts src/popup/popup.ts
+git commit -m "fix: popup uses shared tracker loader, session total removed from UI"
+```
+
+---
+
+### Task 5: Update options page
+
+**Files:**
+- Modify: `src/options/options.ts:1157-1158`
+
+- [ ] **Step 1: Update reset confirmation text**
+
+In `src/options/options.ts` line 1157, change:
+```typescript
+// BEFORE:
+  if (!confirm('Reset all spending totals (daily, session, weekly, monthly) to $0?')) return;
+
+// AFTER:
+  if (!confirm('Reset all spending totals (daily, weekly, monthly) to $0?')) return;
+```
+
+- [ ] **Step 2: Import SPENDING_KEY and use it**
+
+Add import at top of `src/options/options.ts`:
+```typescript
+import { SPENDING_KEY } from '../shared/spendingTracker';
+```
+
+Replace the raw string on line 1158:
+```typescript
+// BEFORE:
+  await chrome.storage.local.remove('hcSpending');
+
+// AFTER:
+  await chrome.storage.local.remove(SPENDING_KEY);
+```
+
+Also update the debug display function (around line 1168):
+```typescript
+// BEFORE:
+  const result = await chrome.storage.local.get('hcSpending');
+
+// AFTER:
+  const result = await chrome.storage.local.get(SPENDING_KEY);
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `npx webpack --mode production`
+Expected: Build succeeds. If build fails, do NOT retry — report the error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/options/options.ts
+git commit -m "maint: remove session from options reset text, use shared SPENDING_KEY"
+```
+
+---
+
+### Task 6: Run all tests and final build
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npx jest --verbose`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run production build**
+
+Run: `npx webpack --mode production`
+Expected: Clean build, no errors.
+
+- [ ] **Step 3: Commit any remaining fixes if needed**
+
+Only if tests or build revealed issues.
+
+---
+
+### Task 7: Version bump and project docs
+
+**Files:**
+- Modify: `manifest.json`
+- Modify: `package.json`
+- Modify: `MTS-TODO.md`
+- Modify: `MTS-Project-Document.md`
+
+- [ ] **Step 1: Bump version to 0.4.28**
+
+In `manifest.json`: update `"version"` to `"0.4.28"`
+In `package.json`: update `"version"` to `"0.4.28"`
+
+- [ ] **Step 2: Run final build**
+
+Run: `npx webpack --mode production`
+Expected: Clean build with version 0.4.28 baked in.
+
+- [ ] **Step 3: Update MTS-TODO.md**
+
+Mark the tracker reset fix as complete, update version and date.
+
+- [ ] **Step 4: Update MTS-Project-Document.md**
+
+Update the spending tracker section to reflect that session tracking has been removed and all totals now reset correctly from any entry point (popup or content script).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manifest.json package.json MTS-TODO.md MTS-Project-Document.md
+git commit -m "maint: bump version to 0.4.28 for tracker reset fix"
+```

--- a/docs/superpowers/specs/2026-03-20-tracker-reset-fix-design.md
+++ b/docs/superpowers/specs/2026-03-20-tracker-reset-fix-design.md
@@ -1,0 +1,133 @@
+# Tracker Reset Fix & Session Removal
+
+**Date:** 2026-03-20
+**Status:** Approved
+**Version target:** 0.4.28
+
+---
+
+## Problem
+
+Two bugs sharing one root cause:
+
+1. **Stale totals in popup.** The daily/weekly/monthly reset logic (date comparison → zero out) only runs inside `loadSpendingTracker()` in `interceptor.ts` (the content script). The popup's `limits.ts` reads raw `chrome.storage.local` and displays whatever's there — no freshness checks. If the user opens the popup after midnight without navigating a Twitch page first, they see yesterday's totals. The popup's `popup.ts` has the same issue — its `updateEscalation()` function reads raw storage for escalation indicator computation.
+
+2. **`sessionTotal` is a stale, confusing metric.** It resets only on channel switch, has no timeout, and persists indefinitely across browser restarts. Daily/weekly/monthly cover the useful ranges. Session is being removed entirely.
+
+**Root cause:** Reset logic is trapped in the content script. No shared "load tracker with freshness checks" function exists.
+
+---
+
+## Design
+
+### New file: `src/shared/spendingTracker.ts`
+
+Single source of truth for all spending tracker reads and writes. Exports:
+
+| Export | Purpose |
+|--------|---------|
+| `SPENDING_KEY` | Storage key constant (`'hcSpending'`) |
+| `loadSpendingTracker(settings)` | Read from `chrome.storage.local`, run daily/weekly/monthly reset checks, **auto-save back** if any resets occurred, return fresh data |
+| `saveSpendingTracker(tracker)` | Write sanitized tracker to storage |
+| `recordPurchase(price, settings, tracker)` | Accumulate totals (daily, weekly, monthly — **not** session), set `lastProceedTimestamp`, save |
+| `formatLocalDate(d)` | `YYYY-MM-DD` in local time |
+| `getCurrentWeekStart(date, resetDay)` | ISO date of current week's start day |
+| `getCurrentMonth(date)` | `YYYY-MM` format |
+
+Functions moved from `interceptor.ts` with two behavioral changes:
+1. `sessionTotal`/`sessionChannel` accumulation and reset logic removed from all functions
+2. `loadSpendingTracker` now **auto-saves** if any period reset occurred (current interceptor version returns the reset tracker in memory but relies on the caller to save — the popup never did, which is why resets didn't persist)
+
+### Type changes: `src/shared/types.ts`
+
+Remove from `SpendingTracker` interface:
+- `sessionTotal: number`
+- `sessionChannel: string`
+
+Remove from `DEFAULT_SPENDING_TRACKER`:
+- `sessionTotal: 0`
+- `sessionChannel: ''`
+
+Update `sanitizeTracker()`: no explicit stripping needed — `sanitizeTracker()` already constructs a fresh object by picking known fields. Once the fields are removed from the interface, old storage values are implicitly dropped on first sanitized load.
+
+### Content script: `src/content/interceptor.ts`
+
+- Remove local definitions: `loadSpendingTracker`, `saveSpendingTracker`, `recordPurchase`, `formatLocalDate`, `getCurrentWeekStart`, `getCurrentMonth`, `SPENDING_KEY`
+- Import all from `../../shared/spendingTracker`
+- Remove the channel-switch session reset block (`if (tracker.sessionChannel !== attempt.channel)`)
+- Remove the `sessionInfo` overlay rendering block (lines 430–433) and its reference in the overlay template (line 443) — this showed "Session total: $X.XX" in the friction overlay
+
+### Popup: `src/popup/sections/limits.ts`
+
+- Import `loadSpendingTracker` and `SPENDING_KEY` from `../../shared/spendingTracker`
+- Remove local `TRACKER_KEY` constant
+- Replace `refreshTracker()` implementation: fetch settings from `chrome.storage.sync`, then call shared `loadSpendingTracker(settings)` instead of raw `chrome.storage.local.get()`. This ensures reset checks run every time the popup opens.
+- Remove all references to `trackerSessionEl` / `tracker-session`
+- Remove `session` from reset confirmation summary text (lines 115–121 currently include `tracker?.sessionTotal` in the summary)
+- Reset button still writes `DEFAULT_SPENDING_TRACKER` to storage
+
+### Popup: `src/popup/popup.ts`
+
+- Import `loadSpendingTracker` and `SPENDING_KEY` from shared module
+- Replace raw `chrome.storage.local.get('hcSpending')` in `updateEscalation()` (line 225–226) with shared `loadSpendingTracker(settings)` so escalation indicators use fresh, reset-checked data
+
+### Popup HTML: `src/popup/popup.html`
+
+Remove the session total row (lines 289–296):
+```html
+<!-- REMOVE -->
+<div class="hc-row">
+  <span class="hc-label">Session total
+    <span class="escalation-info" tabindex="0">ⓘ
+      <span class="info-tooltip-right" role="tooltip">...</span>
+    </span>
+  </span>
+  <span class="tracker-value" id="tracker-session">—</span>
+</div>
+```
+
+### Options page: `src/options/options.ts`
+
+- Update reset confirmation text (line 1157): change `'Reset all spending totals (daily, session, weekly, monthly) to $0?'` to `'Reset all spending totals (daily, weekly, monthly) to $0?'`
+- Import `SPENDING_KEY` from shared module instead of using raw `'hcSpending'` string
+
+---
+
+## Files changed
+
+| File | Action |
+|------|--------|
+| `src/shared/spendingTracker.ts` | **New** — shared tracker load/save/record module |
+| `src/shared/types.ts` | Remove session fields from interface, default, and sanitizer |
+| `src/content/interceptor.ts` | Remove local tracker functions, import shared, remove session reset block, remove overlay session display |
+| `src/popup/sections/limits.ts` | Use shared loader, remove session display, remove session from reset summary |
+| `src/popup/popup.ts` | Use shared loader in `updateEscalation()` |
+| `src/popup/popup.html` | Remove session total row |
+| `src/options/options.ts` | Remove "session" from reset prompt, use shared `SPENDING_KEY` |
+| `manifest.json` | Version bump to 0.4.28 |
+| `package.json` | Version bump to 0.4.28 |
+
+---
+
+## What stays the same
+
+- `writeInterceptEvent()` and intercept logging pipeline (already in `src/shared/interceptLogger.ts`)
+- Calendar, stats, history views — they read intercept events, not `SpendingTracker`
+- All friction overlay logic (except session display removal)
+- Reset button behavior (writes `DEFAULT_SPENDING_TRACKER` to storage)
+
+---
+
+## Testing
+
+1. Set a daily total by proceeding through a purchase intercept
+2. Advance system clock past midnight (or wait)
+3. Open popup without navigating Twitch — daily total should show $0.00
+4. Confirm weekly reset works at week boundary (test both Monday and Sunday reset day configs)
+5. Confirm monthly reset works at month boundary
+6. Confirm session total row is gone from the popup
+7. Confirm session total is gone from the friction overlay
+8. Confirm reset button still zeros all totals and confirmation text says "daily, weekly, monthly" (no session)
+9. Confirm purchases still accumulate daily/weekly/monthly correctly
+10. Confirm escalation indicator in popup uses fresh (reset-checked) tracker data
+11. Build succeeds with no TypeScript errors referencing removed session fields

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "Chrome extension that creates intentional friction before Twitch spending",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -6,7 +6,7 @@
 
 import {
   PurchaseAttempt, OverlayDecision, OverlayCallback, UserSettings, DEFAULT_SETTINGS,
-  FrictionLevel, SpendingTracker, DEFAULT_SPENDING_TRACKER, ComparisonItem, migrateSettings, sanitizeSettings, sanitizeTracker,
+  FrictionLevel, SpendingTracker, DEFAULT_SPENDING_TRACKER, ComparisonItem, migrateSettings, sanitizeSettings,
   WhitelistEntry, WhitelistBehavior,
 } from '../shared/types';
 import { isPurchaseButton, createPurchaseAttempt, getCurrentChannel } from './detector';
@@ -15,6 +15,7 @@ import { applyThemeToOverlay } from './themeManager';
 import { log, debug } from '../shared/logger';
 import { writeInterceptEvent } from '../shared/interceptLogger';
 import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
+import { loadSpendingTracker, recordPurchase } from '../shared/spendingTracker';
 
 /** Result returned by runFrictionFlow */
 interface FrictionResult {
@@ -25,48 +26,6 @@ interface FrictionResult {
 
 /** Storage keys */
 const SETTINGS_KEY = 'hcSettings';
-const SPENDING_KEY = 'hcSpending';
-
-// ── Date Helpers ─────────────────────────────────────────────────────────
-
-/**
- * Format a local Date as YYYY-MM-DD without UTC conversion.
- * Using toISOString() would shift dates for users in non-UTC timezones
- * (e.g., 11:30 PM EDT March 31 → April 1 in UTC).
- */
-function formatLocalDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
-/**
- * Get the start of the current week as YYYY-MM-DD.
- * Supports Monday-start (ISO default) or Sunday-start weeks.
- */
-function getCurrentWeekStart(date: Date = new Date(), resetDay: 'monday' | 'sunday' = 'monday'): string {
-  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
-  if (resetDay === 'sunday') {
-    // Sunday = 0, so offset is just -dayOfWeek
-    d.setDate(d.getDate() - dayOfWeek);
-  } else {
-    // Monday start (ISO): Sunday needs -6, others need 1-dayOfWeek
-    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-    d.setDate(d.getDate() + mondayOffset);
-  }
-  return formatLocalDate(d);
-}
-
-/**
- * Get the current month as YYYY-MM string using local time.
- */
-function getCurrentMonth(date: Date = new Date()): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  return `${y}-${m}`;
-}
 
 // ── Settings & Tracker ──────────────────────────────────────────────────
 
@@ -78,67 +37,6 @@ async function loadSettings(): Promise<UserSettings> {
     debug('Failed to load settings, using defaults:', e);
     return { ...DEFAULT_SETTINGS };
   }
-}
-
-async function loadSpendingTracker(settings: UserSettings): Promise<SpendingTracker> {
-  try {
-    const result = await chrome.storage.local.get(SPENDING_KEY);
-    const tracker: SpendingTracker = sanitizeTracker(result[SPENDING_KEY] || { ...DEFAULT_SPENDING_TRACKER });
-
-    // Backfill new fields for existing installs
-    if (tracker.weeklyTotal === undefined) tracker.weeklyTotal = 0;
-    if (!tracker.weeklyStartDate) tracker.weeklyStartDate = '';
-    if (tracker.monthlyTotal === undefined) tracker.monthlyTotal = 0;
-    if (!tracker.monthlyMonth) tracker.monthlyMonth = '';
-
-    const today = formatLocalDate(new Date());
-    if (tracker.dailyDate !== today) {
-      tracker.dailyTotal = 0;
-      tracker.dailyDate = today;
-    }
-
-    // Weekly reset: calendar-aligned to Monday or Sunday per user preference
-    const currentWeekStart = getCurrentWeekStart(new Date(), settings.weeklyResetDay ?? 'monday');
-    if (tracker.weeklyStartDate !== currentWeekStart) {
-      tracker.weeklyTotal = 0;
-      tracker.weeklyStartDate = currentWeekStart;
-    }
-
-    // Monthly reset: calendar-aligned to 1st of month
-    const currentMonth = getCurrentMonth();
-    if (tracker.monthlyMonth !== currentMonth) {
-      tracker.monthlyTotal = 0;
-      tracker.monthlyMonth = currentMonth;
-    }
-
-    return tracker;
-  } catch (e) {
-    debug('Failed to load spending tracker:', e);
-    return { ...DEFAULT_SPENDING_TRACKER };
-  }
-}
-
-async function saveSpendingTracker(tracker: SpendingTracker): Promise<void> {
-  try {
-    await chrome.storage.local.set({ [SPENDING_KEY]: sanitizeTracker(tracker) });
-  } catch (e) {
-    debug('Failed to save spending tracker:', e);
-  }
-}
-
-async function recordPurchase(priceValue: number | null, settings: UserSettings, tracker: SpendingTracker): Promise<void> {
-  if (priceValue && priceValue > 0) {
-    const priceWithTax = Math.round(priceValue * (1 + settings.taxRate / 100) * 100) / 100;
-    const before = tracker.dailyTotal;
-    tracker.dailyTotal = Math.round((tracker.dailyTotal + priceWithTax) * 100) / 100;
-    tracker.sessionTotal = Math.round((tracker.sessionTotal + priceWithTax) * 100) / 100;
-    tracker.weeklyTotal = Math.round((tracker.weeklyTotal + priceWithTax) * 100) / 100;
-    tracker.monthlyTotal = Math.round((tracker.monthlyTotal + priceWithTax) * 100) / 100;
-    tracker.dailyDate = formatLocalDate(new Date());
-    log(`recordPurchase: +$${priceWithTax.toFixed(2)} (raw=$${priceValue.toFixed(2)}, tax=${settings.taxRate}%) — daily $${before.toFixed(2)} → $${tracker.dailyTotal.toFixed(2)}, weekly $${tracker.weeklyTotal.toFixed(2)}, monthly $${tracker.monthlyTotal.toFixed(2)}`);
-  }
-  tracker.lastProceedTimestamp = Date.now();
-  await saveSpendingTracker(tracker);
 }
 
 // ── Cooldown & Friction Level ───────────────────────────────────────────
@@ -427,11 +325,6 @@ function buildCostBreakdown(priceValue: number, settings: UserSettings, tracker:
   }
   const capSection = capBars ? `<div class="hc-cap-bars">${capBars}</div>` : '';
 
-  let sessionInfo = '';
-  if (tracker.sessionTotal > 0) {
-    sessionInfo = `<p class="hc-session-tracker">Session total: $${tracker.sessionTotal.toFixed(2)}</p>`;
-  }
-
   return `
     <div class="hc-cost-breakdown">
       <p class="hc-cost-line">
@@ -440,7 +333,6 @@ function buildCostBreakdown(priceValue: number, settings: UserSettings, tracker:
       </p>
       ${hoursLine}
       ${capSection}
-      ${sessionInfo}
     </div>
   `;
 }
@@ -1906,12 +1798,6 @@ async function handleClick(event: MouseEvent): Promise<void> {
   }
 
   const tracker = await loadSpendingTracker(settings);
-
-  // Update session channel
-  if (tracker.sessionChannel !== attempt.channel) {
-    tracker.sessionTotal = 0;
-    tracker.sessionChannel = attempt.channel;
-  }
 
   // Whitelist check
   const whitelistEntry = checkWhitelist(attempt.channel, settings);

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -8,6 +8,7 @@ import {
   WhitelistEntry, WhitelistBehavior, ThemePreference,
 } from '../shared/types';
 import { settingsLog, loadLogs, setVersion } from '../shared/logger';
+import { SPENDING_KEY } from '../shared/spendingTracker';
 
 /** Storage key for user settings */
 const SETTINGS_KEY = 'hcSettings';
@@ -1154,8 +1155,8 @@ function showTrackerStatus(message: string, type: 'success' | 'error'): void {
  * Reset the spending tracker stored in local storage
  */
 async function handleResetTracker(): Promise<void> {
-  if (!confirm('Reset all spending totals (daily, session, weekly, monthly) to $0?')) return;
-  await chrome.storage.local.remove('hcSpending');
+  if (!confirm('Reset all spending totals (daily, weekly, monthly) to $0?')) return;
+  await chrome.storage.local.remove(SPENDING_KEY);
   showTrackerStatus('✅ Spending tracker reset', 'success');
   const dataEl = document.getElementById('tracker-data') as HTMLPreElement;
   if (dataEl) dataEl.style.display = 'none';
@@ -1165,7 +1166,7 @@ async function handleResetTracker(): Promise<void> {
  * Display the raw hcSpending JSON for debugging
  */
 async function handleViewTracker(): Promise<void> {
-  const result = await chrome.storage.local.get('hcSpending');
+  const result = await chrome.storage.local.get(SPENDING_KEY);
   const dataEl = document.getElementById('tracker-data') as HTMLPreElement;
   if (!dataEl) return;
   if (dataEl.style.display === 'block') {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -287,14 +287,6 @@
         </div>
         <div class="hc-group">
           <div class="hc-row">
-            <span class="hc-label">Session total
-              <span class="escalation-info" tabindex="0">ⓘ
-                <span class="info-tooltip-right" role="tooltip">Spending on the current channel this browsing session. Resets when you switch channels.</span>
-              </span>
-            </span>
-            <span class="tracker-value" id="tracker-session">—</span>
-          </div>
-          <div class="hc-row">
             <span class="hc-label">Daily total</span>
             <span class="tracker-value" id="tracker-daily">—</span>
           </div>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,6 +1,7 @@
 // src/popup/popup.ts
 import './popup.css';
-import { migrateSettings, sanitizeSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS, UserSettings, SpendingTracker, DEFAULT_SPENDING_TRACKER } from '../shared/types';
+import { migrateSettings, sanitizeSettings, ThemePreference, ONBOARDING_KEYS, PRESET_COMPARISON_ITEMS, DEFAULT_SETTINGS, UserSettings } from '../shared/types';
+import { loadSpendingTracker } from '../shared/spendingTracker';
 import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
 import { initPending, getPending, setPendingField } from './pendingState';
 import { initScrollSpy, ScrollSpyItem } from './scrollSpy';
@@ -222,8 +223,9 @@ async function main(): Promise<void> {
     if (escalationUpdatePending) return;
     escalationUpdatePending = true;
     try {
-      const trackerResult = await chrome.storage.local.get('hcSpending');
-      const tracker: SpendingTracker = { ...DEFAULT_SPENDING_TRACKER, ...trackerResult['hcSpending'] };
+      const settingsResult = await chrome.storage.sync.get('hcSettings');
+      const settings = migrateSettings(settingsResult['hcSettings'] || {});
+      const tracker = await loadSpendingTracker(settings);
       const s = getPending();
       const maxPercent = computeMaxCapPercent(s, tracker);
       const effective = computeEscalatedIntensity(s.frictionIntensity, maxPercent, s.intensityLocked);

--- a/src/popup/sections/limits.ts
+++ b/src/popup/sections/limits.ts
@@ -1,8 +1,7 @@
 import { UserSettings, DEFAULT_SPENDING_TRACKER, migrateSettings } from '../../shared/types';
+import { loadSpendingTracker, SPENDING_KEY } from '../../shared/spendingTracker';
 import { initCalendar } from './calendar';
 import { getPending, setPendingField } from '../pendingState';
-
-const TRACKER_KEY = 'hcSpending'; // Matches interceptor.ts SPENDING_KEY
 
 export interface LimitsController {
   render(settings: UserSettings): void;
@@ -19,7 +18,6 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
   const cooldownEnabledEl = el.querySelector<HTMLInputElement>('#cooldown-enabled')!;
   const cooldownDurationEl = el.querySelector<HTMLSelectElement>('#cooldown-duration')!;
   const trackerDailyEl = el.querySelector<HTMLElement>('#tracker-daily')!;
-  const trackerSessionEl = el.querySelector<HTMLElement>('#tracker-session')!;
   const resetBtnEl = el.querySelector<HTMLButtonElement>('#btn-reset-tracker')!;
   const confirmResetEl = el.querySelector<HTMLElement>('#confirm-reset')!;
   const resetConfirmBtnEl = el.querySelector<HTMLButtonElement>('#btn-reset-confirm')!;
@@ -109,16 +107,14 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
   const resetSummaryEl = el.querySelector<HTMLElement>('#reset-summary')!;
 
   resetBtnEl.addEventListener('click', async () => {
-    const result = await chrome.storage.local.get(TRACKER_KEY);
-    const tracker = result[TRACKER_KEY];
+    const result = await chrome.storage.local.get(SPENDING_KEY);
+    const tracker = result[SPENDING_KEY];
     const parts: string[] = [];
     const daily = tracker?.dailyTotal ?? 0;
-    const session = tracker?.sessionTotal ?? 0;
     const weekly = tracker?.weeklyTotal ?? 0;
     const monthly = tracker?.monthlyTotal ?? 0;
 
     if (daily > 0) parts.push(`daily $${daily.toFixed(2)}`);
-    if (session > 0) parts.push(`session $${session.toFixed(2)}`);
     if (weekly > 0) parts.push(`weekly $${weekly.toFixed(2)}`);
     if (monthly > 0) parts.push(`monthly $${monthly.toFixed(2)}`);
 
@@ -136,7 +132,7 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
     resetBtnEl.hidden = false;
   });
   resetConfirmBtnEl.addEventListener('click', async () => {
-    await chrome.storage.local.set({ [TRACKER_KEY]: DEFAULT_SPENDING_TRACKER });
+    await chrome.storage.local.set({ [SPENDING_KEY]: DEFAULT_SPENDING_TRACKER });
     confirmResetEl.hidden = true;
     resetBtnEl.hidden = false;
     await refreshTracker();
@@ -156,29 +152,19 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
   });
 
   async function refreshTracker(): Promise<void> {
-    const result = await chrome.storage.local.get(TRACKER_KEY);
-    const tracker = result[TRACKER_KEY];
-    if (tracker) {
-      trackerDailyEl.textContent = `$${(tracker.dailyTotal ?? 0).toFixed(2)}`;
-      trackerSessionEl.textContent = `$${(tracker.sessionTotal ?? 0).toFixed(2)}`;
+    const settingsResult = await chrome.storage.sync.get('hcSettings');
+    const userSettings = migrateSettings(settingsResult['hcSettings'] || {});
+    const tracker = await loadSpendingTracker(userSettings);
 
-      // Show weekly/monthly tracker rows only when their cap is enabled
-      const settings = await chrome.storage.sync.get('hcSettings');
-      const userSettings = settings['hcSettings'];
+    trackerDailyEl.textContent = `$${(tracker.dailyTotal ?? 0).toFixed(2)}`;
 
-      if (tracker.weeklyTotal !== undefined) {
-        trackerWeeklyEl.textContent = `$${(tracker.weeklyTotal ?? 0).toFixed(2)}`;
-      }
-      if (tracker.monthlyTotal !== undefined) {
-        trackerMonthlyEl.textContent = `$${(tracker.monthlyTotal ?? 0).toFixed(2)}`;
-      }
+    trackerWeeklyEl.textContent = `$${(tracker.weeklyTotal ?? 0).toFixed(2)}`;
+    trackerMonthlyEl.textContent = `$${(tracker.monthlyTotal ?? 0).toFixed(2)}`;
 
-      // Show/hide rows based on whether caps are enabled
-      const weeklyEnabled = userSettings?.weeklyCap?.enabled ?? false;
-      const monthlyEnabled = userSettings?.monthlyCap?.enabled ?? false;
-      trackerWeeklyRowEl.hidden = !weeklyEnabled;
-      trackerMonthlyRowEl.hidden = !monthlyEnabled;
-    }
+    const weeklyEnabled = userSettings.weeklyCap?.enabled ?? false;
+    const monthlyEnabled = userSettings.monthlyCap?.enabled ?? false;
+    trackerWeeklyRowEl.hidden = !weeklyEnabled;
+    trackerMonthlyRowEl.hidden = !monthlyEnabled;
   }
 
   function render(settings: UserSettings): void {

--- a/src/shared/spendingTracker.ts
+++ b/src/shared/spendingTracker.ts
@@ -1,0 +1,102 @@
+import { UserSettings, SpendingTracker, DEFAULT_SPENDING_TRACKER, sanitizeTracker } from './types';
+import { log, debug } from './logger';
+
+export const SPENDING_KEY = 'hcSpending';
+
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function getCurrentWeekStart(date: Date = new Date(), resetDay: 'monday' | 'sunday' = 'monday'): string {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  if (resetDay === 'sunday') {
+    // Sunday = 0, so offset is just -dayOfWeek
+    d.setDate(d.getDate() - dayOfWeek);
+  } else {
+    // Monday start (ISO): Sunday needs -6, others need 1-dayOfWeek
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    d.setDate(d.getDate() + mondayOffset);
+  }
+  return formatLocalDate(d);
+}
+
+export function getCurrentMonth(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+export async function loadSpendingTracker(settings: UserSettings): Promise<SpendingTracker> {
+  try {
+    const result = await chrome.storage.local.get(SPENDING_KEY);
+    const tracker: SpendingTracker = sanitizeTracker(result[SPENDING_KEY] || { ...DEFAULT_SPENDING_TRACKER });
+
+    // Backfill new fields for existing installs
+    if (tracker.weeklyTotal === undefined) tracker.weeklyTotal = 0;
+    if (!tracker.weeklyStartDate) tracker.weeklyStartDate = '';
+    if (tracker.monthlyTotal === undefined) tracker.monthlyTotal = 0;
+    if (!tracker.monthlyMonth) tracker.monthlyMonth = '';
+
+    let dirty = false;
+
+    const today = formatLocalDate(new Date());
+    if (tracker.dailyDate !== today) {
+      tracker.dailyTotal = 0;
+      tracker.dailyDate = today;
+      dirty = true;
+    }
+
+    const currentWeekStart = getCurrentWeekStart(new Date(), settings.weeklyResetDay ?? 'monday');
+    if (tracker.weeklyStartDate !== currentWeekStart) {
+      tracker.weeklyTotal = 0;
+      tracker.weeklyStartDate = currentWeekStart;
+      dirty = true;
+    }
+
+    const currentMonth = getCurrentMonth();
+    if (tracker.monthlyMonth !== currentMonth) {
+      tracker.monthlyTotal = 0;
+      tracker.monthlyMonth = currentMonth;
+      dirty = true;
+    }
+
+    if (dirty) {
+      await saveSpendingTracker(tracker);
+    }
+
+    return tracker;
+  } catch (e) {
+    debug('Failed to load spending tracker:', e);
+    return { ...DEFAULT_SPENDING_TRACKER };
+  }
+}
+
+export async function saveSpendingTracker(tracker: SpendingTracker): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [SPENDING_KEY]: sanitizeTracker(tracker) });
+  } catch (e) {
+    debug('Failed to save spending tracker:', e);
+  }
+}
+
+export async function recordPurchase(
+  priceValue: number | null,
+  settings: UserSettings,
+  tracker: SpendingTracker,
+): Promise<void> {
+  if (priceValue && priceValue > 0) {
+    const priceWithTax = Math.round(priceValue * (1 + settings.taxRate / 100) * 100) / 100;
+    const before = tracker.dailyTotal;
+    tracker.dailyTotal = Math.round((tracker.dailyTotal + priceWithTax) * 100) / 100;
+    tracker.weeklyTotal = Math.round((tracker.weeklyTotal + priceWithTax) * 100) / 100;
+    tracker.monthlyTotal = Math.round((tracker.monthlyTotal + priceWithTax) * 100) / 100;
+    tracker.dailyDate = formatLocalDate(new Date());
+    log(`recordPurchase: +$${priceWithTax.toFixed(2)} (raw=$${priceValue.toFixed(2)}, tax=${settings.taxRate}%) — daily $${before.toFixed(2)} → $${tracker.dailyTotal.toFixed(2)}, weekly $${tracker.weeklyTotal.toFixed(2)}, monthly $${tracker.monthlyTotal.toFixed(2)}`);
+  }
+  tracker.lastProceedTimestamp = Date.now();
+  await saveSpendingTracker(tracker);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -203,8 +203,6 @@ export interface SpendingTracker {
   lastProceedTimestamp: number | null;
   dailyTotal: number;
   dailyDate: string;
-  sessionTotal: number;
-  sessionChannel: string;
   weeklyTotal: number;
   weeklyStartDate: string;   // ISO date of the day that starts the current week (Monday or Sunday, YYYY-MM-DD)
   monthlyTotal: number;
@@ -215,8 +213,6 @@ export const DEFAULT_SPENDING_TRACKER: SpendingTracker = {
   lastProceedTimestamp: null,
   dailyTotal: 0,
   dailyDate: '',
-  sessionTotal: 0,
-  sessionChannel: '',
   weeklyTotal: 0,
   weeklyStartDate: '',
   monthlyTotal: 0,
@@ -515,8 +511,6 @@ export function sanitizeTracker(t: SpendingTracker): SpendingTracker {
     lastProceedTimestamp,
     dailyTotal: sanitizeTotal(t.dailyTotal),
     dailyDate: validDate(t.dailyDate, /^\d{4}-\d{2}-\d{2}$/),
-    sessionTotal: sanitizeTotal(t.sessionTotal),
-    sessionChannel: typeof t.sessionChannel === 'string' ? t.sessionChannel : '',
     weeklyTotal: sanitizeTotal(t.weeklyTotal),
     weeklyStartDate: validDate(t.weeklyStartDate, /^\d{4}-\d{2}-\d{2}$/),
     monthlyTotal: sanitizeTotal(t.monthlyTotal),

--- a/tests/shared/spendingTracker.test.ts
+++ b/tests/shared/spendingTracker.test.ts
@@ -1,0 +1,51 @@
+import {
+  formatLocalDate,
+  getCurrentWeekStart,
+  getCurrentMonth,
+} from '../../src/shared/spendingTracker';
+
+describe('formatLocalDate', () => {
+  test('formats date as YYYY-MM-DD', () => {
+    const d = new Date(2026, 2, 20); // March 20, 2026
+    expect(formatLocalDate(d)).toBe('2026-03-20');
+  });
+
+  test('zero-pads single-digit month and day', () => {
+    const d = new Date(2026, 0, 5); // Jan 5
+    expect(formatLocalDate(d)).toBe('2026-01-05');
+  });
+});
+
+describe('getCurrentWeekStart', () => {
+  test('returns Monday for monday reset on a Wednesday', () => {
+    const wed = new Date(2026, 2, 18); // Wed Mar 18
+    expect(getCurrentWeekStart(wed, 'monday')).toBe('2026-03-16');
+  });
+
+  test('returns Sunday for sunday reset on a Wednesday', () => {
+    const wed = new Date(2026, 2, 18); // Wed Mar 18
+    expect(getCurrentWeekStart(wed, 'sunday')).toBe('2026-03-15');
+  });
+
+  test('returns same day when date IS the reset day (Monday)', () => {
+    const mon = new Date(2026, 2, 16); // Mon Mar 16
+    expect(getCurrentWeekStart(mon, 'monday')).toBe('2026-03-16');
+  });
+
+  test('returns same day when date IS the reset day (Sunday)', () => {
+    const sun = new Date(2026, 2, 15); // Sun Mar 15
+    expect(getCurrentWeekStart(sun, 'sunday')).toBe('2026-03-15');
+  });
+});
+
+describe('getCurrentMonth', () => {
+  test('returns YYYY-MM format', () => {
+    const d = new Date(2026, 2, 20);
+    expect(getCurrentMonth(d)).toBe('2026-03');
+  });
+
+  test('zero-pads single-digit month', () => {
+    const d = new Date(2026, 0, 1);
+    expect(getCurrentMonth(d)).toBe('2026-01');
+  });
+});

--- a/tests/shared/types.test.ts
+++ b/tests/shared/types.test.ts
@@ -1,4 +1,4 @@
-import { migrateSettings, DEFAULT_SETTINGS, UserSettings } from '../../src/shared/types';
+import { migrateSettings, DEFAULT_SETTINGS, UserSettings, sanitizeTracker, DEFAULT_SPENDING_TRACKER, SpendingTracker } from '../../src/shared/types';
 
 describe('migrateSettings', () => {
   test('adds weeklyResetDay with default monday for existing users', () => {
@@ -33,5 +33,38 @@ describe('migrateSettings', () => {
     const saved: Partial<UserSettings> = { frictionIntensity: 'high' };
     const result = migrateSettings(saved);
     expect(result.frictionIntensity).toBe('high');
+  });
+});
+
+describe('sanitizeTracker', () => {
+  test('returns valid tracker with correct defaults', () => {
+    const result = sanitizeTracker({ ...DEFAULT_SPENDING_TRACKER });
+    expect(result.dailyTotal).toBe(0);
+    expect(result.weeklyTotal).toBe(0);
+    expect(result.monthlyTotal).toBe(0);
+    expect(result.lastProceedTimestamp).toBeNull();
+    expect(result).not.toHaveProperty('sessionTotal');
+    expect(result).not.toHaveProperty('sessionChannel');
+  });
+
+  test('strips legacy sessionTotal/sessionChannel from old storage', () => {
+    const oldData = {
+      ...DEFAULT_SPENDING_TRACKER,
+      sessionTotal: 42.50,
+      sessionChannel: 'xqc',
+    } as any;
+    const result = sanitizeTracker(oldData);
+    expect(result).not.toHaveProperty('sessionTotal');
+    expect(result).not.toHaveProperty('sessionChannel');
+  });
+
+  test('clamps negative totals to 0', () => {
+    const bad = { ...DEFAULT_SPENDING_TRACKER, dailyTotal: -5 } as any;
+    expect(sanitizeTracker(bad).dailyTotal).toBe(0);
+  });
+
+  test('rounds totals to 2 decimal places', () => {
+    const t = { ...DEFAULT_SPENDING_TRACKER, dailyTotal: 1.999 } as any;
+    expect(sanitizeTracker(t).dailyTotal).toBe(2.00);
   });
 });


### PR DESCRIPTION
## Summary

- **Fixed stale spending totals in popup.** Daily/weekly/monthly reset logic only ran in the content script — the popup read raw storage and displayed yesterday's values. Now both use a shared `loadSpendingTracker()` that runs reset checks on every read and auto-saves when resets occur.
- **Removed `sessionTotal` and `sessionChannel` entirely.** The metric was stale and confusing — it only reset on channel switch, had no timeout, and persisted across browser restarts. Daily/weekly/monthly cover the useful ranges.
- **Created `src/shared/spendingTracker.ts`** as single source of truth for all tracker reads/writes. Extracted from `interceptor.ts` with no logic changes beyond the session removal and auto-save-on-reset addition.

## Changes

| File | Change |
|------|--------|
| `src/shared/spendingTracker.ts` | New shared module — load/save/record with reset logic |
| `src/shared/types.ts` | Removed `sessionTotal`/`sessionChannel` from interface, default, sanitizer |
| `src/content/interceptor.ts` | Uses shared module, session overlay display removed |
| `src/popup/sections/limits.ts` | Uses shared loader, session row and reset summary updated |
| `src/popup/popup.ts` | Uses shared loader in `updateEscalation()` |
| `src/popup/popup.html` | Session total row removed |
| `src/options/options.ts` | Session removed from reset prompt, uses shared `SPENDING_KEY` |

## Test plan

- [x] All 61 Jest tests pass (including 12 new tests for shared module and sanitizer)
- [x] Production build clean
- [ ] Open popup after midnight without navigating Twitch — daily total should show $0.00
- [ ] Verify weekly/monthly reset at their boundaries
- [ ] Confirm session total row is gone from popup
- [ ] Confirm reset button zeros all totals correctly
- [ ] Confirm purchases still accumulate daily/weekly/monthly