### PR TITLE
feat: friction trigger mode (Price Guard / Zero Trust)

### DIFF
--- a/docs/dev/HC-Project-Document.md
+++ b/docs/dev/HC-Project-Document.md
@@ -253,6 +253,13 @@ Step 3: Type confirmation
 - Requires solving a simple math problem
 - Sends notification to accountability partner
 
+### Friction Trigger Mode
+
+Users choose when friction activates via the **Trigger Mode** setting:
+
+- **Price Guard** (default) — Friction triggers only when a price is detected on the purchase button. If the extension can't read the price, the click passes through silently (still logged).
+- **Zero Trust** — Friction triggers on every purchase button regardless of price detection. No-price overlays show rotating contextual messages from two tonal buckets (matter-of-fact and cheeky, 16 messages total). All intensity steps (reason selection, cooldown timer, math challenge, type-to-confirm) still apply based on the user's intensity setting.
+
 ---
 
 ## Technical Architecture

--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-04-02
-**Current Version:** 1.0.2
+**Updated:** 2026-04-13
+**Current Version:** 1.0.3
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -24,6 +24,7 @@
 | Add-on 3 — Weekly/Monthly Limits         | ✅ Complete       |
 | Interactive Onboarding Tour              | ✅ Complete        |
 | Firefox AMO Port                         | ✅ Complete       |
+| Friction Trigger Mode (Price Guard / Zero Trust) | ✅ Complete |
 | Add-ons 6–12 — Future Enhancements       | ⏸️ Deferred       |
 
 ---

