### PR TITLE
fix: scope HC to www.twitch.tv only (#40)

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
 **Updated:** 2026-04-15
-**Current Version:** 1.0.7
+**Current Version:** 1.0.8
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -312,4 +312,10 @@ Sidebar nav was clickable during the onboarding wizard because `.hc-nav { displa
 
 ---
 
-_Last updated 2026-04-15 against the v1.0.7 codebase. Nav lock during onboarding wizard._
+## SUBDOMAIN SCOPE FIX (v1.0.8)
+
+Manifest match patterns narrowed from `*.twitch.tv` to `www.twitch.tv` in both Chrome and Firefox manifests. HC no longer activates on docs.twitch.tv, dashboard.twitch.tv, or other non-spending subdomains. (#40)
+
+---
+
+_Last updated 2026-04-15 against the v1.0.8 codebase. Subdomain scope fix._

--- a/docs/superpowers/plans/2026-04-15-scope-twitch-subdomain.md
+++ b/docs/superpowers/plans/2026-04-15-scope-twitch-subdomain.md
@@ -1,0 +1,167 @@
+# Scope HC to www.twitch.tv Only — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop HC from activating on non-spending Twitch subdomains (docs, dashboard, clips, embed, etc.)
+
+**Architecture:** Replace the wildcard `*.twitch.tv` match pattern with `www.twitch.tv` in all manifest match fields. Pure config change — no source code modifications.
+
+**Tech Stack:** Chrome Extension Manifest V3 JSON
+
+**Spec:** `docs/superpowers/specs/2026-04-15-scope-twitch-subdomain-design.md`
+
+**Branch:** `fix/scope-twitch-subdomain-40`
+
+**IMPORTANT:** Do NOT bump versions. Versioning is handled separately after implementation.
+
+---
+
+### Task 1: Update Chrome manifest
+
+**Files:**
+- Modify: `manifest.json:17` (`host_permissions`)
+- Modify: `manifest.json:24` (`content_scripts[0].matches`)
+- Modify: `manifest.json:39` (`web_accessible_resources[0].matches`)
+
+- [ ] **Step 1: Replace all three wildcard patterns in manifest.json**
+
+Replace every instance of `https://*.twitch.tv/*` with `https://www.twitch.tv/*` in `manifest.json`. There are exactly 3 occurrences:
+
+```json
+// Line 17 — host_permissions
+"host_permissions": [
+    "https://www.twitch.tv/*"
+],
+
+// Line 24 — content_scripts
+"matches": ["https://www.twitch.tv/*"],
+
+// Line 39 — web_accessible_resources
+"matches": ["https://www.twitch.tv/*"]
+```
+
+- [ ] **Step 2: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8')); console.log('valid')"`
+Expected: `valid`
+
+- [ ] **Step 3: Verify exactly 3 replacements, 0 wildcards remain**
+
+Run: `grep -c "www.twitch.tv" manifest.json && grep -c "\\*.twitch.tv" manifest.json || echo "0 wildcards remain"`
+Expected: `3` then `0 wildcards remain`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add manifest.json
+git commit -m "fix: scope Chrome manifest to www.twitch.tv only (#40)"
+```
+
+---
+
+### Task 2: Update Firefox manifest
+
+**Files:**
+- Modify: `manifest.firefox.json:25` (`host_permissions`)
+- Modify: `manifest.firefox.json:32` (`content_scripts[0].matches`)
+- Modify: `manifest.firefox.json:47` (`web_accessible_resources[0].matches`)
+
+- [ ] **Step 1: Replace all three wildcard patterns in manifest.firefox.json**
+
+Replace every instance of `https://*.twitch.tv/*` with `https://www.twitch.tv/*` in `manifest.firefox.json`. There are exactly 3 occurrences:
+
+```json
+// Line 25 — host_permissions
+"host_permissions": [
+    "https://www.twitch.tv/*"
+],
+
+// Line 32 — content_scripts
+"matches": ["https://www.twitch.tv/*"],
+
+// Line 47 — web_accessible_resources
+"matches": ["https://www.twitch.tv/*"]
+```
+
+- [ ] **Step 2: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('manifest.firefox.json','utf8')); console.log('valid')"`
+Expected: `valid`
+
+- [ ] **Step 3: Verify exactly 3 replacements, 0 wildcards remain**
+
+Run: `grep -c "www.twitch.tv" manifest.firefox.json && grep -c "\\*.twitch.tv" manifest.firefox.json || echo "0 wildcards remain"`
+Expected: `3` then `0 wildcards remain`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add manifest.firefox.json
+git commit -m "fix: scope Firefox manifest to www.twitch.tv only (#40)"
+```
+
+---
+
+### Task 3: Version bump and build
+
+**Files:**
+- Modify: `manifest.json:4` (`version`)
+- Modify: `package.json` (`version`)
+
+- [ ] **Step 1: Bump patch version in both manifest.json and package.json**
+
+Bump from `1.0.7` to `1.0.8` in `manifest.json` line 4 and `package.json`.
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: Clean build with no errors. If build fails, stop and tell the user to run it manually.
+
+- [ ] **Step 3: Commit version bump**
+
+```bash
+git add manifest.json package.json
+git commit -m "chore: bump version to 1.0.8"
+```
+
+---
+
+### Task 4: Update project docs
+
+**Files:**
+- Modify: `docs/dev/HypeControl-TODO.md`
+- Modify: `docs/dev/HC-Project-Document.md` (if relevant section exists)
+
+- [ ] **Step 1: Add entry to HypeControl-TODO.md**
+
+Add a completed section after the NAV LOCK entry:
+
+```markdown
+## SUBDOMAIN SCOPE FIX (v1.0.8)
+
+Manifest match patterns narrowed from `*.twitch.tv` to `www.twitch.tv` in both Chrome and Firefox manifests. HC no longer activates on docs.twitch.tv, dashboard.twitch.tv, or other non-spending subdomains. (#40)
+```
+
+Update the header: `Current Version: 1.0.8`, `Updated: 2026-04-15`.
+Update the footer timestamp.
+
+- [ ] **Step 2: Commit doc updates**
+
+```bash
+git add docs/dev/HypeControl-TODO.md docs/dev/HC-Project-Document.md
+git commit -m "docs: document subdomain scope fix (#40)"
+```
+
+---
+
+### Task 5: Push and open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin fix/scope-twitch-subdomain-40
+```
+
+- [ ] **Step 2: Open PR referencing issue #40**
+
+Open PR with title `fix: scope HC to www.twitch.tv only (#40)` and stop. Do not merge.

--- a/docs/superpowers/specs/2026-04-15-scope-twitch-subdomain-design.md
+++ b/docs/superpowers/specs/2026-04-15-scope-twitch-subdomain-design.md
@@ -1,0 +1,43 @@
+# Fix: Scope HC to www.twitch.tv Only (#40)
+
+**Date:** 2026-04-15
+**Issue:** [#40](https://github.com/Ktulue/HypeControl/issues/40)
+**Type:** Bug fix
+
+## Problem
+
+HC uses `https://*.twitch.tv/*` in both manifests, causing the content script to inject on every Twitch subdomain — `docs.twitch.tv`, `dashboard.twitch.tv`, `clips.twitch.tv`, etc. The HC shield appears on pages where no spending is possible.
+
+## Decision
+
+Manifest-only fix. Replace `https://*.twitch.tv/*` with `https://www.twitch.tv/*` in all match patterns. No runtime code changes.
+
+### Alternatives considered
+
+- **Runtime URL guard in content script:** Rejected. Solves a manifest problem with runtime code. Script still loads on every subdomain before bailing out.
+- **Manifest + runtime guard:** Rejected. Redundant — manifest match is authoritative.
+
+## Changes
+
+### `manifest.json` — 3 locations
+
+| Field | Before | After |
+|---|---|---|
+| `host_permissions` | `https://*.twitch.tv/*` | `https://www.twitch.tv/*` |
+| `content_scripts[0].matches` | `https://*.twitch.tv/*` | `https://www.twitch.tv/*` |
+| `web_accessible_resources[0].matches` | `https://*.twitch.tv/*` | `https://www.twitch.tv/*` |
+
+### `manifest.firefox.json` — same 3 locations
+
+Identical changes.
+
+## Edge Cases
+
+- **Bare `twitch.tv` (no www):** Twitch 301-redirects to `www.twitch.tv`. The manifest match catches it after redirect.
+- **Future spending subdomains:** If Twitch moves purchases to a subdomain, add it to manifests in a future release.
+
+## Testing
+
+1. Load unpacked extension.
+2. Visit `dashboard.twitch.tv` — no HC shield.
+3. Visit `www.twitch.tv/<channel>` — HC shield present, interception works normally.

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -22,14 +22,14 @@
     "tabs"
   ],
   "host_permissions": [
-    "https://*.twitch.tv/*"
+    "https://www.twitch.tv/*"
   ],
   "background": {
     "scripts": ["serviceWorker.js"]
   },
   "content_scripts": [
     {
-      "matches": ["https://*.twitch.tv/*"],
+      "matches": ["https://www.twitch.tv/*"],
       "js": ["content.js"],
       "css": ["content.css"],
       "run_at": "document_idle"
@@ -44,7 +44,7 @@
         "assets/fonts/SpaceGrotesk-SemiBold.woff2",
         "assets/fonts/SpaceGrotesk-Bold.woff2"
       ],
-      "matches": ["https://*.twitch.tv/*"]
+      "matches": ["https://www.twitch.tv/*"]
     }
   ],
   "action": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/manifest.json
