### PR TITLE
maint: rewrite README for Chrome Web Store launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ If applicable, add screenshots.
 **Environment**
 - OS: [e.g. Windows 11, macOS 15]
 - Browser: [e.g. Chrome 124, Firefox 128]
-- Extension version: [e.g. v0.4.14]
+- Extension version: [e.g. v1.0.0]
 
 **Additional context**
 Any other details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Ideas & Feature Discussions"
+    url: https://github.com/Ktulue/HypeControl/discussions/new?category=ideas
+    about: "Suggest ideas or discuss potential features"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Hype Control
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Before You Start
+
+**Please file an issue first.** Whether it's a bug report or a feature idea, open an issue so we can discuss the approach before you write code. This avoids wasted effort on both sides.
+
+- [Report a bug](https://github.com/Ktulue/HypeControl/issues/new?template=bug_report.md)
+- [Suggest a feature](https://github.com/Ktulue/HypeControl/discussions/new?category=ideas)
+
+## Development Setup
+
+**Prerequisites:** Node.js 18+
+
+```bash
+git clone https://github.com/Ktulue/HypeControl.git
+cd HypeControl
+npm install          # installs deps and builds via postinstall
+```
+
+Load the extension in Chrome:
+1. Open `chrome://extensions/`
+2. Enable "Developer mode"
+3. Click "Load unpacked" and select the `dist/` folder
+
+## Making Changes
+
+1. Fork the repo and create a branch: `feat/your-feature`, `fix/your-bug`, or `maint/your-cleanup`
+2. Make your changes
+3. Run `npm run build` to verify the build passes
+4. Open a PR against `main`
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [GNU GPL v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,128 +1,52 @@
 # Hype Control
 
-A Chrome extension that creates intentional friction before spending money on Twitch. Designed to promote mindful spending habits.
+*Friction between your wallet and the hype train.*
 
-## Overview
+You love your streamers. You've also tipped more in one stream than you spent on groceries that week. Hype Control is a lightweight Chrome extension that adds a friction layer between you and impulse purchases — spending caps, cooldown timers, and confirmation prompts that give your future self a fighting chance.
 
-Hype Control intercepts Twitch checkout flows (gifting subs, subscribing, Bits purchases) and presents a series of prompts that:
-
-- Shows the **real cost** including sales tax
-- Converts the cost to **hours of work** based on your take-home pay
-- Requires **multi-step confirmation** before proceeding
-- Compares the purchase to relatable real-world items (e.g., "That's 16 Costco hot dogs")
-- Optionally bypasses friction during **streaming mode** (so you can gift to your community while live)
+**[Install from the Chrome Web Store](TODO(store-url))**
 
 ## Features
 
-- 🛑 Intercepts gift subs, subs, and Bits purchases before they go through
-- 💰 Calculates true cost with configurable sales tax rate
-- ⏱️ Converts cost to work hours based on your take-home hourly rate
-- 🔢 Multi-step friction flow — each comparison item is its own confirmation step
-- 📊 Daily spending cap with silent bypass below budget and full friction when over
-- ⏳ Spending cooldown — enforces a waiting period after each purchase
-- 🎥 Streaming mode — detects when you're live on your own channel and bypasses friction automatically, with a configurable grace period after your stream ends
-- ⭐ Channel whitelist — skip, reduce, or apply full friction for channels you intentionally support
-- 📋 Activity log — full history of intercepts, decisions, and settings changes
-- 🔔 Toast notifications for silent bypass events (budget bypass, streaming mode, whitelisted channels)
+- **Real cost display** — Shows the actual price including sales tax, because Twitch won't.
+- **Work-hours conversion** — Translates every purchase into hours of your life. "That's 2.5 hours of work" hits different than "$50."
+- **Comparison items** — Puts your spending in terms you actually feel. That gift sub? That's 16 Costco hot dogs.
+- **Multi-step confirmation** — Confirmation steps scale with price. Small purchases get a nudge; big ones get a cooldown timer, type-to-confirm, and a math challenge. Earn it.
+- **Daily, weekly, and monthly spending caps** — Purchases under budget pass through silently; go over and the friction kicks in. Progress bars track where you stand.
+- **Spending cooldown timer** — Enforces a waiting period after each purchase. The hype fades fast when you have to sit with it.
+- **Activity log and savings calendar** — Full history of every intercept, every decision, and every dollar you didn't spend. The calendar turns your restraint into a streak.
+- **Streaming mode** — Auto-detects when you're live on your own channel and steps aside. Toast notifications let you know friction was bypassed, so you stay aware without the interruption.
+- **Channel whitelist** — Skip friction entirely, reduce it to a toast, or keep full friction per channel. Your regulars, your rules.
 
-## Installation
+## How It Works
 
-Available on the [Chrome Web Store](https://chromewebstore.google.com/detail/hype-control/).
+You click a purchase button on Twitch and Hype Control steps in before the transaction goes through. An overlay shows you the real cost with tax, how many hours of work it represents, and what else that money could buy. If the price is high enough, you'll need to clear multiple confirmation steps — cooldown timers, type-to-confirm, even a math problem. You either proceed deliberately, knowing exactly what you're spending, or you walk away. Either way, the decision is yours — Hype Control just makes sure it's actually a decision.
 
-For development:
-1. Clone this repository
-2. Run `npm install` (this also triggers the build automatically via `postinstall`)
-   - On Windows you can also just double-click `setup.bat`
-3. Open Chrome → `chrome://extensions/`
-4. Enable "Developer mode"
-5. Click "Load unpacked" and select the `dist/` folder
+## Privacy
 
-## Configuration
-
-Click the extension icon (or right-click → Options) to open the settings page:
-
-- **Hourly rate** — Your take-home pay, used to calculate "X hours of work"
-- **Sales tax rate** — Added to the displayed price to show true cost
-- **Comparison items** — Toggle preset items on/off; add your own with a custom name, emoji, and price
-- **Daily spending cap** — Set a daily limit; purchases under the cap pass through silently with a toast
-- **Spending cooldown** — Block further purchases for 5/10/30 minutes after each one
-- **Friction thresholds** — Set floor/ceiling dollar amounts to control nudge vs. full friction
-- **Streaming mode** — Enter your Twitch username; friction bypasses while you're live and during a configurable grace period after your stream ends
-- **Channel whitelist** — Add channels with Skip (no friction), Reduced (toast only), or Full (full friction with a note) behavior
-- **Toast duration** — How long silent-bypass notifications stay on screen
-
-## Tech Stack
-
-- TypeScript
-- Chrome Extension Manifest V3
-- Webpack
-- Live detection via DOM selectors (no Twitch API required)
-
-## Project Structure
-
-```
-HypeControl/
-├── manifest.json
-├── package.json
-├── assets/
-│   └── icons/
-└── src/
-    ├── background/
-    │   └── serviceWorker.ts
-    ├── content/
-    │   ├── index.ts           # Entry point, sets up observer + interceptor
-    │   ├── interceptor.ts     # Overlay flow, friction logic, click handling
-    │   ├── detector.ts        # Purchase button detection, price extraction
-    │   ├── streamingMode.ts   # Live detection, grace period, bypass logic
-    │   └── styles.css
-    ├── options/
-    │   ├── options.html
-    │   └── options.ts
-    ├── logs/
-    │   ├── logs.html
-    │   └── logs.ts
-    └── shared/
-        ├── types.ts           # Shared interfaces and defaults
-        └── logger.ts          # Event logging to chrome.storage.local
-```
+All data stays on your device. Nothing is collected, transmitted, or tracked — ever. Read the full [privacy policy](https://ktulue.github.io/HypeControl/privacy.html).
 
 ## Known Issues
 
 - **Bits Combo module** — The animated Bits Combo (timer/counter) that Twitch displays during cheering cannot currently be intercepted. Hype Control can intercept the "Get Bits" button in the top navigation bar, but the Combo module uses a non-standard rendering path that doesn't expose a clickable element Hype Control can hook.
-- **Emoji input (Windows)** — The Windows emoji picker (Win + .) allows inserting non-emoji characters (Latin symbols, special characters) into the emoji field. GIF selection is not supported. For best results, stick to standard emoji from the Smileys or Symbols categories.
-- **Emoji input (macOS)** — The macOS Character Viewer works as expected for standard emoji. GIF insertion is not supported.
 
 ## Contributing
 
-Contributions welcome! Please read the license terms below before contributing.
+Want to contribute, report a bug, or run it locally? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-This project is licensed under the **GNU General Public License v3.0** - see the [LICENSE](LICENSE) file for details.
-
-This means you are free to:
-- ✅ Use this software
-- ✅ Modify this software
-- ✅ Distribute this software
-
-Under the following conditions:
-- 📖 Source code must remain open
-- 📖 Derivative works must also be GPL v3
-- 📖 Changes must be documented
-
-You **cannot**:
-- ❌ Close-source this project or derivatives
-- ❌ Sell closed-source versions
+[GNU General Public License v3.0](LICENSE)
 
 ## Acknowledgments
 
 - **HolmsB** — For helping name the extension "Hype Control"
 - **Lanzirelli** — Logo & Icons design
 
-## Support
-
-☕ [Buy me a coffee on Ko-fi](https://ko-fi.com/ktulue)
-
 ---
 
-*Created by [Ktulue](https://github.com/Ktulue) | The Water Father 🌊*
+## Support
+
+☕ [Buy me a coffee on Ko-fi](http://ko-fi.com/ktulue)
+
+Created by Ktulue | The Water Father 🌊

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You click a purchase button on Twitch and Hype Control steps in before the trans
 
 ## Privacy
 
-All data stays on your device. Nothing is collected, transmitted, or tracked — ever. Read the full [privacy policy](https://ktulue.github.io/HypeControl/privacy.html).
+All data stays on your device. Nothing is collected, transmitted, or tracked — read the full [privacy policy](https://ktulue.github.io/HypeControl/privacy.html).
 
 ## Known Issues
 

--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,6 +1,6 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-03-20
+**Updated:** 2026-03-21
 **Current Version:** 0.4.28
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
@@ -222,6 +222,10 @@ The original design called for a guided overlay on the Twitch page highlighting 
 1. **Chrome Web Store Launch** — Store listing, privacy policy, screenshots, version 1.0.0 release
 2. **Firefox AMO Port** — Adapt extension for Firefox (manifest changes, `browser.*` API audit, AMO submission)
 
+### Recently Completed
+
+- [x] **README Rewrite (2026-03-21)** — Rewrote README.md from developer-focused internal docs to a user-first, brand-voice public page for the Chrome Web Store launch. No version bump (content-only change).
+
 ### Future Enhancements
 
 - Add-on 6 — Export Data (CSV/JSON)
@@ -295,4 +299,4 @@ Shared spendingTracker module, daily/weekly/monthly reset fix for popup, session
 
 ---
 
-_Last updated 2026-03-20 against the v0.4.28 codebase. Repository cleaned up for Chrome Web Store launch preparation._
+_Last updated 2026-03-21 against the v0.4.28 codebase. Repository cleaned up for Chrome Web Store launch preparation. README rewritten for public launch._

--- a/docs/dev/superpowers/plans/2026-03-21-readme-rewrite.md
+++ b/docs/dev/superpowers/plans/2026-03-21-readme-rewrite.md
@@ -1,0 +1,168 @@
+# README Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite README.md from developer-focused internal docs to a user-first, brand-voice public page for Chrome Web Store launch.
+
+**Architecture:** Single-file rewrite of `README.md`. No code changes, no build required. The new README follows the 10-section structure defined in the spec, with brand voice in sections 1–4 and professional tone in sections 5–10.
+
+**Tech Stack:** Markdown only. No version bump (content-only change). No build step.
+
+**Spec:** `docs/dev/superpowers/specs/2026-03-21-readme-rewrite-design.md`
+
+**Branch:** `maint/readme-rewrite` (already created, spec already committed)
+
+**IMPORTANT:** Do NOT bump versions. This is a content-only change.
+
+---
+
+### Task 1: Write the new README
+
+**Files:**
+- Modify: `README.md` (full rewrite)
+
+**Reference files (read for context, do not modify):**
+- `CLAUDE.md` — Design context section has brand personality, aesthetic direction, and design principles
+- `docs/dev/superpowers/specs/2026-03-21-readme-rewrite-design.md` — The approved spec
+- `CONTRIBUTING.md` — Already exists, linked from new README
+
+- [ ] **Step 1: Read the spec and current README**
+
+Read both files to understand the full structure and approved copy.
+
+- [ ] **Step 2: Write the complete new README.md**
+
+Replace the entire file with the new 10-section structure. Follow these rules exactly:
+
+**Section 1 — Title + Tagline + Hook (use verbatim from spec):**
+```markdown
+# Hype Control
+
+*Friction between your wallet and the hype train.*
+
+You love your streamers. You've also tipped more in one stream than you spent on groceries that week. Hype Control is a lightweight Chrome extension that adds a friction layer between you and impulse purchases — spending caps, cooldown timers, and confirmation prompts that give your future self a fighting chance.
+```
+
+**Section 2 — Install link (headingless, directly after hook):**
+```markdown
+**[Install from the Chrome Web Store](TODO(store-url))**
+```
+
+**Section 3 — Features:**
+- `## Features` heading
+- 9 bullet points as a flat list (no subgroup headings)
+- Brand voice tone — lead with mechanic, follow with personality
+- Cover these 9 mechanics in order:
+  1. Real cost display (price + sales tax)
+  2. Work-hours conversion
+  3. Comparison items
+  4. Multi-step confirmation scaling with price
+  5. Daily/weekly/monthly spending caps
+  6. Spending cooldown timer
+  7. Activity log + savings calendar
+  8. Streaming mode with toast notifications
+  9. Channel whitelist (skip/reduce/full)
+- Tone example from spec: "Daily spending cap — purchases under budget pass through silently; go over and the friction kicks in."
+- Read `CLAUDE.md` Design Context for voice guidance: "sharp, cheeky, honest" — the friend who grabs your wrist, not a lecture
+
+**Section 4 — How It Works:**
+- `## How It Works` heading
+- 3–5 sentences, user's perspective
+- Flow: click buy → overlay with real cost + work hours → comparison items → confirmation steps scale with price → proceed deliberately or walk away
+- Brand voice, no code, no technical details
+
+**Section 5 — Privacy:**
+- `## Privacy` heading
+- Two sentences: all data local, nothing collected/transmitted/tracked
+- Link to `https://ktulue.github.io/HypeControl/privacy.html`
+- Professional tone
+
+**Section 6 — Known Issues:**
+- `## Known Issues` heading
+- Bits Combo limitation only (copy from current README, keep as-is)
+- Do NOT include emoji picker issues
+
+**Section 7 — Contributing:**
+```markdown
+## Contributing
+
+Want to contribute, report a bug, or run it locally? See [CONTRIBUTING.md](CONTRIBUTING.md).
+```
+
+**Section 8 — License:**
+```markdown
+## License
+
+[GNU General Public License v3.0](LICENSE)
+```
+
+**Section 9 — Acknowledgments:**
+```markdown
+## Acknowledgments
+
+- **HolmsB** — For helping name the extension "Hype Control"
+- **Lanzirelli** — Logo & Icons design
+```
+
+**Section 10 — Support (canonical format from global CLAUDE.md):**
+```markdown
+---
+
+## Support
+
+☕ [Buy me a coffee on Ko-fi](http://ko-fi.com/ktulue)
+
+Created by Ktulue | The Water Father 🌊
+```
+
+- [ ] **Step 3: Verify the TODO marker is greppable**
+
+Run: `grep -n "TODO(store-url)" README.md`
+Expected: Exactly 1 match on the install link line.
+
+- [ ] **Step 4: Verify no removed sections remain**
+
+Run: `grep -n "Tech Stack\|Project Structure\|Configuration\|emoji picker\|Emoji input" README.md`
+Expected: No matches.
+
+- [ ] **Step 5: Verify Support section matches global template**
+
+Run: `grep -n "ko-fi.com/ktulue" README.md`
+Expected: Exactly 1 match.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md
+git commit -m "maint: rewrite README for Chrome Web Store launch
+
+Rewrites the README from developer-focused internal docs to a
+user-first public page with brand voice, streamlined feature list,
+and clean structure for the Chrome Web Store launch."
+```
+
+---
+
+### Task 2: Update post-work docs
+
+**Files:**
+- Modify: `docs/dev/HypeControl-TODO.md`
+- Modify: `docs/dev/HC-Project-Document.md` (only if README status is tracked there)
+
+- [ ] **Step 1: Update TODO.md**
+
+In `docs/dev/HypeControl-TODO.md`:
+- Under the "CURRENT ROADMAP" section, note that the README rewrite is complete
+- Update the `Updated` date in the header to `2026-03-21`
+- Update the footer timestamp
+
+- [ ] **Step 2: Check if HC-Project-Document.md references README**
+
+Read `docs/dev/HC-Project-Document.md` and search for "README". If the project doc tracks README status, update it. If not, no changes needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/HypeControl-TODO.md docs/dev/HC-Project-Document.md
+git commit -m "maint: update post-work docs for README rewrite"
+```

--- a/docs/dev/superpowers/specs/2026-03-20-github-infrastructure-design.md
+++ b/docs/dev/superpowers/specs/2026-03-20-github-infrastructure-design.md
@@ -1,0 +1,76 @@
+# GitHub Infrastructure — Design Spec
+
+**Date:** 2026-03-20
+**Status:** Approved
+**Branch:** `maint/github-setup`
+
+---
+
+## Goal
+
+Set up GitHub infrastructure for a professional public-facing Chrome extension: landing page and privacy policy for GitHub Pages, contributor guide, and issue template improvements.
+
+---
+
+## New Files
+
+### `CONTRIBUTING.md` (root)
+Minimal contributor guide (~20 lines):
+- Prerequisites: Node.js 18+
+- Build steps: `npm install` (triggers postinstall build), load `dist/` in Chrome
+- Branch naming: `feat/`, `fix/`, `maint/` prefixes
+- PR process: file an issue first, fork, branch, PR against main
+- Link to issue templates
+
+### `docs/index.html`
+Landing page served by GitHub Pages at `ktulue.github.io/HypeControl`.
+- Clean, professional, light/neutral design
+- Sections: hero with tagline, key features (3-4 bullets), screenshot placeholder, install CTA (placeholder Chrome Web Store URL until live), footer with links
+- Self-contained — inline CSS, no framework, no build step
+- Must work as a static HTML page served by GitHub Pages
+
+### `docs/privacy.html`
+Privacy policy served at `ktulue.github.io/HypeControl/privacy.html`.
+- What the extension does (brief)
+- What data is stored: all local via `chrome.storage.local` and `chrome.storage.sync`
+- What is NOT collected: no personal data, no analytics, no external transmission
+- Permissions used and why:
+  - `host_permissions` (`*://*.twitch.tv/*`) — content script injects friction overlays on Twitch pages
+  - `storage` — saves user settings and spending data locally
+- Contact: GitHub Issues link
+- Effective date
+- Self-contained HTML, same style as landing page for visual consistency
+
+### `.github/ISSUE_TEMPLATE/config.yml`
+Adds external links to the issue template chooser:
+```yaml
+blank_issues_enabled: false
+contact_links:
+  - name: "Ideas & Feature Discussions"
+    url: https://github.com/Ktulue/HypeControl/discussions/new?category=ideas
+    about: "Suggest ideas or discuss potential features"
+```
+
+## Modified Files
+
+### `.github/ISSUE_TEMPLATE/bug_report.md`
+Update version example from `v0.4.14` to `v1.0.0`.
+
+---
+
+## Manual Steps (post-merge, documented in PR description)
+
+These cannot be done via code — they require the GitHub web UI:
+
+1. **GitHub Pages:** Settings → Pages → Source: Deploy from branch `main`, folder `/docs` → Save
+2. **Repo topics:** Settings → About (gear icon) → Add topics: `chrome-extension`, `twitch`, `spending-tracker`, `impulse-control`, `browser-extension`
+3. **Social preview:** Settings → Social preview → Upload a 1280x640 image (can do later)
+
+---
+
+## What stays the same
+
+- All source code
+- Feature request template (already clean)
+- LICENSE, CLAUDE.md, README.md (README rewrite is workstream 4)
+- No version bump

--- a/docs/dev/superpowers/specs/2026-03-21-readme-rewrite-design.md
+++ b/docs/dev/superpowers/specs/2026-03-21-readme-rewrite-design.md
@@ -1,0 +1,181 @@
+# README Rewrite — Design Spec
+
+**Date:** 2026-03-21
+**Status:** Approved
+**Branch:** `maint/readme-rewrite`
+
+---
+
+## Goal
+
+Rewrite the README from a developer-focused internal doc to a user-first public-facing page for the Chrome Web Store launch. The README is the first thing potential users see on GitHub — it needs to sell the extension, carry the brand voice, and guide users to install.
+
+---
+
+## Audience Priority
+
+**Users first, developers second.** The README leads with value and personality. Developer setup is a single link to `CONTRIBUTING.md` near the bottom.
+
+---
+
+## Tone Calibration
+
+- **Sections 1–4** (header through How It Works): Brand voice — sharp, cheeky, honest. Previews the actual experience of using HypeControl.
+- **Sections 5–10** (privacy through support): Clean and professional. No jokes in privacy, license, or contributor info.
+
+---
+
+## Final Structure
+
+### 1. Title + Tagline + Hook
+
+```
+# Hype Control
+
+*Friction between your wallet and the hype train.*
+
+You love your streamers. You've also tipped more in one stream than you spent
+on groceries that week. Hype Control is a lightweight Chrome extension that adds
+a friction layer between you and impulse purchases — spending caps, cooldown
+timers, and confirmation prompts that give your future self a fighting chance.
+```
+
+Title is the extension name. Tagline is italicized subtitle. Hook is the opening body paragraph — approved copy, use verbatim.
+
+### 2. Install Link
+
+Headingless bold link on its own line, directly after the hook paragraph (no `##` heading). Keeps the flow from hook → CTA → features without a section break.
+
+```markdown
+**[Install from the Chrome Web Store](TODO(store-url))**
+```
+
+The `TODO(store-url)` marker is easy to grep for when the listing goes live.
+
+### 3. Features
+
+9 bullet points with brand-voice descriptions. No subgroup headings in the final output — present as a flat list under `## Features`. The grouping below is for the implementer's reference only.
+
+**Friction flow (4 bullets):**
+1. Real cost display (price + sales tax)
+2. Work-hours conversion ("That's 2.5 hours of your life")
+3. Comparison items ("That's 16 Costco hot dogs")
+4. Multi-step confirmation that scales with price (nudge → cooldown → type-to-confirm → math challenge)
+
+**Spending awareness (3 bullets):**
+5. Daily/weekly/monthly spending caps with progress tracking
+6. Spending cooldown timer between purchases
+7. Activity log + savings calendar — full history of what you blocked and what you saved
+
+**Smart bypasses (2 bullets):**
+8. Streaming mode (auto-detects when you're live, bypasses friction with toast notification)
+9. Channel whitelist (skip/reduce/full friction per channel)
+
+Each bullet should be 1–2 lines. Lead with the mechanic, follow with the personality. Example tone: not "Configurable daily spending cap with silent bypass below threshold" but something like "Daily spending cap — purchases under budget pass through silently; go over and the friction kicks in."
+
+Copy for these bullets is left to the implementer but must match the brand voice established in section 1. The CLAUDE.md design context ("sharp, cheeky, honest") and the hook paragraph set the tone target.
+
+### 4. How It Works
+
+One short paragraph (3–5 sentences) walking through the friction flow from the user's perspective: you click buy → overlay appears with real cost and work hours → comparison items make you think twice → confirmation steps scale with price → you either proceed deliberately or walk away. No code, no technical details.
+
+### 5. Privacy
+
+Two sentences max:
+- All data stays on your device (`chrome.storage.local` and `chrome.storage.sync`). Nothing is collected, transmitted, or tracked.
+- Link to full privacy policy: `https://ktulue.github.io/HypeControl/privacy.html`
+
+### 6. Known Issues
+
+**Keep:** Bits Combo limitation (user-facing — explains why animated Bits cheering can't be intercepted).
+
+**Cut:** Emoji picker platform quirks (not user-facing enough for the README).
+
+### 7. Contributing
+
+One-liner invitation + link to `CONTRIBUTING.md`:
+
+```markdown
+## Contributing
+
+Want to contribute, report a bug, or run it locally? See [CONTRIBUTING.md](CONTRIBUTING.md).
+```
+
+No dev setup, no branch conventions — `CONTRIBUTING.md` already covers all of that.
+
+### 8. License
+
+One-liner + link. No verbose explanation of GPL rights/restrictions:
+
+```markdown
+## License
+
+[GNU General Public License v3.0](LICENSE)
+```
+
+### 9. Acknowledgments
+
+Keep as-is:
+- **HolmsB** — naming the extension
+- **Lanzirelli** — logo & icons design
+
+### 10. Support
+
+Required per global instructions. Normalize to the global `CLAUDE.md` template format:
+
+```markdown
+---
+
+## Support
+
+☕ [Buy me a coffee on Ko-fi](http://ko-fi.com/ktulue)
+
+Created by Ktulue | The Water Father 🌊
+```
+
+Check for `ko-fi.com/ktulue` before appending. If present, replace with the canonical format above.
+
+---
+
+## What Gets Removed
+
+| Current Section | Reason |
+|---|---|
+| Configuration (field-by-field settings list) | The popup UI is self-explanatory |
+| Tech Stack | Developer-only; visible in `package.json` |
+| Project Structure (file tree) | Developer-only; visible in the repo itself |
+| Emoji picker known issues | Too granular for user-facing README |
+| Verbose license explanation | Replaced with one-liner + link |
+| Development setup steps | Already in `CONTRIBUTING.md` |
+
+---
+
+## What Stays the Same
+
+- `CONTRIBUTING.md` (not modified — already solid)
+- Acknowledgments section (HolmsB, Lanzirelli)
+- Support/Ko-fi section
+- LICENSE file
+
+---
+
+## Placeholder Strategy
+
+Chrome Web Store URL uses `TODO(store-url)` — grep-friendly marker. Single location (the install link near the top). Swap in the real URL once the listing goes live.
+
+---
+
+## No Screenshots
+
+No screenshot section in the README. Visual marketing handled by:
+- Chrome Web Store listing (screenshots required for submission)
+- GitHub Pages landing page (`docs/index.html`)
+- Future promo video content (YouTube, short clips — post-launch)
+
+The README sells with copy, not images.
+
+---
+
+## Tagline Decision
+
+"Friction between your wallet and the hype train" is the README tagline. Whether the logo's "Mindful Twitch Spending" subtitle also changes is a separate decision outside this spec's scope.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hype Control — Mindful Spending for Twitch</title>
+  <meta name="description" content="A free Chrome extension that creates intentional friction before Twitch purchases. Stop impulse spending on gift subs, Bits, and subscriptions.">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
+      color: #1a1a2e;
+      background: #fafafa;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    /* Hero */
+    .hero {
+      text-align: center;
+      padding: 80px 24px 48px;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      color: #f0f0f0;
+    }
+
+    .hero-logo {
+      width: 72px;
+      height: 72px;
+      margin-bottom: 16px;
+    }
+
+    .hero h1 {
+      font-size: 2.4rem;
+      font-weight: 700;
+      margin-bottom: 12px;
+      letter-spacing: -0.5px;
+    }
+
+    .hero p {
+      font-size: 1.15rem;
+      color: #c0c0d0;
+      max-width: 520px;
+      margin: 0 auto 32px;
+    }
+
+    .cta-btn {
+      display: inline-block;
+      padding: 14px 32px;
+      background: #9147ff;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      transition: background 0.2s;
+    }
+
+    .cta-btn:hover { background: #7c3aed; }
+
+    .cta-note {
+      display: block;
+      margin-top: 12px;
+      font-size: 0.85rem;
+      color: #8888aa;
+    }
+
+    /* Features */
+    .features {
+      padding: 64px 24px;
+    }
+
+    .features h2 {
+      text-align: center;
+      font-size: 1.6rem;
+      margin-bottom: 40px;
+      color: #1a1a2e;
+    }
+
+    .feature-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 32px;
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    @media (max-width: 560px) {
+      .feature-grid { grid-template-columns: 1fr; }
+    }
+
+    .feature {
+      padding: 24px;
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid #e8e8f0;
+    }
+
+    .feature h3 {
+      font-size: 1.05rem;
+      margin-bottom: 8px;
+      color: #1a1a2e;
+    }
+
+    .feature p {
+      font-size: 0.92rem;
+      color: #555;
+    }
+
+    /* How it works */
+    .how-it-works {
+      padding: 64px 24px;
+      background: #f0f0f5;
+    }
+
+    .how-it-works h2 {
+      text-align: center;
+      font-size: 1.6rem;
+      margin-bottom: 40px;
+    }
+
+    .steps {
+      max-width: 520px;
+      margin: 0 auto;
+    }
+
+    .step {
+      display: flex;
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .step-num {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      background: #9147ff;
+      color: #fff;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 0.95rem;
+    }
+
+    .step-text h3 {
+      font-size: 1rem;
+      margin-bottom: 4px;
+    }
+
+    .step-text p {
+      font-size: 0.9rem;
+      color: #555;
+    }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      padding: 48px 24px;
+      color: #777;
+      font-size: 0.85rem;
+    }
+
+    .footer-links {
+      margin-bottom: 16px;
+    }
+
+    .footer-links a {
+      color: #9147ff;
+      text-decoration: none;
+      margin: 0 12px;
+    }
+
+    .footer-links a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+  <section class="hero">
+    <img src="https://raw.githubusercontent.com/Ktulue/HypeControl/main/assets/icons/ChromeWebStore/HC_icon_128px.png" alt="Hype Control icon" class="hero-logo">
+    <h1>Hype Control</h1>
+    <p>A free Chrome extension that creates intentional friction before Twitch purchases. Stop impulse spending on gift subs, Bits, and subscriptions.</p>
+    <a href="#" class="cta-btn" id="install-btn">Install from Chrome Web Store</a>
+    <span class="cta-note">Free &middot; Open Source &middot; No data collection</span>
+  </section>
+
+  <section class="features">
+    <div class="container">
+      <h2>What It Does</h2>
+      <div class="feature-grid">
+        <div class="feature">
+          <h3>Real Cost Breakdown</h3>
+          <p>See the true price with tax, how many work hours it costs, and what else you could buy with that money.</p>
+        </div>
+        <div class="feature">
+          <h3>Multi-Step Friction</h3>
+          <p>Four intensity levels from a gentle nudge to a full gauntlet — math challenges, cooldown timers, and type-to-confirm.</p>
+        </div>
+        <div class="feature">
+          <h3>Spending Limits</h3>
+          <p>Daily, weekly, and monthly caps with visual progress bars. Auto-escalates friction as you approach your limit.</p>
+        </div>
+        <div class="feature">
+          <h3>Streaming Mode</h3>
+          <p>Automatically bypasses friction when you're live on your own channel, so you can gift subs to your community freely.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="how-it-works">
+    <div class="container">
+      <h2>How It Works</h2>
+      <div class="steps">
+        <div class="step">
+          <div class="step-num">1</div>
+          <div class="step-text">
+            <h3>Install the extension</h3>
+            <p>Add Hype Control from the Chrome Web Store. Set your hourly rate, tax rate, and friction level.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num">2</div>
+          <div class="step-text">
+            <h3>Browse Twitch normally</h3>
+            <p>Hype Control runs silently in the background. No impact until you click a purchase button.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num">3</div>
+          <div class="step-text">
+            <h3>Get a reality check</h3>
+            <p>Before any gift sub, subscription, or Bits purchase goes through, you see the real cost — in dollars, work hours, and everyday items.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num">4</div>
+          <div class="step-text">
+            <h3>Decide with a clear head</h3>
+            <p>Cancel or proceed — your call. Hype Control tracks your savings and shows you how much you've kept in your pocket.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/Ktulue/HypeControl">GitHub</a>
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="https://ko-fi.com/ktulue">Support on Ko-fi</a>
+    </div>
+    <p>Created by <a href="https://github.com/Ktulue" style="color: #9147ff; text-decoration: none;">Ktulue</a> | The Water Father</p>
+    <p style="margin-top: 8px;">Licensed under GNU GPL v3.0</p>
+  </footer>
+
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — Hype Control</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
+      color: #1a1a2e;
+      background: #fafafa;
+      line-height: 1.7;
+      padding: 48px 24px;
+    }
+
+    .container {
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      margin-bottom: 8px;
+    }
+
+    .effective-date {
+      color: #777;
+      font-size: 0.9rem;
+      margin-bottom: 40px;
+    }
+
+    h2 {
+      font-size: 1.2rem;
+      margin-top: 32px;
+      margin-bottom: 12px;
+      color: #1a1a2e;
+    }
+
+    p, li {
+      font-size: 0.95rem;
+      color: #333;
+      margin-bottom: 12px;
+    }
+
+    ul {
+      padding-left: 24px;
+      margin-bottom: 16px;
+    }
+
+    li { margin-bottom: 8px; }
+
+    a { color: #9147ff; }
+    a:hover { text-decoration: none; }
+
+    .back-link {
+      display: inline-block;
+      margin-top: 40px;
+      font-size: 0.9rem;
+    }
+
+    .footer {
+      margin-top: 48px;
+      padding-top: 24px;
+      border-top: 1px solid #e0e0e0;
+      font-size: 0.85rem;
+      color: #777;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="container">
+    <h1>Privacy Policy</h1>
+    <p class="effective-date">Effective date: March 20, 2026</p>
+
+    <p>Hype Control is a free, open-source Chrome extension that creates intentional friction before Twitch purchases. This policy explains what data the extension handles and how.</p>
+
+    <h2>Data Collection</h2>
+    <p><strong>Hype Control does not collect, transmit, or share any personal data.</strong> There are no analytics, no tracking, no external servers, and no third-party services. All data stays on your device.</p>
+
+    <h2>Data Storage</h2>
+    <p>The extension stores two categories of data locally on your device using Chrome's built-in storage APIs:</p>
+    <ul>
+      <li><strong>User settings</strong> (<code>chrome.storage.sync</code>) — Your hourly rate, tax rate, friction level, comparison items, spending caps, channel whitelist, and other preferences. These sync across your Chrome browsers if you're signed into Chrome, but are never sent to Hype Control or any third party.</li>
+      <li><strong>Spending data</strong> (<code>chrome.storage.local</code>) — Daily, weekly, and monthly spending totals, intercept event history (purchase type, price, outcome), and activity logs. This data stays on the device where it was created and is not synced.</li>
+    </ul>
+    <p>You can reset all spending data at any time using the "Reset Tracker" button in the extension popup. Uninstalling the extension removes all stored data.</p>
+
+    <h2>Permissions</h2>
+    <p>Hype Control requests only the permissions necessary to function:</p>
+    <ul>
+      <li><strong>Host permission for Twitch</strong> (<code>*://*.twitch.tv/*</code>) — Required to inject the content script that detects purchase buttons and displays friction overlays on Twitch pages. The extension does not access, read, or modify any other websites.</li>
+      <li><strong>Storage</strong> (<code>storage</code>) — Required to save your settings and spending data locally using Chrome's storage API.</li>
+    </ul>
+
+    <h2>Third-Party Services</h2>
+    <p>Hype Control does not use any third-party services, SDKs, or APIs. No data is sent to external servers of any kind.</p>
+
+    <h2>Open Source</h2>
+    <p>The complete source code is publicly available at <a href="https://github.com/Ktulue/HypeControl">github.com/Ktulue/HypeControl</a> under the GNU GPL v3.0 license. You can verify every claim in this policy by reading the code.</p>
+
+    <h2>Changes to This Policy</h2>
+    <p>If this policy changes, the updated version will be posted here with a new effective date. Significant changes will be noted in the extension's changelog.</p>
+
+    <h2>Contact</h2>
+    <p>Questions or concerns? Open an issue on <a href="https://github.com/Ktulue/HypeControl/issues">GitHub</a>.</p>
+
+    <a href="index.html" class="back-link">&larr; Back to Hype Control</a>
+
+    <div class="footer">
+      <p>Hype Control is created by <a href="https://github.com/Ktulue">Ktulue</a> and is not affiliated with Twitch or Amazon.</p>
+    </div>
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Rewrites the README from developer-focused internal docs to a user-first, brand-voice public page
- New tagline: "Friction between your wallet and the hype train"
- 10-section structure: hook, install link, features (9 bullets with personality), how it works, privacy, known issues, contributing, license, acknowledgments, support
- Removes developer-only sections (tech stack, project structure, config reference, emoji picker known issues)
- Developers directed to CONTRIBUTING.md via a single link

**Note:** This branch is based on `maint/github-setup` (PR #23). Merge #23 first.

## Test plan

- [ ] Read through the README on GitHub and verify the brand voice lands
- [ ] Verify `TODO(store-url)` placeholder is present (will be replaced when store listing goes live)
- [ ] Confirm all links work: CONTRIBUTING.md, LICENSE, privacy policy URL
- [ ] Confirm no developer-only content remains (no file tree, no tech stack, no config list)

Generated with [Claude Code](https://claude.com/claude-code)