### PR TITLE
maint: bump to v1.0.0 for Chrome Web Store launch

### DIFF
--- a/docs/dev/HC-Project-Document.md
+++ b/docs/dev/HC-Project-Document.md
@@ -6,7 +6,7 @@
 
 **Created:** January 2026  
 **Author:** Josh (Ktulue) + Claude  
-**Status:** Planning Phase Complete - Ready for Implementation  
+**Status:** v1.0.0 — Chrome Web Store Launch  
 **License:** GPL v3  
 **Repository:** Ktulue/MTS
 

--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-03-21
-**Current Version:** 0.4.28
+**Updated:** 2026-03-23
+**Current Version:** 1.0.0
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -219,12 +219,13 @@ The original design called for a guided overlay on the Twitch page highlighting 
 
 ### Next Up
 
-1. **Chrome Web Store Launch** — Store listing, privacy policy, screenshots, version 1.0.0 release
-2. **Firefox AMO Port** — Adapt extension for Firefox (manifest changes, `browser.*` API audit, AMO submission)
+1. **Firefox AMO Port** — Adapt extension for Firefox (manifest changes, `browser.*` API audit, AMO submission)
 
 ### Recently Completed
 
-- [x] **README Rewrite (2026-03-21)** — Rewrote README.md from developer-focused internal docs to a user-first, brand-voice public page for the Chrome Web Store launch. No version bump (content-only change).
+- [x] **Chrome Web Store Launch (2026-03-23)** — v1.0.0 release. Version bump, brand-voice alignment across manifest/landing page/store listing, build and submission.
+- [x] **Landing Page Brand Voice (2026-03-23)** — Aligned docs/index.html copy with README's sharp/cheeky tone.
+- [x] **README Rewrite (2026-03-21)** — Rewrote README.md from developer-focused internal docs to a user-first, brand-voice public page for the Chrome Web Store launch.
 
 ### Future Enhancements
 
@@ -299,4 +300,4 @@ Shared spendingTracker module, daily/weekly/monthly reset fix for popup, session
 
 ---
 
-_Last updated 2026-03-21 against the v0.4.28 codebase. Repository cleaned up for Chrome Web Store launch preparation. README rewritten for public launch._
+_Last updated 2026-03-23 against the v1.0.0 codebase. Chrome Web Store launch._

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "0.4.28",
-  "description": "Create intentional friction before Twitch purchases to encourage mindful spending",
+  "version": "1.0.0",
+  "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",
     "48": "assets/icons/ChromeWebStore/HC_icon_48px.png",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hype-control",
-  "version": "0.4.28",
-  "description": "Chrome extension that creates intentional friction before Twitch spending",
+  "version": "1.0.0",
+  "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",
     "dev": "webpack --mode development --watch",


### PR DESCRIPTION
Version bump to 1.0.0 in manifest.json and package.json. Aligned manifest/package descriptions with brand voice. Updated TODO and project document to reflect CWS launch status.