### PR TITLE
fix(ui): show Reset/Wipe/Nevermind buttons on same row

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
 **Updated:** 2026-04-15
-**Current Version:** 1.0.5
+**Current Version:** 1.0.6
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -363,14 +363,14 @@ body {
 .btn-danger {
   background: var(--danger);
   color: white;
-  border: none;
+  border: 1px solid transparent;
   border-radius: var(--radius);
   font-size: 12px;
   padding: 8px 14px;
   cursor: pointer;
 }
 .btn-danger:hover { background: var(--danger-hover); }
-.btn-sm { padding: 3px 8px; font-size: 11px; }
+.btn-sm { padding: 3px 8px; font-size: 11px; line-height: 1.4; box-sizing: border-box; }
 
 /* ─── Stat tiles ─────────────────────────────────────────── */
 .stat-tiles {
@@ -534,22 +534,21 @@ body {
   color: var(--text-muted);
 }
 
-/* ─── Confirm reset ──────────────────────────────────────── */
-.confirm-reset {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 11px;
-  color: var(--text-secondary);
-}
-.reset-summary {
-  color: var(--danger);
-  font-weight: 500;
-  line-height: 1.4;
+/* ─── Reset tracker ─────────────────────────────────────── */
+.reset-row {
+  padding: 4px 0;
 }
 .reset-actions {
   display: flex;
+  align-items: center;
   gap: 6px;
+}
+.reset-summary {
+  color: var(--danger);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin-top: 4px;
 }
 
 /* ─── Savings Calendar ──────────────────────────────────── */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -317,15 +317,13 @@
             </button>
           </div>
           <div id="calendar-container" hidden></div>
-          <div class="hc-row reset-row">
-            <button class="btn-danger btn-sm" id="btn-reset-tracker">Reset Tracker</button>
-            <div class="confirm-reset" id="confirm-reset" hidden>
-              <p class="reset-summary" id="reset-summary"></p>
-              <div class="reset-actions">
-                <button class="btn-danger btn-sm" id="btn-reset-confirm">Wipe it</button>
-                <button class="btn-sm" id="btn-reset-cancel">Nevermind</button>
-              </div>
+          <div class="reset-row">
+            <div class="reset-actions">
+              <button class="btn-danger btn-sm" id="btn-reset-tracker">Reset Tracker</button>
+              <button class="btn-danger btn-sm" id="btn-reset-confirm" hidden>Wipe it</button>
+              <button class="btn-secondary btn-sm" id="btn-reset-cancel" hidden>Nevermind</button>
             </div>
+            <p class="reset-summary" id="reset-summary" hidden></p>
           </div>
         </div>
       </section>

--- a/src/popup/sections/limits.ts
+++ b/src/popup/sections/limits.ts
@@ -19,9 +19,9 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
   const cooldownDurationEl = el.querySelector<HTMLSelectElement>('#cooldown-duration')!;
   const trackerDailyEl = el.querySelector<HTMLElement>('#tracker-daily')!;
   const resetBtnEl = el.querySelector<HTMLButtonElement>('#btn-reset-tracker')!;
-  const confirmResetEl = el.querySelector<HTMLElement>('#confirm-reset')!;
   const resetConfirmBtnEl = el.querySelector<HTMLButtonElement>('#btn-reset-confirm')!;
   const resetCancelBtnEl = el.querySelector<HTMLButtonElement>('#btn-reset-cancel')!;
+  const resetSummaryEl = el.querySelector<HTMLElement>('#reset-summary')!;
   const weeklyCapEnabledEl = el.querySelector<HTMLInputElement>('#weekly-cap-enabled')!;
   const weeklyCapAmountEl = el.querySelector<HTMLInputElement>('#weekly-cap-amount')!;
   const weeklyResetDayRowEl = el.querySelector<HTMLElement>('#weekly-reset-day-row')!;
@@ -104,7 +104,16 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
   });
 
   // Reset tracker (inline confirmation with dynamic summary)
-  const resetSummaryEl = el.querySelector<HTMLElement>('#reset-summary')!;
+  function showConfirm(): void {
+    resetConfirmBtnEl.hidden = false;
+    resetCancelBtnEl.hidden = false;
+    resetSummaryEl.hidden = false;
+  }
+  function hideConfirm(): void {
+    resetConfirmBtnEl.hidden = true;
+    resetCancelBtnEl.hidden = true;
+    resetSummaryEl.hidden = true;
+  }
 
   resetBtnEl.addEventListener('click', async () => {
     const result = await chrome.storage.local.get(SPENDING_KEY);
@@ -124,17 +133,14 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
       resetSummaryEl.textContent = `This wipes ${parts.join(', ')} back to $0. Cooldown timer resets too.`;
     }
 
-    resetBtnEl.hidden = true;
-    confirmResetEl.hidden = false;
+    showConfirm();
   });
   resetCancelBtnEl.addEventListener('click', () => {
-    confirmResetEl.hidden = true;
-    resetBtnEl.hidden = false;
+    hideConfirm();
   });
   resetConfirmBtnEl.addEventListener('click', async () => {
     await chrome.storage.local.set({ [SPENDING_KEY]: DEFAULT_SPENDING_TRACKER });
-    confirmResetEl.hidden = true;
-    resetBtnEl.hidden = false;
+    hideConfirm();
     await refreshTracker();
   });
 


### PR DESCRIPTION
## Summary
- All three reset buttons (Reset Tracker, Wipe it, Nevermind) now sit in a single flex row instead of swapping between separate UI states
- "Wipe it" and "Nevermind" start hidden and appear inline next to "Reset Tracker" when clicked
- Summary text drops below the button row
- Normalized `btn-danger` border (`1px solid transparent`) to match `btn-secondary` box model so all `btn-sm` buttons render at the same height

## Test plan
- [ ] Open popup > Limits section — "Reset Tracker" button visible
- [ ] Click "Reset Tracker" — "Wipe it" and "Nevermind" appear on the same row
- [ ] Click "Nevermind" — confirm buttons hide, Reset Tracker stays
- [ ] Click "Reset Tracker" again, then "Wipe it" — tracker resets, confirm buttons hide
- [ ] Verify all three buttons are the same height when visible together

Generated with [Claude Code](https://claude.com/claude-code)