### PR TITLE
fix(detector): prevent false-positive interception on Gifted Subscriptions tab

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-04-13
-**Current Version:** 1.0.4
+**Updated:** 2026-04-15
+**Current Version:** 1.0.5
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -300,4 +300,4 @@ Shared spendingTracker module, daily/weekly/monthly reset fix for popup, session
 
 ---
 
-_Last updated 2026-04-13 against the v1.0.4 codebase. Stream override bug fix (#32)._
+_Last updated 2026-04-15 against the v1.0.5 codebase. Firefox "Gifted Subscriptions" tab false-positive fix._

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/detector.ts
+++ b/src/content/detector.ts
@@ -114,7 +114,9 @@ function determinePurchaseType(element: HTMLElement): PurchaseType {
   if (lowerText.includes('community gift')) {
     return 'Community Gift';
   }
-  if (lowerText.includes('gift') && lowerText.includes('sub')) {
+  // "Gift N sub(s)" — quantity variant. Imperative "gift" only, never past-tense
+  // "gifted" (e.g. "Gifted Subscriptions" tab is navigation, not a purchase).
+  if (/\bgift\s+\d+\s+subs?\b/.test(lowerText)) {
     return 'Gift A Sub';
   }
   if (lowerText.includes('get bits') || lowerText.includes('buy bits')) {
@@ -340,8 +342,10 @@ export function isPurchaseButton(element: HTMLElement | null): boolean {
     if (INTERCEPT_KEYWORDS.some(keyword => str.includes(keyword))) {
       return true;
     }
-    // Check for "gift" + "sub" pattern (catches "Gift 1 sub", "Gift 5 subs", etc.)
-    if (str.includes('gift') && str.includes('sub')) {
+    // Check for "gift N sub(s)" pattern (catches "Gift 1 sub", "Gift 5 subs", etc.)
+    // Must be imperative "gift", NOT past-tense "gifted" — "gifted" means the
+    // purchase already happened (e.g. "Gifted Subscriptions" tab in Firefox).
+    if (/\bgift\s+\d+\s+subs?\b/.test(str)) {
       return true;
     }
     return false;


### PR DESCRIPTION
Replaces the overly broad `includes('gift') && includes('sub')` pattern in
`detector.ts` with an explicit regex (`/\bgift\s+\d+\s+subs?\b/`) that only
matches imperative quantity variants like "Gift 5 subs".

The loose pattern matched the "Gifted Subscriptions" tab label on Twitch's
Subscriptions page, triggering a friction overlay on what is purely navigation.
Firefox-specific because its DOM falls through to the `textContent` label path
that Chrome short-circuits via `data-a-target`.

Past-tense "gifted" is inherently different from imperative "gift" — if the
gift already happened, there's nothing to intercept.

Fixes #35