### PR TITLE
fix(ui): lock sidebar nav during onboarding wizard

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
 **Updated:** 2026-04-15
-**Current Version:** 1.0.6
+**Current Version:** 1.0.7
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -300,4 +300,10 @@ Shared spendingTracker module, daily/weekly/monthly reset fix for popup, session
 
 ---
 
-_Last updated 2026-04-15 against the v1.0.5 codebase. Firefox "Gifted Subscriptions" tab false-positive fix._
+## NAV LOCK DURING ONBOARDING (v1.0.7)
+
+Sidebar nav was clickable during the onboarding wizard because `.hc-nav { display: flex }` overrode the `hidden` HTML attribute. Added `.hc-nav[hidden] { display: none; }` rule.
+
+---
+
+_Last updated 2026-04-15 against the v1.0.7 codebase. Nav lock during onboarding wizard._

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -136,6 +136,7 @@ body {
   border-left: 1px solid var(--border-color);
   gap: 2px;
 }
+.hc-nav[hidden] { display: none; }
 .nav-label {
   width: 100%;
   padding: 7px 10px;


### PR DESCRIPTION
## Summary
- `.hc-nav { display: flex }` overrode the HTML `hidden` attribute, leaving the sidebar nav clickable while the onboarding wizard was active
- Added `.hc-nav[hidden] { display: none; }` to properly hide it during onboarding

## Test plan
- [ ] Fresh install or clear `hcSettings` from storage to trigger onboarding wizard
- [ ] Verify sidebar nav is not visible or clickable during the wizard
- [ ] Complete or skip the wizard — nav should reappear and function normally

Generated with [Claude Code](https://claude.com/claude-code)