--- a/docs/superpowers/plans/2026-04-13-friction-trigger-mode.md
+++ b/docs/superpowers/plans/2026-04-13-friction-trigger-mode.md
@@ -1,0 +1,522 @@
+# Friction Trigger Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do NOT bump versions — versioning is handled separately at the end.**
+
+**Goal:** Add a "Friction Trigger Mode" setting (Price Guard / Zero Trust) that controls whether friction fires only on price-detected purchases or on all purchase buttons regardless of price.
+
+**Architecture:** New `frictionTriggerMode` field on `UserSettings` with values `'price-guard'` (default) or `'zero-trust'`. `determineFrictionLevel()` branches on this field when `priceValue === null`. Zero Trust no-price overlays show rotating messages from a 16-message pool (two tonal buckets). The `runFrictionFlow()` early return on null price is conditioned so intensity steps still fire under Zero Trust.
+
+**Tech Stack:** TypeScript, Chrome Extension MV3, webpack
+
+---
+
+### Task 1: Add `frictionTriggerMode` to types and settings
+
+**Files:**
+- Modify: `src/shared/types.ts:38` (FrictionTriggerMode type)
+- Modify: `src/shared/types.ts:102-120` (UserSettings interface)
+- Modify: `src/shared/types.ts:157-199` (DEFAULT_SETTINGS)
+- Modify: `src/shared/types.ts:237-317` (migrateSettings)
+- Modify: `src/shared/types.ts:383-488` (sanitizeSettings)
+
+- [ ] **Step 1: Add the type alias and update UserSettings**
+
+After line 38 (`export type FrictionLevel = 'none' | 'nudge' | 'full' | 'cap-bypass';`), add:
+
+```typescript
+/** Controls when friction triggers: price-detected only, or every purchase button */
+export type FrictionTriggerMode = 'price-guard' | 'zero-trust';
+```
+
+Add to the `UserSettings` interface (after `frictionIntensity: FrictionIntensity;` at line 111):
+
+```typescript
+  frictionTriggerMode: FrictionTriggerMode;
+```
+
+Update the import at the top of `interceptor.ts` to include `FrictionTriggerMode`.
+
+- [ ] **Step 2: Add default value**
+
+In `DEFAULT_SETTINGS` (after `frictionIntensity: 'low',` at line 183):
+
+```typescript
+  frictionTriggerMode: 'price-guard',
+```
+
+- [ ] **Step 3: Add migration support**
+
+In `migrateSettings()`, add after the `frictionIntensity` line (~line 299):
+
+```typescript
+    frictionTriggerMode: saved.frictionTriggerMode ?? DEFAULT_SETTINGS.frictionTriggerMode,
+```
+
+- [ ] **Step 4: Add sanitization**
+
+In `sanitizeSettings()`, add after the `frictionIntensity` validation (~line 402):
+
+```typescript
+  const frictionTriggerMode = validEnum(s.frictionTriggerMode, ['price-guard', 'zero-trust'] as const, DEFAULT_SETTINGS.frictionTriggerMode);
+```
+
+And add `frictionTriggerMode,` to the returned object (after the `frictionIntensity,` line in the result object ~line 465).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat: add frictionTriggerMode to UserSettings type and defaults"
+```
+
+---
+
+### Task 2: Add rotating Zero Trust message pool to interceptor
+
+**Files:**
+- Modify: `src/content/interceptor.ts:1-18` (imports)
+- Modify: `src/content/interceptor.ts` (new constant near top, after imports)
+
+- [ ] **Step 1: Add message pool constant**
+
+After the imports section (~line 18) and before the `FrictionResult` interface (~line 20), add:
+
+```typescript
+// ── Zero Trust no-price overlay messages ────────────────────────────────
+// Two tonal buckets: matter-of-fact and cheeky. Selection alternates buckets
+// with no back-to-back duplicates.
+
+const ZERO_TRUST_MESSAGES_FACTUAL = [
+  "No price detected. That doesn't mean it's free.",
+  "We couldn't read a number. You're in Zero Trust — so we showed up anyway.",
+  "Price? No idea. But you told us to stop you every time.",
+  "Can't see what this costs. Can you?",
+  "No price tag on this one. Zero Trust doesn't care.",
+  "We don't know the price. That's exactly why we're here.",
+  "Price not found. Zero Trust mode doesn't take days off.",
+  "Unknown cost. Known impulse risk.",
+];
+
+const ZERO_TRUST_MESSAGES_CHEEKY = [
+  "Zero Trust means zero exceptions. Even this one.",
+  "No price tag? Suspicious.",
+  "Flying blind on the cost. Good thing you brought a parachute.",
+  "Couldn't find a price. Found you clicking though.",
+  "The price is a mystery. Your spending habits are not.",
+  "No number to crunch. Just a button to question.",
+  "We can't tell you what this costs. We can tell you to think about it.",
+  "Price unknown. Wallet concern: very known.",
+];
+
+let lastZeroTrustBucket: 'factual' | 'cheeky' | null = null;
+let lastZeroTrustIndex: number = -1;
+
+function pickZeroTrustMessage(): string {
+  // Alternate buckets, avoiding back-to-back duplicates within a bucket
+  const useBucket: 'factual' | 'cheeky' = lastZeroTrustBucket === 'factual' ? 'cheeky' : 'factual';
+  const pool = useBucket === 'factual' ? ZERO_TRUST_MESSAGES_FACTUAL : ZERO_TRUST_MESSAGES_CHEEKY;
+
+  let idx: number;
+  do {
+    idx = Math.floor(Math.random() * pool.length);
+  } while (idx === lastZeroTrustIndex && pool.length > 1);
+
+  lastZeroTrustBucket = useBucket;
+  lastZeroTrustIndex = idx;
+  return pool[idx];
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "feat: add Zero Trust rotating message pool and picker"
+```
+
+---
+
+### Task 3: Update `determineFrictionLevel()` to respect trigger mode
+
+**Files:**
+- Modify: `src/content/interceptor.ts:104-172` (determineFrictionLevel function)
+
+- [ ] **Step 1: Move null-price check above thresholds-disabled check and add trigger mode branching**
+
+The function already receives `settings: UserSettings`. Currently lines 151-155 have the thresholds-disabled check BEFORE the null-price check, which means thresholds-disabled would return `'full'` even for null-price Price Guard clicks. We need to reorder so null-price is checked first.
+
+Replace lines 151-155 entirely. Current code:
+
+```typescript
+  if (!settings.frictionThresholds.enabled) {
+    log('Thresholds disabled — defaulting to full modal');
+    return 'full';
+  }
+  if (priceValue === null || priceValue <= 0) return 'full';
+```
+
+New code:
+
+```typescript
+  if (priceValue === null || priceValue <= 0) {
+    if (settings.frictionTriggerMode === 'zero-trust') {
+      log('No price detected — Zero Trust mode: full friction applied');
+      return 'full';
+    }
+    log('No price detected — Price Guard mode: no friction applied');
+    return 'none';
+  }
+
+  if (!settings.frictionThresholds.enabled) {
+    log('Thresholds disabled — defaulting to full modal');
+    return 'full';
+  }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "feat: determineFrictionLevel respects frictionTriggerMode setting"
+```
+
+---
+
+### Task 4: Update `showMainOverlay()` to use rotating messages for Zero Trust no-price
+
+**Files:**
+- Modify: `src/content/interceptor.ts:508-588` (showMainOverlay function)
+
+- [ ] **Step 1: Replace static no-price copy with rotating message**
+
+`showMainOverlay` already receives `settings: UserSettings`. Change lines 520-525 from:
+
+```typescript
+  let priceExtra = '';
+  if (attempt.priceValue !== null && attempt.priceValue > 0) {
+    priceExtra = buildCostBreakdown(attempt.priceValue, settings, tracker);
+  } else {
+    priceExtra = '<p class="hc-price-note">Unable to detect price. Proceed with caution.</p>';
+  }
+```
+
+to:
+
+```typescript
+  let priceExtra = '';
+  if (attempt.priceValue !== null && attempt.priceValue > 0) {
+    priceExtra = buildCostBreakdown(attempt.priceValue, settings, tracker);
+  } else {
+    const noteEl = document.createElement('p');
+    noteEl.className = 'hc-price-note';
+    noteEl.textContent = settings.frictionTriggerMode === 'zero-trust'
+      ? pickZeroTrustMessage()
+      : 'Unable to detect price. Proceed with caution.';
+    priceExtra = noteEl.outerHTML;
+  }
+```
+
+Note: We use DOM construction + `textContent` to stay consistent with the project's XSS prevention rules, even though these are hardcoded strings. The pattern is the convention.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "feat: Zero Trust no-price overlay shows rotating messages"
+```
+
+---
+
+### Task 5: Fix `runFrictionFlow()` early return so intensity steps fire for Zero Trust no-price
+
+**Files:**
+- Modify: `src/content/interceptor.ts:1534-1542` (runFrictionFlow null-price early return)
+
+- [ ] **Step 1: Condition the early return on Price Guard mode**
+
+The current code at lines 1534-1542:
+
+```typescript
+  // Build comparison steps — only when price is detected
+  const priceWithTax = (attempt.priceValue && attempt.priceValue > 0)
+    ? Math.round(attempt.priceValue * (1 + settings.taxRate / 100) * 100) / 100
+    : null;
+
+  if (priceWithTax === null) {
+    log('Friction flow: no price detected, skipping comparison steps');
+    return { decision: 'proceed', purchaseReason };
+  }
+```
+
+Change to:
+
+```typescript
+  // Build comparison steps — only when price is detected
+  const priceWithTax = (attempt.priceValue && attempt.priceValue > 0)
+    ? Math.round(attempt.priceValue * (1 + settings.taxRate / 100) * 100) / 100
+    : null;
+
+  if (priceWithTax === null) {
+    log('Friction flow: no price detected, skipping comparison steps');
+    // Price Guard would never reach here (determineFrictionLevel returns 'none').
+    // Zero Trust continues to intensity steps below — fall through.
+  }
+```
+
+- [ ] **Step 2: Guard comparison step loop against null price**
+
+The comparison step code (lines 1544-1593) already uses `priceWithTax` to build comparisons. We need to wrap the comparison block so it only runs when `priceWithTax` is not null. The code immediately after the null check starts with:
+
+```typescript
+  // nudge: enabled items where scope is 'nudge' or 'both', limited to softNudgeSteps
+  // full: enabled items where scope is 'full' or 'both' (scope replaces the old "all items" behavior)
+  const itemPool = maxComparisons !== undefined
+```
+
+Wrap the entire comparison block (from `const itemPool` through the comparison step loop ending before `// ── Intensity-gated steps`) in a null check:
+
+```typescript
+  if (priceWithTax !== null) {
+    // nudge: enabled items where scope is 'nudge' or 'both', limited to softNudgeSteps
+    // full: enabled items where scope is 'full' or 'both'
+    const itemPool = maxComparisons !== undefined
+      ? settings.comparisonItems
+          .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'full')
+          .slice(0, maxComparisons)
+      : settings.comparisonItems
+          .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'nudge');
+```
+
+Read lines 1544-1593 to identify the exact end of the comparison block, then close the `if` brace before the intensity-gated steps comment. The comparison block ends just before the `// ── Intensity-gated steps` comment at line 1595. Add the closing `}` before that comment:
+
+```typescript
+  } // end if (priceWithTax !== null)
+
+  // ── Intensity-gated steps ─────────────────────────────────────────────
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "feat: Zero Trust no-price overlays now run intensity steps"
+```
+
+---
+
+### Task 6: Add trigger mode segmented control to popup HTML
+
+**Files:**
+- Modify: `src/popup/popup.html:147-165` (friction section, before intensity fieldset)
+
+- [ ] **Step 1: Add the trigger mode control**
+
+Insert the following BEFORE the existing intensity fieldset (before line 148 `<div class="hc-row">`  that contains `<fieldset class="hc-fieldset">` with `<legend class="hc-label">Intensity</legend>`):
+
+```html
+        <div class="hc-row">
+          <fieldset class="hc-fieldset">
+            <legend class="hc-label">Trigger Mode</legend>
+            <div class="segmented" id="friction-trigger-mode" data-pending-field="frictionTriggerMode">
+              <button class="seg-btn" data-value="price-guard">Price Guard</button>
+              <button class="seg-btn" data-value="zero-trust">Zero Trust</button>
+            </div>
+          </fieldset>
+        </div>
+        <div class="trigger-mode-desc" id="trigger-mode-desc">
+          <p class="hc-hint" id="trigger-mode-hint"></p>
+        </div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/popup/popup.html
+git commit -m "feat: add trigger mode segmented control to popup HTML"
+```
+
+---
+
+### Task 7: Wire trigger mode control in friction section TypeScript
+
+**Files:**
+- Modify: `src/popup/sections/friction.ts:1-181`
+
+- [ ] **Step 1: Update imports**
+
+Change line 1 from:
+
+```typescript
+import { UserSettings, FrictionIntensity, DelayTimerConfig, FrictionThresholds, DEFAULT_SETTINGS } from '../../shared/types';
+```
+
+to:
+
+```typescript
+import { UserSettings, FrictionIntensity, FrictionTriggerMode, DelayTimerConfig, FrictionThresholds, DEFAULT_SETTINGS } from '../../shared/types';
+```
+
+- [ ] **Step 2: Add DOM references and wiring**
+
+After line 33 (`const lockEl = ...`), add:
+
+```typescript
+  const triggerModeEl = el.querySelector<HTMLElement>('#friction-trigger-mode')!;
+  const triggerModeDescEl = el.querySelector<HTMLElement>('#trigger-mode-hint')!;
+```
+
+Add the description text mapping and update function after the `renderSegmented` function (~line 47):
+
+```typescript
+  const TRIGGER_MODE_DESCRIPTIONS: Record<FrictionTriggerMode, string> = {
+    'price-guard': "Friction triggers only when a price is detected. If we can't read the number, you walk.",
+    'zero-trust': "Friction on every purchase button — price or not. You asked for this.",
+  };
+
+  function updateTriggerModeDesc(mode: FrictionTriggerMode): void {
+    triggerModeDescEl.textContent = TRIGGER_MODE_DESCRIPTIONS[mode];
+  }
+```
+
+- [ ] **Step 3: Add event listener for trigger mode buttons**
+
+After the intensity segmented listener block (~after line 100), add:
+
+```typescript
+  // Trigger mode segmented
+  triggerModeEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const val = btn.dataset.value as FrictionTriggerMode;
+      setPendingField('frictionTriggerMode', val);
+      renderSegmented(triggerModeEl, val);
+      updateTriggerModeDesc(val);
+    });
+  });
+```
+
+- [ ] **Step 4: Update render function**
+
+In the `render` function (~line 163), after `renderSegmented(intensityEl, settings.frictionIntensity);` (line 168), add:
+
+```typescript
+    renderSegmented(triggerModeEl, settings.frictionTriggerMode);
+    updateTriggerModeDesc(settings.frictionTriggerMode);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/popup/sections/friction.ts
+git commit -m "feat: wire trigger mode segmented control with descriptions"
+```
+
+---
+
+### Task 8: Add CSS for trigger mode description hint
+
+**Files:**
+- Identify the CSS file used by the popup (likely `src/popup/popup.css` or a shared CSS file)
+
+- [ ] **Step 1: Find and read the popup CSS file**
+
+Check `src/popup/popup.css` for existing `.hc-hint` styles. If `.hc-hint` already exists, no new CSS is needed — the description text will inherit the existing hint styling.
+
+If `.hc-hint` does NOT exist, add to the popup CSS:
+
+```css
+.trigger-mode-desc {
+  padding: 0 0 4px;
+}
+
+.hc-hint {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  margin: 2px 0 0;
+  line-height: 1.4;
+}
+```
+
+If `.hc-hint` already exists, just add the `.trigger-mode-desc` wrapper style if needed for spacing.
+
+- [ ] **Step 2: Commit (if changes were needed)**
+
+```bash
+git add src/popup/popup.css
+git commit -m "maint: add trigger mode description hint styles"
+```
+
+---
+
+### Task 9: Update docs
+
+**Files:**
+- Modify: `docs/dev/HypeControl-TODO.md`
+- Modify: `docs/dev/HC-Project-Document.md`
+
+- [ ] **Step 1: Update HypeControl-TODO.md**
+
+Update the header:
+- Set `Updated:` to `2026-04-13`
+- Bump `Current Version:` to the new version (after version bump)
+
+Add a new completed item in the appropriate section:
+
+```markdown
+| Friction Trigger Mode (Price Guard / Zero Trust) | ✅ Complete |
+```
+
+- [ ] **Step 2: Update HC-Project-Document.md**
+
+Find the section describing the friction/overlay system and add a note about trigger modes:
+
+```markdown
+**Friction Trigger Mode:** Users choose between Price Guard (friction only when price detected — default) and Zero Trust (friction on every purchase button regardless of price detection, with rotating contextual messages).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/HypeControl-TODO.md docs/dev/HC-Project-Document.md
+git commit -m "maint: update project docs for friction trigger mode feature"
+```
+
+---
+
+### Task 10: Version bump and build
+
+**Files:**
+- Modify: `manifest.json` (version field)
+- Modify: `package.json` (version field)
+
+- [ ] **Step 1: Bump patch version in both files**
+
+Increment the patch version (e.g., `1.0.2` → `1.0.3`) in both `manifest.json` and `package.json`.
+
+- [ ] **Step 2: Run build**
+
+```bash
+npm run build
+```
+
+If the build fails, stop and tell the user to run `npm run build` manually.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add manifest.json package.json
+git commit -m "maint: bump to v1.0.3 for friction trigger mode feature"
+```
+
+---
+
+## Task Dependency Summary
+
+```
+Task 1 (types) → Task 2 (message pool) → Task 3 (determineFrictionLevel)
+                                        → Task 4 (overlay messages)
+                                        → Task 5 (runFrictionFlow fix)
+Task 1 (types) → Task 6 (popup HTML) → Task 7 (friction.ts wiring) → Task 8 (CSS)
+Tasks 3-8 all complete → Task 9 (docs) → Task 10 (version bump + build)
+```
+
+Tasks 2-5 (interceptor changes) and Tasks 6-8 (UI changes) can run in parallel after Task 1 completes, since they touch different files.

--- a/docs/superpowers/specs/2026-04-13-friction-trigger-mode-design.md
+++ b/docs/superpowers/specs/2026-04-13-friction-trigger-mode-design.md
@@ -1,0 +1,140 @@
+# Friction Trigger Mode — Design Spec
+
+**Date:** 2026-04-13
+**Branch:** `feat/friction-trigger-mode`
+**Status:** Approved
+
+---
+
+## Summary
+
+HypeControl currently triggers friction on every intercepted purchase button click, regardless of whether a price was detected. This design introduces a **Friction Trigger Mode** setting that lets users choose between two behaviors:
+
+- **Price Guard** (new default): Friction only fires when a price is detected. No price = silent pass.
+- **Zero Trust**: Friction fires on every purchase button — price or not. Includes rotating no-price overlay messages.
+
+## Motivation
+
+The current "always friction" approach was a deliberate conservative choice during MVP. Now that the extension is stable and shipping, users should be able to choose: most users benefit from price-gated friction (no false positives on unreadable buttons), while users who want maximum accountability can opt into Zero Trust.
+
+---
+
+## New Setting: `frictionTriggerMode`
+
+### Type Definition
+
+```typescript
+frictionTriggerMode: 'price-guard' | 'zero-trust'
+```
+
+- **Default:** `'price-guard'`
+- **Storage:** `chrome.storage.sync` (user preference)
+- **Migration:** Existing users receive `'price-guard'` via `migrateSettings()`. This is an intentional behavior change — the new default is the desired direction.
+
+### Settings UI
+
+Segmented control in the Friction section, near the existing intensity picker. Two buttons:
+
+| Label | Description |
+|---|---|
+| **Price Guard** | "Friction triggers only when a price is detected. If we can't read the number, you walk." |
+| **Zero Trust** | "Friction on every purchase button — price or not. You asked for this." |
+
+---
+
+## Behavior Change: `determineFrictionLevel()`
+
+### Current Logic (line 155 of interceptor.ts)
+
+```
+priceValue === null → return 'full'
+```
+
+### New Logic
+
+```
+priceValue === null →
+  if triggerMode === 'zero-trust' → return 'full'
+  if triggerMode === 'price-guard' → return 'none'
+```
+
+### What Does NOT Change
+
+- **Cap checks** — already gate on `priceValue !== null`. Null-price clicks skip cap logic regardless of mode.
+- **Threshold checks** — already require a numeric price. In Zero Trust, null-price clicks bypass thresholds and go straight to `'full'`.
+- **Whitelist / streaming mode / cooldown** — run before `determineFrictionLevel()`, unaffected.
+- **Intensity steps** (reason selection, cooldown timer, math challenge, type-to-confirm) — fire based on `frictionIntensity` / escalation, independent of trigger mode. A Zero Trust no-price overlay at extreme intensity gets the full gauntlet.
+- **Comparison steps** — already skipped when `priceValue === null` (line 1539-1541 in `runFrictionFlow`). No change needed.
+
+### Price Guard `'none'` Path
+
+When Price Guard silently passes a no-price click, it still logs an intercept event (`outcome: 'proceeded'`, `price: null`) so history stays complete.
+
+---
+
+## Zero Trust No-Price Overlay
+
+When Zero Trust fires on a null-price click, the overlay shows a stripped-down layout.
+
+### Shown
+
+- Channel name
+- Purchase type (button text)
+- One rotating message from the pool (randomly selected)
+- "Cancel" and "Proceed Anyway" buttons
+- All intensity steps fire after the main overlay (based on `frictionIntensity` setting)
+
+### Not Shown
+
+- Cost breakdown (no price)
+- Work-time calculation
+- Cap progress bars
+- Comparison steps
+
+### Rotating Message Pool (~16 messages, two buckets)
+
+Selection logic: random pick, no back-to-back duplicate. Alternates between buckets to avoid tonal clusters.
+
+**Matter-of-fact bucket:**
+
+1. "No price detected. That doesn't mean it's free."
+2. "We couldn't read a number. You're in Zero Trust — so we showed up anyway."
+3. "Price? No idea. But you told us to stop you every time."
+4. "Can't see what this costs. Can you?"
+5. "No price tag on this one. Zero Trust doesn't care."
+6. "We don't know the price. That's exactly why we're here."
+7. "Price not found. Zero Trust mode doesn't take days off."
+8. "Unknown cost. Known impulse risk."
+
+**Cheeky bucket:**
+
+1. "Zero Trust means zero exceptions. Even this one."
+2. "No price tag? Suspicious."
+3. "Flying blind on the cost. Good thing you brought a parachute."
+4. "Couldn't find a price. Found you clicking though."
+5. "The price is a mystery. Your spending habits are not."
+6. "No number to crunch. Just a button to question."
+7. "We can't tell you what this costs. We can tell you to think about it."
+8. "Price unknown. Wallet concern: very known."
+
+---
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add `frictionTriggerMode` to `UserSettings`, `DEFAULT_SETTINGS`, `migrateSettings()`, `sanitizeSettings()` |
+| `src/content/interceptor.ts` | Update `determineFrictionLevel()` to check trigger mode. Replace static no-price copy with rotating message pool + selection logic. |
+| `src/options/options.html` | Add segmented control for trigger mode in the Friction section |
+| `src/options/options.ts` | Wire up trigger mode control — read/write/save, aria-pressed state |
+| `docs/dev/HypeControl-TODO.md` | Mark feature complete, update version/date |
+| `docs/dev/HC-Project-Document.md` | Update friction system description to reflect trigger modes |
+
+### Files NOT Touched
+
+- `spendingTracker.ts` — no tracker logic affected
+- `interceptLogger.ts` — already handles null-price events
+- `popup.ts` / `popup.html` — no display changes
+- `logs.ts` / `logs.html` — already renders null-price events
+- `escalation.ts` — intensity escalation is independent of trigger mode
+- `detector.ts` — price detection logic unchanged

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -573,7 +573,12 @@ async function showMainOverlay(
   if (attempt.priceValue !== null && attempt.priceValue > 0) {
     priceExtra = buildCostBreakdown(attempt.priceValue, settings, tracker);
   } else {
-    priceExtra = '<p class="hc-price-note">Unable to detect price. Proceed with caution.</p>';
+    const noteEl = document.createElement('p');
+    noteEl.className = 'hc-price-note';
+    noteEl.textContent = settings.frictionTriggerMode === 'zero-trust'
+      ? pickZeroTrustMessage()
+      : 'Unable to detect price. Proceed with caution.';
+    priceExtra = noteEl.outerHTML;
   }
 
   const quickAddBtn = onWhitelistAdd

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -44,20 +44,22 @@ const ZERO_TRUST_MESSAGES_CHEEKY = [
 ];
 
 let lastZeroTrustBucket: 'factual' | 'cheeky' | null = null;
-let lastZeroTrustIndex: number = -1;
+let lastFactualIndex: number = -1;
+let lastCheekyIndex: number = -1;
 
 function pickZeroTrustMessage(): string {
-  // Alternate buckets, avoiding back-to-back duplicates within a bucket
+  // Alternate buckets; avoid repeating the same index within each bucket
   const useBucket: 'factual' | 'cheeky' = lastZeroTrustBucket === 'factual' ? 'cheeky' : 'factual';
   const pool = useBucket === 'factual' ? ZERO_TRUST_MESSAGES_FACTUAL : ZERO_TRUST_MESSAGES_CHEEKY;
+  const lastIdx = useBucket === 'factual' ? lastFactualIndex : lastCheekyIndex;
 
   let idx: number;
   do {
     idx = Math.floor(Math.random() * pool.length);
-  } while (idx === lastZeroTrustIndex && pool.length > 1);
+  } while (idx === lastIdx && pool.length > 1);
 
   lastZeroTrustBucket = useBucket;
-  lastZeroTrustIndex = idx;
+  if (useBucket === 'factual') lastFactualIndex = idx; else lastCheekyIndex = idx;
   return pool[idx];
 }
 

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1595,59 +1595,61 @@ async function runFrictionFlow(
 
   if (priceWithTax === null) {
     log('Friction flow: no price detected, skipping comparison steps');
-    return { decision: 'proceed', purchaseReason };
+    // Price Guard would never reach here (determineFrictionLevel returns 'none').
+    // Zero Trust continues to intensity steps below — fall through.
   }
 
-  // nudge: enabled items where scope is 'nudge' or 'both', limited to softNudgeSteps
-  // full: enabled items where scope is 'full' or 'both' (scope replaces the old "all items" behavior)
-  const itemPool = maxComparisons !== undefined
-    ? settings.comparisonItems
-        .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'full')
-        .slice(0, maxComparisons)
-    : settings.comparisonItems
-        .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'nudge');
+  if (priceWithTax !== null) {
+    // nudge: enabled items where scope is 'nudge' or 'both', limited to softNudgeSteps
+    // full: enabled items where scope is 'full' or 'both' (scope replaces the old "all items" behavior)
+    const itemPool = maxComparisons !== undefined
+      ? settings.comparisonItems
+          .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'full')
+          .slice(0, maxComparisons)
+      : settings.comparisonItems
+          .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'nudge');
 
-  const taxPrice = `$${priceWithTax.toFixed(2)}`;
-  const comparisonSteps: { item: ComparisonItem; display: ComparisonDisplay }[] = [];
+    const taxPrice = `$${priceWithTax.toFixed(2)}`;
+    const comparisonSteps: { item: ComparisonItem; display: ComparisonDisplay }[] = [];
 
-  for (const item of itemPool) {
-    const display = formatComparisonDisplay(item, priceWithTax, taxPrice);
-    comparisonSteps.push({ item, display });
-  }
-
-  // Total steps = 1 (main) + N (comparisons)
-  const totalSteps = 1 + comparisonSteps.length;
-
-  log(`Friction flow: ${comparisonSteps.length} comparison step(s) (${maxComparisons !== undefined ? 'nudge/enabled only' : 'full/all items'}), priceWithTax=${taxPrice}`);
-
-  // Steps 2+: Each comparison item
-  // We need a reference to the last overlay shown so we can pass it to subsequent steps.
-  // Comparison steps each create their own overlay element; after the loop we need
-  // the most-recently-created overlay for the intensity steps below.
-  // showComparisonStep creates its own overlay internally, so we capture it via a
-  // wrapper that returns it. For now, we create a placeholder overlay to reuse for
-  // the intensity steps (it will be re-populated by each step function).
-  let intensityOverlay: HTMLElement | null = null;
-
-  for (let i = 0; i < comparisonSteps.length; i++) {
-    const { item, display } = comparisonSteps[i];
-    const stepNumber = i + 2; // Step 1 was the main overlay
-
-    const decision = await showComparisonStep(item, display, stepNumber, totalSteps, attempt);
-    if (decision === 'cancel') {
-      log(`Friction flow: cancelled at Step ${stepNumber} (${item.name})`, {
-        stepsCompleted: stepNumber - 1,
-        totalSteps,
-      });
-      return { decision: 'cancel', cancelledAtStep: stepNumber };
+    for (const item of itemPool) {
+      const display = formatComparisonDisplay(item, priceWithTax, taxPrice);
+      comparisonSteps.push({ item, display });
     }
-  }
 
-  log('Friction flow: completed all comparison steps', {
-    totalSteps,
-    channel: attempt.channel,
-    rawPrice: attempt.rawPrice,
-  });
+    // Total steps = 1 (main) + N (comparisons)
+    const totalSteps = 1 + comparisonSteps.length;
+
+    log(`Friction flow: ${comparisonSteps.length} comparison step(s) (${maxComparisons !== undefined ? 'nudge/enabled only' : 'full/all items'}), priceWithTax=${taxPrice}`);
+
+    // Steps 2+: Each comparison item
+    // We need a reference to the last overlay shown so we can pass it to subsequent steps.
+    // Comparison steps each create their own overlay element; after the loop we need
+    // the most-recently-created overlay for the intensity steps below.
+    // showComparisonStep creates its own overlay internally, so we capture it via a
+    // wrapper that returns it. For now, we create a placeholder overlay to reuse for
+    // the intensity steps (it will be re-populated by each step function).
+
+    for (let i = 0; i < comparisonSteps.length; i++) {
+      const { item, display } = comparisonSteps[i];
+      const stepNumber = i + 2; // Step 1 was the main overlay
+
+      const decision = await showComparisonStep(item, display, stepNumber, totalSteps, attempt);
+      if (decision === 'cancel') {
+        log(`Friction flow: cancelled at Step ${stepNumber} (${item.name})`, {
+          stepsCompleted: stepNumber - 1,
+          totalSteps,
+        });
+        return { decision: 'cancel', cancelledAtStep: stepNumber };
+      }
+    }
+
+    log('Friction flow: completed all comparison steps', {
+      totalSteps,
+      channel: attempt.channel,
+      rawPrice: attempt.rawPrice,
+    });
+  }
 
   // ── Intensity-gated steps ─────────────────────────────────────────────
   // For steps 3+, we reuse a shared overlay element that each step re-populates.
@@ -1655,6 +1657,7 @@ async function runFrictionFlow(
   // The subsequent steps (cooldown, type-to-confirm, math) expect the overlay to
   // already be in the DOM (they only set innerHTML and apply theme).
   // So after reason selection proceeds we must re-append before the next step.
+  let intensityOverlay: HTMLElement | null = null;
   const maxPercent = computeMaxCapPercent(settings, tracker);
   const intensity = computeEscalatedIntensity(
     settings.frictionIntensity ?? 'low',

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -17,6 +17,50 @@ import { writeInterceptEvent } from '../shared/interceptLogger';
 import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
 import { loadSpendingTracker, recordPurchase } from '../shared/spendingTracker';
 
+// ── Zero Trust no-price overlay messages ────────────────────────────────
+// Two tonal buckets: matter-of-fact and cheeky. Selection alternates buckets
+// with no back-to-back duplicates.
+
+const ZERO_TRUST_MESSAGES_FACTUAL = [
+  "No price detected. That doesn't mean it's free.",
+  "We couldn't read a number. You're in Zero Trust — so we showed up anyway.",
+  "Price? No idea. But you told us to stop you every time.",
+  "Can't see what this costs. Can you?",
+  "No price tag on this one. Zero Trust doesn't care.",
+  "We don't know the price. That's exactly why we're here.",
+  "Price not found. Zero Trust mode doesn't take days off.",
+  "Unknown cost. Known impulse risk.",
+];
+
+const ZERO_TRUST_MESSAGES_CHEEKY = [
+  "Zero Trust means zero exceptions. Even this one.",
+  "No price tag? Suspicious.",
+  "Flying blind on the cost. Good thing you brought a parachute.",
+  "Couldn't find a price. Found you clicking though.",
+  "The price is a mystery. Your spending habits are not.",
+  "No number to crunch. Just a button to question.",
+  "We can't tell you what this costs. We can tell you to think about it.",
+  "Price unknown. Wallet concern: very known.",
+];
+
+let lastZeroTrustBucket: 'factual' | 'cheeky' | null = null;
+let lastZeroTrustIndex: number = -1;
+
+function pickZeroTrustMessage(): string {
+  // Alternate buckets, avoiding back-to-back duplicates within a bucket
+  const useBucket: 'factual' | 'cheeky' = lastZeroTrustBucket === 'factual' ? 'cheeky' : 'factual';
+  const pool = useBucket === 'factual' ? ZERO_TRUST_MESSAGES_FACTUAL : ZERO_TRUST_MESSAGES_CHEEKY;
+
+  let idx: number;
+  do {
+    idx = Math.floor(Math.random() * pool.length);
+  } while (idx === lastZeroTrustIndex && pool.length > 1);
+
+  lastZeroTrustBucket = useBucket;
+  lastZeroTrustIndex = idx;
+  return pool[idx];
+}
+
 /** Result returned by runFrictionFlow */
 interface FrictionResult {
   decision: OverlayDecision;
@@ -148,11 +192,19 @@ function determineFrictionLevel(
     return 'cap-bypass';
   }
 
+  if (priceValue === null || priceValue <= 0) {
+    if (settings.frictionTriggerMode === 'zero-trust') {
+      log('No price detected — Zero Trust mode: full friction applied');
+      return 'full';
+    }
+    log('No price detected — Price Guard mode: no friction applied');
+    return 'none';
+  }
+
   if (!settings.frictionThresholds.enabled) {
     log('Thresholds disabled — defaulting to full modal');
     return 'full';
   }
-  if (priceValue === null || priceValue <= 0) return 'full';
 
   const priceWithTax = Math.round(priceValue * (1 + settings.taxRate / 100) * 100) / 100;
   const t1 = settings.frictionThresholds.thresholdFloor;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1022,6 +1022,7 @@ async function getFormSettings(): Promise<UserSettings> {
     // Popup-managed fields — preserve current values
     weeklyResetDay: cachedSettings?.weeklyResetDay ?? DEFAULT_SETTINGS.weeklyResetDay,
     intensityLocked: cachedSettings?.intensityLocked ?? DEFAULT_SETTINGS.intensityLocked,
+    frictionTriggerMode: cachedSettings?.frictionTriggerMode ?? DEFAULT_SETTINGS.frictionTriggerMode,
   };
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -488,6 +488,9 @@ body {
   margin-top: 2px;
   margin-bottom: 4px;
 }
+.trigger-mode-desc {
+  padding: 0 0 4px;
+}
 .hint-link {
   color: var(--text-muted);
   text-decoration: underline;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -146,6 +146,18 @@
         </div>
         <div class="hc-row">
           <fieldset class="hc-fieldset">
+            <legend class="hc-label">Trigger Mode</legend>
+            <div class="segmented" id="friction-trigger-mode" data-pending-field="frictionTriggerMode">
+              <button class="seg-btn" data-value="price-guard">Price Guard</button>
+              <button class="seg-btn" data-value="zero-trust">Zero Trust</button>
+            </div>
+          </fieldset>
+        </div>
+        <div class="trigger-mode-desc" id="trigger-mode-desc">
+          <p class="hc-hint" id="trigger-mode-hint"></p>
+        </div>
+        <div class="hc-row">
+          <fieldset class="hc-fieldset">
             <legend class="hc-label">Intensity</legend>
             <div class="segmented" id="friction-intensity" data-pending-field="frictionIntensity">
               <button class="seg-btn" data-value="low">Low</button>

--- a/src/popup/sections/friction.ts
+++ b/src/popup/sections/friction.ts
@@ -1,4 +1,4 @@
-import { UserSettings, FrictionIntensity, DelayTimerConfig, FrictionThresholds, DEFAULT_SETTINGS } from '../../shared/types';
+import { UserSettings, FrictionIntensity, FrictionTriggerMode, DelayTimerConfig, FrictionThresholds, DEFAULT_SETTINGS } from '../../shared/types';
 import { setPendingField, getPending } from '../pendingState';
 
 function parseLocaleNumber(str: string): number {
@@ -32,6 +32,8 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
   const ceilingEl = el.querySelector<HTMLInputElement>('#threshold-ceiling')!;
   const nudgeStepsEl = el.querySelector<HTMLInputElement>('#threshold-nudge-steps')!;
   const lockEl = el.querySelector<HTMLInputElement>('#friction-intensity-lock')!;
+  const triggerModeEl = el.querySelector<HTMLElement>('#friction-trigger-mode')!;
+  const triggerModeDescEl = el.querySelector<HTMLElement>('#trigger-mode-hint')!;
   const escalationIndicatorEl = el.querySelector<HTMLElement>('#friction-escalation-indicator')!;
   const calcToggle = el.querySelector<HTMLAnchorElement>('#friction-calc-toggle')!;
   const salaryCalcPanel = el.querySelector<HTMLElement>('#friction-salary-calc')!;
@@ -44,6 +46,15 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
     container.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
       btn.classList.toggle('active', btn.dataset.value === value);
     });
+  }
+
+  const TRIGGER_MODE_DESCRIPTIONS: Record<FrictionTriggerMode, string> = {
+    'price-guard': "Friction triggers only when a price is detected. If we can't read the number, you walk.",
+    'zero-trust': "Friction on every purchase button — price or not. You asked for this.",
+  };
+
+  function updateTriggerModeDesc(mode: FrictionTriggerMode): void {
+    triggerModeDescEl.textContent = TRIGGER_MODE_DESCRIPTIONS[mode];
   }
 
   // Hourly rate
@@ -102,6 +113,16 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
   lockEl.addEventListener('change', () => {
     setPendingField('intensityLocked', lockEl.checked);
     callbacks.onLockChange?.();
+  });
+
+  // Trigger mode segmented
+  triggerModeEl.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const val = btn.dataset.value as FrictionTriggerMode;
+      setPendingField('frictionTriggerMode', val);
+      renderSegmented(triggerModeEl, val);
+      updateTriggerModeDesc(val);
+    });
   });
 
   // Delay timer toggle
@@ -166,6 +187,8 @@ export function initFriction(el: HTMLElement, callbacks: FrictionCallbacks): Fri
     hourlyRateEl.value = String(settings.hourlyRate);
     taxRateEl.value = String(settings.taxRate);
     renderSegmented(intensityEl, settings.frictionIntensity);
+    renderSegmented(triggerModeEl, settings.frictionTriggerMode);
+    updateTriggerModeDesc(settings.frictionTriggerMode);
     delayEnabledEl.checked = settings.delayTimer.enabled;
     delayDurationEl.hidden = !settings.delayTimer.enabled;
     renderSegmented(delayDurationEl, String(settings.delayTimer.seconds));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,6 +40,9 @@ export type FrictionLevel = 'none' | 'nudge' | 'full' | 'cap-bypass';
 /** User-selectable named friction intensity (how intense friction is when it triggers) */
 export type FrictionIntensity = 'low' | 'medium' | 'high' | 'extreme';
 
+/** Controls when friction triggers: price-detected only, or every purchase button */
+export type FrictionTriggerMode = 'price-guard' | 'zero-trust';
+
 /** Friction threshold tier configuration */
 export interface FrictionThresholds {
   enabled: boolean;
@@ -109,6 +112,7 @@ export interface UserSettings {
   monthlyCap: MonthlyCapConfig;
   frictionThresholds: FrictionThresholds;
   frictionIntensity: FrictionIntensity;
+  frictionTriggerMode: FrictionTriggerMode;
   delayTimer: DelayTimerConfig;
   streamingMode: StreamingModeConfig;
   toastDurationSeconds: number;
@@ -181,6 +185,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
     softNudgeSteps: 1,
   },
   frictionIntensity: 'low',
+  frictionTriggerMode: 'price-guard',
   delayTimer: {
     enabled: false,
     seconds: 10,
@@ -297,6 +302,7 @@ export function migrateSettings(saved: Partial<UserSettings>): UserSettings {
       };
     })(),
     frictionIntensity: saved.frictionIntensity ?? DEFAULT_SETTINGS.frictionIntensity,
+    frictionTriggerMode: saved.frictionTriggerMode ?? DEFAULT_SETTINGS.frictionTriggerMode,
     delayTimer: {
       ...DEFAULT_SETTINGS.delayTimer,
       ...(saved.delayTimer || {}),
@@ -400,6 +406,7 @@ export function sanitizeSettings(s: UserSettings): UserSettings {
   const softNudgeSteps = clampNum(s.frictionThresholds.softNudgeSteps, 1, 10, DEFAULT_SETTINGS.frictionThresholds.softNudgeSteps);
 
   const frictionIntensity = validEnum(s.frictionIntensity, ['low', 'medium', 'high', 'extreme'] as const, DEFAULT_SETTINGS.frictionIntensity);
+  const frictionTriggerMode = validEnum(s.frictionTriggerMode, ['price-guard', 'zero-trust'] as const, DEFAULT_SETTINGS.frictionTriggerMode);
   const delaySeconds = validEnum(s.delayTimer.seconds, [5, 10, 30, 60] as const, DEFAULT_SETTINGS.delayTimer.seconds);
   const theme = validEnum(s.theme, ['auto', 'light', 'dark'] as const, DEFAULT_SETTINGS.theme);
   const weeklyResetDay = validEnum(s.weeklyResetDay, ['monday', 'sunday'] as const, DEFAULT_SETTINGS.weeklyResetDay);
@@ -463,6 +470,7 @@ export function sanitizeSettings(s: UserSettings): UserSettings {
       softNudgeSteps,
     },
     frictionIntensity,
+    frictionTriggerMode,
     delayTimer: {
       enabled: strictBool(s.delayTimer.enabled),
       seconds: delaySeconds,


### PR DESCRIPTION
## Summary

Closes #31

- Adds a **Friction Trigger Mode** setting with two modes: **Price Guard** (default — friction only fires when a price is detected) and **Zero Trust** (friction on every purchase button regardless of price detection)
- Zero Trust no-price overlays show rotating contextual messages from a 16-message pool (two tonal buckets: matter-of-fact and cheeky)
- Intensity steps (reason selection, cooldown timer, math challenge, type-to-confirm) still fire for Zero Trust no-price overlays based on the user's intensity setting

## Test Plan

- [x] Load extension, open Twitch, click a purchase button where price IS detected — friction overlay should show as before (both modes)
- [x] In Price Guard mode, trigger a purchase button where price is NOT detected — should silently pass through (no overlay), but intercept event is still logged
- [x] In Zero Trust mode, trigger a purchase button where price is NOT detected — friction overlay should appear with a rotating message, no cost breakdown, and intensity steps should fire
- [x] Switch between Price Guard and Zero Trust in popup settings — description text updates, setting persists across sessions
- [x] Upgrade from v1.0.2 — existing users should get Price Guard as default via migration

Generated with [Claude Code](https://claude.com/claude-code)