### PR TITLE
maint: align landing page copy with brand voice

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hype Control — Mindful Spending for Twitch</title>
-  <meta name="description" content="A free Chrome extension that creates intentional friction before Twitch purchases. Stop impulse spending on gift subs, Bits, and subscriptions.">
+  <title>Hype Control — Friction Between Your Wallet and the Hype Train</title>
+  <meta name="description" content="You love your streamers. You've also tipped more in one stream than you spent on groceries. Hype Control adds friction before Twitch purchases so your future self has a fighting chance.">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -185,9 +185,9 @@
   <section class="hero">
     <img src="https://raw.githubusercontent.com/Ktulue/HypeControl/main/assets/icons/ChromeWebStore/HC_icon_128px.png" alt="Hype Control icon" class="hero-logo">
     <h1>Hype Control</h1>
-    <p>A free Chrome extension that creates intentional friction before Twitch purchases. Stop impulse spending on gift subs, Bits, and subscriptions.</p>
+    <p>You love your streamers. You've also tipped more in one stream than you spent on groceries that week. Hype Control adds a friction layer between you and impulse purchases — spending caps, cooldown timers, and confirmation prompts that give your future self a fighting chance.</p>
     <a href="#" class="cta-btn" id="install-btn">Install from Chrome Web Store</a>
-    <span class="cta-note">Free &middot; Open Source &middot; No data collection</span>
+    <span class="cta-note">Free &middot; Open Source &middot; Your data never leaves your device</span>
   </section>
 
   <section class="features">
@@ -195,20 +195,20 @@
       <h2>What It Does</h2>
       <div class="feature-grid">
         <div class="feature">
-          <h3>Real Cost Breakdown</h3>
-          <p>See the true price with tax, how many work hours it costs, and what else you could buy with that money.</p>
+          <h3>Real Cost Display</h3>
+          <p>Shows the actual price with tax, because Twitch won't. Translates every purchase into work hours and comparison items. "That's 16 Costco hot dogs" hits different than "$50."</p>
         </div>
         <div class="feature">
           <h3>Multi-Step Friction</h3>
-          <p>Four intensity levels from a gentle nudge to a full gauntlet — math challenges, cooldown timers, and type-to-confirm.</p>
+          <p>Confirmation steps scale with price. Small purchases get a nudge; big ones get a cooldown timer, type-to-confirm, and a math challenge. Earn it.</p>
         </div>
         <div class="feature">
           <h3>Spending Limits</h3>
-          <p>Daily, weekly, and monthly caps with visual progress bars. Auto-escalates friction as you approach your limit.</p>
+          <p>Daily, weekly, and monthly caps with progress bars that track where you stand. Go over and the friction kicks in harder. Budget-aware by design.</p>
         </div>
         <div class="feature">
           <h3>Streaming Mode</h3>
-          <p>Automatically bypasses friction when you're live on your own channel, so you can gift subs to your community freely.</p>
+          <p>Auto-detects when you're live on your own channel and steps aside. Toast notifications let you know friction was bypassed, so you stay aware without the interruption.</p>
         </div>
       </div>
     </div>
@@ -221,29 +221,29 @@
         <div class="step">
           <div class="step-num">1</div>
           <div class="step-text">
-            <h3>Install the extension</h3>
-            <p>Add Hype Control from the Chrome Web Store. Set your hourly rate, tax rate, and friction level.</p>
+            <h3>Install &amp; configure</h3>
+            <p>Add Hype Control from the Chrome Web Store. Set your hourly rate, tax rate, and how much friction you want between you and your wallet.</p>
           </div>
         </div>
         <div class="step">
           <div class="step-num">2</div>
           <div class="step-text">
-            <h3>Browse Twitch normally</h3>
-            <p>Hype Control runs silently in the background. No impact until you click a purchase button.</p>
+            <h3>Watch Twitch like normal</h3>
+            <p>Hype Control sits quietly in the background. Zero impact until you reach for a purchase button.</p>
           </div>
         </div>
         <div class="step">
           <div class="step-num">3</div>
           <div class="step-text">
-            <h3>Get a reality check</h3>
-            <p>Before any gift sub, subscription, or Bits purchase goes through, you see the real cost — in dollars, work hours, and everyday items.</p>
+            <h3>Get the reality check</h3>
+            <p>Before any gift sub, subscription, or Bits purchase goes through, you see the real cost — in dollars, work hours, and everyday items. The discomfort is intentional.</p>
           </div>
         </div>
         <div class="step">
           <div class="step-num">4</div>
           <div class="step-text">
-            <h3>Decide with a clear head</h3>
-            <p>Cancel or proceed — your call. Hype Control tracks your savings and shows you how much you've kept in your pocket.</p>
+            <h3>Decide deliberately</h3>
+            <p>Proceed or walk away. Either way, it was actually a decision — not a reflex. Your savings calendar tracks every dollar you didn't spend.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Update docs/index.html to match the sharp, cheeky tone established in the README. Replaces the soft "mindful spending" copy with the brand voice — "friction between your wallet and the hype train."