+++ b/manifest.json
@@ -14,14 +14,14 @@
     "tabs"
   ],
   "host_permissions": [
-    "https://*.twitch.tv/*"
+    "https://www.twitch.tv/*"
   ],
   "background": {
     "service_worker": "serviceWorker.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://*.twitch.tv/*"],
+      "matches": ["https://www.twitch.tv/*"],
       "js": ["content.js"],
       "css": ["content.css"],
       "run_at": "document_idle"
@@ -36,7 +36,7 @@
         "assets/fonts/SpaceGrotesk-SemiBold.woff2",
         "assets/fonts/SpaceGrotesk-Bold.woff2"
       ],
-      "matches": ["https://*.twitch.tv/*"]
+      "matches": ["https://www.twitch.tv/*"]
     }
   ],
   "action": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",


### PR DESCRIPTION
## Summary
- Narrowed manifest match patterns from `*.twitch.tv` to `www.twitch.tv` in both Chrome and Firefox manifests
- HC no longer activates on `docs.twitch.tv`, `dashboard.twitch.tv`, `clips.twitch.tv`, or other non-spending subdomains
- Pure config change — no source code modifications

Closes #40

## Test plan
- [ ] Load unpacked extension, visit `dashboard.twitch.tv` — no HC shield
- [ ] Visit `www.twitch.tv/<channel>` — HC shield present, interception works normally

Generated with [Claude Code](https://claude.com/claude-code)