### PR TITLE
fix: bug report link now opens with template pre-selected

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-03-23
-**Current Version:** 1.0.0
+**Updated:** 2026-03-31
+**Current Version:** 1.0.1
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -415,7 +415,7 @@
 
   <footer class="hc-footer">
     <div class="footer-links">
-      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
+      <a class="footer-link" href="https://github.com/Ktulue/HypeControl/issues/new?template=bug_report.md" target="_blank" rel="noopener noreferrer">🐛 Bug</a>
       <a class="footer-link" href="https://github.com/Ktulue/HypeControl/discussions/new?category=ideas" target="_blank" rel="noopener noreferrer">💡 Ideas</a>
     </div>
     <button class="btn-save" id="btn-save">💾 Save Settings</button>


### PR DESCRIPTION
The popup footer bug link pointed to /issues/new without a template parameter, landing users on a blank page. Added ?template=bug_report.md so it auto-selects the Bug Report template.

Bumps to v1.0.1.