### PR TITLE
fix: close type-to-confirm paste bypass (#49) + cut v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.1] - 2026-04-28
+
+### Fixed
+- **Type-to-confirm paste bypass closed (#49).** Pasting, dropping, or autofilling the confirmation phrase no longer enables the Confirm button. Blocked vectors: keyboard paste (Ctrl/Cmd+V), right-click paste, drag-and-drop into the input, and `execCommand`/IME paste paths via `beforeinput`. The displayed phrase is no longer mouse-selectable, closing the drag-the-prompt vector. Password-manager autofill is suppressed via `name="hc-no-autofill"`, `data-1p-ignore`, and `data-lpignore="true"` hints. Caught cheat attempts trigger a Newman-flavored callout from a 4-line random pool.
+- **Screen-reader announcement reliability for the new callout.** The `role="alert"` element flips visible *before* its text is set, so Chrome+NVDA reliably fires the live-region announcement.
+
+---
 ## [1.1.0] - 2026-04-24
 
 ### Changed

--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,7 +1,7 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-04-24
-**Current Version:** 1.1.0
+**Updated:** 2026-04-27
+**Current Version:** 1.1.1
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
 ---
@@ -349,4 +349,10 @@ Lockstep minor bump across all three version files (`manifest.json`, `manifest.f
 
 ---
 
-_Last updated 2026-04-24 against the v1.1.0 codebase. Dual-platform release cut._
+## TYPE-TO-CONFIRM PASTE BYPASS FIX (v1.1.1)
+
+Closed the copy/paste bypass on the type-to-confirm friction step. `paste`, `drop`, and paste-flavored `beforeinput` events on the input are now blocked; `.hc-confirm-phrase` flipped from `user-select: all` to `user-select: none` so the prompt itself can't be dragged into the input; three autofill-suppression attributes (`name="hc-no-autofill"`, `data-1p-ignore`, `data-lpignore="true"`) discourage password managers. Caught cheats trigger a Newman-flavored callout from a 4-line random pool — "Ah ah ah. You didn't type the magic phrase." (#49)
+
+---
+
+_Last updated 2026-04-27 against the v1.1.1 codebase. Type-to-confirm paste bypass closed (#49)._

--- a/docs/dev/superpowers/plans/2026-04-27-type-to-confirm-paste-bypass.md
+++ b/docs/dev/superpowers/plans/2026-04-27-type-to-confirm-paste-bypass.md
@@ -1,0 +1,638 @@
+# Type-to-Confirm Paste Bypass — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Do NOT bump versions mid-plan.** Only the final task touches version numbers. Subagents working on earlier tasks must leave `manifest.json`, `manifest.firefox.json`, and `package.json` alone.
+
+**Goal:** Fix [#49](https://github.com/Ktulue/HypeControl/issues/49) — close the copy/paste bypass on the type-to-confirm friction step. Block paste, drop, and `beforeinput` paste-flavored events on the input; make the displayed phrase unselectable; flash a Newman-flavored callout when a cheat attempt is caught.
+
+**Architecture:** Pure UI/event hardening inside `showTypeToConfirmStep()`. One CSS change closes the drag-the-prompt vector; three event listeners route through a single `triggerCheatCallout()` helper that clears the input, re-disables Confirm, and flashes a randomized line from a fixed copy pool via `textContent`. No new settings, types, storage, or migrations.
+
+**Tech Stack:** TypeScript, webpack, Chrome MV3, Firefox MV3, no test framework for content scripts — verify in-browser per the spec's manual test plan.
+
+**Spec:** `docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md`
+
+**Branch:** `fix/type-to-confirm-paste-bypass` (already created — spec already committed)
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/content/styles.css` — flip `.hc-confirm-phrase` to `user-select: none`; add `.hc-cheat-callout` styles
+- `src/content/interceptor.ts` — add cheat-callout pool + picker; modify the rendered HTML inside `showTypeToConfirmStep()`; wire paste/drop/beforeinput listeners; hide callout on legitimate input
+- `manifest.json` + `manifest.firefox.json` + `package.json` — version bump (final task only)
+- `docs/dev/HypeControl-TODO.md` — mark issue #49 fix completed
+- `docs/dev/HC-Project-Document.md` — update friction-overlay section if status text changed
+
+No new files.
+
+---
+
+## Task 1: Make displayed phrase unselectable (CSS)
+
+This task lands first because it's a one-line change that closes the drag-the-prompt bypass entirely. Even if everything else stalled, this would be a partial fix on its own.
+
+**Files:**
+- Modify: `src/content/styles.css:718-730` (the `.hc-confirm-phrase` rule)
+
+- [ ] **Step 1: Flip `user-select` from `all` to `none` and add the WebKit prefix**
+
+In `src/content/styles.css`, locate the `.hc-confirm-phrase` rule (around line 718). Change the last property line and add a sibling property:
+
+Before:
+```css
+.hc-confirm-phrase {
+  display: inline-block;
+  font-family: var(--hc-font);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--hc-primary-text);
+  background: rgba(var(--hc-primary-rgb), 0.12);
+  border: 1px solid rgba(var(--hc-primary-rgb), 0.3);
+  border-radius: 4px;
+  padding: 6px 14px;
+  margin: 12px 0 16px;
+  user-select: all;
+}
+```
+
+After:
+```css
+.hc-confirm-phrase {
+  display: inline-block;
+  font-family: var(--hc-font);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--hc-primary-text);
+  background: rgba(var(--hc-primary-rgb), 0.12);
+  border: 1px solid rgba(var(--hc-primary-rgb), 0.3);
+  border-radius: 4px;
+  padding: 6px 14px;
+  margin: 12px 0 16px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+```
+
+- [ ] **Step 2: Verify the change builds**
+
+Run: `npm run build`
+
+Expected: webpack completes with no errors. The CSS bundle in `dist/` reflects the change. (You don't need to load the extension yet — Task 7 covers manual verification.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/styles.css
+git commit -m "fix(ui): make type-to-confirm phrase unselectable (#49)"
+```
+
+---
+
+## Task 2: Add `.hc-cheat-callout` styles
+
+**Files:**
+- Modify: `src/content/styles.css` (insert a new rule directly after `.hc-confirm-input::placeholder` at ~line 754)
+
+- [ ] **Step 1: Append the new rule**
+
+In `src/content/styles.css`, immediately after the `.hc-confirm-input::placeholder` block (which ends around line 754), insert:
+
+```css
+.hc-cheat-callout {
+  margin-top: 8px;
+  font-family: var(--hc-font);
+  font-size: 13px;
+  color: var(--hc-danger);
+  font-weight: 600;
+  text-align: center;
+}
+```
+
+This rule sits between the type-to-confirm inputs and the math-challenge styles. The `--hc-font` and `--hc-danger` tokens already exist in the project's CSS variables (used elsewhere in the same file).
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+
+Expected: clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/styles.css
+git commit -m "fix(ui): add cheat-callout style for type-to-confirm (#49)"
+```
+
+---
+
+## Task 3: Add the cheat-callout copy pool and picker
+
+**Files:**
+- Modify: `src/content/interceptor.ts` (just below `TYPE_TO_CONFIRM_PHRASE` at line 1106)
+
+- [ ] **Step 1: Insert the constants**
+
+In `src/content/interceptor.ts`, find this line (around line 1106):
+
+```typescript
+const TYPE_TO_CONFIRM_PHRASE = 'I want to buy this';
+```
+
+Immediately after it, add:
+
+```typescript
+const CHEAT_CALLOUT_LINES: readonly string[] = [
+  "Ah ah ah. You didn't type the magic phrase.",
+  "Ah ah ah — pasting isn't typing.",
+  'The friction is the feature. Hands on keyboard.',
+  'Nice try. Hands on keyboard.',
+];
+
+function pickCheatLine(): string {
+  return CHEAT_CALLOUT_LINES[Math.floor(Math.random() * CHEAT_CALLOUT_LINES.length)];
+}
+```
+
+Note the mixed quote styles: lines containing apostrophes (`didn't`, `isn't`) use double quotes to avoid escaping; the others use single quotes to match the rest of the file.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+
+Expected: no new errors. The constants are declared but not yet referenced — TS treats unused module-scoped consts as valid.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "fix(interceptor): add cheat-callout copy pool and picker (#49)"
+```
+
+---
+
+## Task 4: Update the rendered HTML inside `showTypeToConfirmStep()`
+
+This task hardens the input element against autofill/password-manager fills and adds the callout DOM node. The listeners come in Task 5.
+
+**Files:**
+- Modify: `src/content/interceptor.ts:1116-1141` (the template literal in `showTypeToConfirmStep`)
+
+- [ ] **Step 1: Replace the rendered HTML**
+
+In `src/content/interceptor.ts`, find the `overlay.innerHTML = ...` block at the start of `showTypeToConfirmStep` (around line 1116). The current block looks like:
+
+```typescript
+  overlay.innerHTML = `
+    <div class="hc-modal">
+      <div class="hc-header">
+        <span class="hc-icon">⌨️</span>
+        <h2 class="hc-title" id="hc-overlay-heading">Type to confirm</h2>
+      </div>
+      <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
+        <p class="hc-message">To proceed, type the following phrase exactly:</p>
+        <p class="hc-confirm-phrase">${TYPE_TO_CONFIRM_PHRASE}</p>
+        <input
+          type="text"
+          class="hc-confirm-input"
+          id="hc-confirm-input"
+          placeholder="Type the phrase above..."
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </div>
+      <div class="hc-actions">
+        <button class="hc-btn hc-btn-cancel" data-action="cancel">Cancel</button>
+        <button class="hc-btn hc-btn-proceed" data-action="proceed" disabled aria-disabled="true" style="opacity: 0.4; cursor: not-allowed;">
+          Confirm
+        </button>
+      </div>
+    </div>
+  `;
+```
+
+Replace it with:
+
+```typescript
+  overlay.innerHTML = `
+    <div class="hc-modal">
+      <div class="hc-header">
+        <span class="hc-icon">⌨️</span>
+        <h2 class="hc-title" id="hc-overlay-heading">Type to confirm</h2>
+      </div>
+      <div class="hc-content" id="hc-overlay-desc" style="text-align: center;">
+        <p class="hc-message">To proceed, type the following phrase exactly:</p>
+        <p class="hc-confirm-phrase">${TYPE_TO_CONFIRM_PHRASE}</p>
+        <input
+          type="text"
+          class="hc-confirm-input"
+          id="hc-confirm-input"
+          placeholder="Type the phrase above..."
+          autocomplete="off"
+          spellcheck="false"
+          name="hc-no-autofill"
+          data-1p-ignore
+          data-lpignore="true"
+        />
+        <p class="hc-cheat-callout" id="hc-cheat-callout" role="alert" style="display: none;"></p>
+      </div>
+      <div class="hc-actions">
+        <button class="hc-btn hc-btn-cancel" data-action="cancel">Cancel</button>
+        <button class="hc-btn hc-btn-proceed" data-action="proceed" disabled aria-disabled="true" style="opacity: 0.4; cursor: not-allowed;">
+          Confirm
+        </button>
+      </div>
+    </div>
+  `;
+```
+
+Three changes:
+- Three new attributes on the `<input>`: `name="hc-no-autofill"`, `data-1p-ignore`, `data-lpignore="true"`. These tell 1Password / LastPass / Bitwarden to skip the field.
+- One new element after the input: `<p class="hc-cheat-callout" id="hc-cheat-callout" role="alert" style="display: none;"></p>`. Empty `textContent` — the listeners populate it.
+- The `${TYPE_TO_CONFIRM_PHRASE}` interpolation is unchanged. It's a hard-coded module constant, not user input — no XSS risk.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "fix(interceptor): add callout element and autofill-suppression attrs (#49)"
+```
+
+---
+
+## Task 5: Wire paste/drop/beforeinput listeners and `triggerCheatCallout()`
+
+This is the core behavior change. Three new event listeners route through one shared helper.
+
+**Files:**
+- Modify: `src/content/interceptor.ts:1145-1202` (the `Promise` body inside `showTypeToConfirmStep`)
+
+- [ ] **Step 1: Add the `calloutEl` reference and `triggerCheatCallout()` helper**
+
+Find the `return new Promise((resolve) => {` block inside `showTypeToConfirmStep` (around line 1145). After the existing `proceedBtn` lookup line and before the `finish` declaration, the structure becomes:
+
+```typescript
+  return new Promise((resolve) => {
+    let resolved = false;
+    const previousFocus = document.activeElement as HTMLElement | null;
+    const inputEl = overlay.querySelector('#hc-confirm-input') as HTMLInputElement | null;
+    const proceedBtn = overlay.querySelector('[data-action="proceed"]') as HTMLButtonElement | null;
+    const calloutEl = overlay.querySelector('#hc-cheat-callout') as HTMLElement | null;
+
+    const triggerCheatCallout = () => {
+      if (!inputEl) return;
+      inputEl.value = '';
+      if (proceedBtn) {
+        proceedBtn.disabled = true;
+        proceedBtn.setAttribute('aria-disabled', 'true');
+        proceedBtn.style.opacity = '0.4';
+        proceedBtn.style.cursor = 'not-allowed';
+      }
+      if (calloutEl) {
+        calloutEl.textContent = pickCheatLine();
+        calloutEl.style.display = '';
+      }
+      inputEl.focus();
+      log('Type-to-confirm: paste/drop bypass attempt blocked');
+    };
+
+    const finish = (decision: 'cancel' | 'proceed') => {
+```
+
+Three additions: the `calloutEl` lookup, the `triggerCheatCallout` helper, and an empty line before `finish`. Everything else in the block stays identical.
+
+The helper uses `textContent` (not `innerHTML`) per the project's stored XSS feedback rule. The lines in the pool are static module constants, but the project's policy is "always `textContent` for dynamic strings" — follow it for consistency.
+
+- [ ] **Step 2: Wire `paste` and `drop` listeners**
+
+Below the existing `inputEl?.addEventListener('input', ...)` block (which currently handles match-checking around line 1160), add two new listeners. The diff is:
+
+Before (current, around lines 1160-1168):
+```typescript
+    inputEl?.addEventListener('input', () => {
+      const matches = (inputEl.value.trim().toLowerCase() === TYPE_TO_CONFIRM_PHRASE.toLowerCase());
+      if (proceedBtn) {
+        proceedBtn.disabled = !matches;
+        proceedBtn.setAttribute('aria-disabled', String(!matches));
+        proceedBtn.style.opacity = matches ? '' : '0.4';
+        proceedBtn.style.cursor = matches ? '' : 'not-allowed';
+      }
+    });
+```
+
+After:
+```typescript
+    inputEl?.addEventListener('input', () => {
+      if (calloutEl) calloutEl.style.display = 'none';
+      const matches = (inputEl.value.trim().toLowerCase() === TYPE_TO_CONFIRM_PHRASE.toLowerCase());
+      if (proceedBtn) {
+        proceedBtn.disabled = !matches;
+        proceedBtn.setAttribute('aria-disabled', String(!matches));
+        proceedBtn.style.opacity = matches ? '' : '0.4';
+        proceedBtn.style.cursor = matches ? '' : 'not-allowed';
+      }
+    });
+
+    inputEl?.addEventListener('paste', (e) => {
+      e.preventDefault();
+      triggerCheatCallout();
+    });
+
+    inputEl?.addEventListener('drop', (e) => {
+      e.preventDefault();
+      triggerCheatCallout();
+    });
+
+    inputEl?.addEventListener('beforeinput', (e) => {
+      const ev = e as InputEvent;
+      if (
+        ev.inputType === 'insertFromPaste' ||
+        ev.inputType === 'insertFromDrop' ||
+        ev.inputType === 'insertReplacementText'
+      ) {
+        e.preventDefault();
+        triggerCheatCallout();
+      }
+    });
+```
+
+Two specific changes inside the `input` listener and three brand-new listeners:
+1. The new `if (calloutEl) calloutEl.style.display = 'none';` line at the top of the existing `input` listener hides the callout on every legitimate keystroke.
+2. The new `paste`, `drop`, and `beforeinput` listeners each call `e.preventDefault()` and route through `triggerCheatCallout()`.
+
+The `beforeinput` listener filters by `inputType` so legitimate keystrokes (which have `inputType === 'insertText'`) pass through untouched. It catches `execCommand('insertText')`, drag-drop replacements, and exotic IME paste paths.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+
+Expected: no errors. `InputEvent` is a built-in DOM type; no import needed.
+
+- [ ] **Step 4: Verify webpack build (Chrome target)**
+
+Run: `npm run build`
+
+Expected: clean compile, `dist/` rebuilt.
+
+- [ ] **Step 5: Verify webpack build (Firefox target)**
+
+Run: `npm run build:firefox`
+
+Expected: clean compile. The Firefox build path is mandatory because the issue reporter is on Zen/Firefox; we must not regress that target.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "fix(interceptor): block paste/drop/beforeinput on type-to-confirm (#49)"
+```
+
+---
+
+## Task 6: Run Jest suite (regression check)
+
+The fix doesn't add tests, but the existing Jest suite must still pass — `interceptor.ts` is imported transitively by some shared modules' test paths via type imports.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+
+Expected: all suites pass. If anything breaks, the failure is unrelated to this fix (no production code in the test paths was touched) — investigate before proceeding.
+
+---
+
+## Task 7: Manual verification in-browser
+
+Follow the spec's 11-point testing plan. This is the primary verification — there are no automated tests for content-script overlay behavior in this project.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Load the unpacked extension (Chrome)**
+
+In Chrome: `chrome://extensions` → Developer Mode on → "Load unpacked" → select the `dist/` folder. Reload the extension if it was already loaded.
+
+- [ ] **Step 2: Trigger a friction overlay that includes the type-to-confirm step**
+
+Configure friction in the extension popup so the type-to-confirm step appears (e.g., set friction intensity to whatever level includes the typing step in the project's current friction ladder — refer to `src/content/interceptor.ts` step ordering if unsure). On Twitch, attempt a Bits cheer or sub gift to trigger the overlay. Click through any preceding steps until the type-to-confirm step is shown.
+
+- [ ] **Step 3: Walk the spec's 11-point manual test plan**
+
+Open `docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md` and run each numbered test in the "Testing Plan" section:
+
+1. Keyboard paste blocked
+2. Right-click paste blocked
+3. Drag-and-drop the prompt phrase blocked (CSS prevents selection)
+4. Drag-and-drop external text blocked
+5. `beforeinput` defense-in-depth (devtools `execCommand('insertText', false, ...)`)
+6. Autofill / password manager
+7. Legitimate typing still works
+8. Callout hides on resumed typing
+9. Rapid repeated paste attempts (callout text rotates)
+10. Cancel still works
+11. No regression in math challenge
+
+For each item, confirm the expected result. If any test fails, fix before proceeding.
+
+- [ ] **Step 4: Repeat in Firefox**
+
+Build the Firefox bundle (`npm run build:firefox` already produced it), then load `dist/` via `about:debugging` → "This Firefox" → "Load Temporary Add-on" → select any file in `dist/`. Re-run the same 11-point plan in Firefox. The reporter's environment is Zen (Firefox-based), so a Firefox pass is non-negotiable.
+
+- [ ] **Step 5: No commit needed**
+
+Manual verification has no diff. Move on if all tests pass.
+
+---
+
+## Task 8: Update project docs
+
+Per project convention (CLAUDE.md "Post-Work Updates"), update the TODO and project document before bumping the version.
+
+**Files:**
+- Modify: `docs/dev/HypeControl-TODO.md`
+- Modify: `docs/dev/HC-Project-Document.md` (only if a status changed)
+
+- [ ] **Step 1: Update HypeControl-TODO.md**
+
+Open `docs/dev/HypeControl-TODO.md`. Update:
+- The `Updated` date in the header to today (2026-04-27)
+- The `Current Version` field to `1.1.1`
+- Add (or check off, if already listed) an entry for "Issue #49 — Type-to-confirm paste bypass closed (paste/drop/beforeinput blocked, displayed phrase unselectable, cheeky callout)" under whatever section matches the project's recent-fixes structure
+- Update the footer timestamp
+
+- [ ] **Step 2: Update HC-Project-Document.md (only if status changed)**
+
+Open `docs/dev/HC-Project-Document.md`. If it documents a "type-to-confirm step" or "friction step inventory" with status text, update it to reflect that the paste bypass is closed. If no such section exists or its content is still accurate, skip this step.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/HypeControl-TODO.md docs/dev/HC-Project-Document.md
+git commit -m "docs: log #49 paste-bypass fix in TODO and project doc"
+```
+
+(If `HC-Project-Document.md` had no changes, omit it from the `git add`.)
+
+---
+
+## Task 9: Run security review
+
+Per the project's stored feedback rule (`feedback_security_review_before_pr.md`): **always run `/security-review` on the branch before opening the PR**. This is non-negotiable.
+
+**Files:** none modified by this task; any findings get fixed in follow-up commits on the same branch.
+
+- [ ] **Step 1: Invoke `/security-review`**
+
+In the Claude Code session, run the `/security-review` command. It will analyze the diff against `main` and report any findings.
+
+- [ ] **Step 2: Triage findings**
+
+For each finding:
+- **High/Medium severity related to the diff:** fix on this branch before continuing.
+- **Pre-existing issues unrelated to this fix:** note them, but don't fix here. Open a separate ticket if not already tracked.
+- **False positives:** acknowledge in plan notes, no action.
+
+- [ ] **Step 3: Commit any fixes**
+
+If fixes were needed, commit them with messages like `fix(security): <specific issue>`. If no fixes, skip.
+
+---
+
+## Task 10: Version bump and release artifacts
+
+This is the only task that touches version numbers. It uses the project's `npm run release` script per `docs/dev/RELEASE-PROCESS.md` — never bump manifests by hand.
+
+**Files (touched by the script, not directly):**
+- Modify: `manifest.json`, `manifest.firefox.json`, `package.json` — patch bump 1.1.0 → 1.1.1
+- Modify (script-generated): `CHANGELOG.md`, `docs/release-notes/v1.1.1.md`
+
+- [ ] **Step 1: Run the release script**
+
+Run: `npm run release`
+
+The script will:
+1. Lockstep-bump all three version files from 1.1.0 to 1.1.1
+2. Scaffold a CHANGELOG entry
+3. Scaffold a release-notes file at `docs/release-notes/v1.1.1.md`
+4. Pause so you can edit the scaffolded notes
+
+If the script aborts due to drift between the three version files, fix manually so all three read 1.1.0, then re-run. Do not allow drift.
+
+- [ ] **Step 2: Edit the release notes**
+
+Open `docs/release-notes/v1.1.1.md`. Add user-facing copy along these lines (adjust to match the project's release-note voice — see `docs/release-notes/v1.1.0.md` for tone):
+
+> **#49 — Closed the copy/paste bypass on the type-to-confirm friction step.** Pasting, dragging, and autofilling the confirmation phrase no longer enables the Confirm button. Caught a cheat? You'll get a Newman-flavored callout. Friction is the feature.
+
+Save.
+
+- [ ] **Step 3: Continue the release script**
+
+Run: `npm run release -- --continue`
+
+The script will run `npm run build` and `npm run build:firefox` back to back. **If either build fails, the script aborts. Do not retry — ask the user to run the failing build manually in their own terminal** (per CLAUDE.md). If both succeed, the script produces the dual-platform bundles.
+
+- [ ] **Step 4: Commit the release artifacts**
+
+```bash
+git add manifest.json manifest.firefox.json package.json CHANGELOG.md docs/release-notes/v1.1.1.md
+git commit -m "maint: cut v1.1.1 — paste-bypass fix (#49)"
+```
+
+(Adjust the file list if `npm run release` writes additional bookkeeping files; check `git status` first.)
+
+---
+
+## Task 11: Open the PR (do not merge)
+
+Per the user's global git workflow (CLAUDE.md): **always open the PR and stop. Never run `gh pr merge` without explicit user approval.**
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin fix/type-to-confirm-paste-bypass`
+
+Expected: branch published, PR-create URL printed.
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "fix: close type-to-confirm paste bypass (#49)" --body "$(cat <<'EOF'
+## Summary
+
+- Closes #49 — copy/paste bypass on the type-to-confirm friction step
+- Blocks `paste`, `drop`, and paste-flavored `beforeinput` events on the input
+- Makes `.hc-confirm-phrase` unselectable so the prompt itself can't be dragged/copied
+- Adds three autofill-suppression attributes (`name="hc-no-autofill"`, `data-1p-ignore`, `data-lpignore="true"`)
+- Flashes a Newman-flavored cheeky callout when a cheat attempt is caught
+- Patch bump: 1.1.0 → 1.1.1
+
+## Test plan
+
+- [ ] Keyboard paste (Ctrl/Cmd+V) blocked, callout flashes, input stays empty
+- [ ] Right-click paste blocked
+- [ ] Displayed phrase cannot be selected by mouse
+- [ ] Drag-and-drop external text into input blocked
+- [ ] `execCommand('insertText', ...)` from devtools is caught by `beforeinput` listener
+- [ ] Password manager (1Password / LastPass / Bitwarden) does not auto-fill
+- [ ] Legitimate typing still enables Confirm
+- [ ] Callout hides as soon as user resumes typing
+- [ ] Repeated pastes rotate copy randomly
+- [ ] Cancel and Escape still work
+- [ ] Math-challenge step unchanged (out of scope)
+- [ ] All 11 manual tests pass on Chrome and Firefox
+EOF
+)"
+```
+
+The PR description deliberately omits any robot/AI emoji per the project's stored "no robot emoji in PRs" feedback rule.
+
+- [ ] **Step 3: Stop**
+
+Print the PR URL to the user. Say: "PR #N is open — ready to merge when you give the word." Do **not** run `gh pr merge`. Wait for the user.
+
+---
+
+## Self-Review (run after writing the plan)
+
+This section is a checklist for the plan-writer (you) to run before handoff.
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| Block keyboard paste (Ctrl/Cmd+V) | Task 5 (paste listener) |
+| Block right-click paste | Task 5 (paste listener fires for context-menu paste) |
+| Block drop event | Task 5 (drop listener) |
+| Block `beforeinput` paste-flavored inputType | Task 5 (beforeinput listener with inputType filter) |
+| Make displayed phrase unselectable | Task 1 (CSS) |
+| Newman-flavored callout copy pool of 4 lines | Task 3 |
+| Random pick on each attempt | Task 3 (`pickCheatLine`) |
+| `textContent` only (not innerHTML) | Task 5 (`triggerCheatCallout`) |
+| Re-disable Confirm on cheat attempt | Task 5 (`triggerCheatCallout`) |
+| Hide callout on resumed typing | Task 5 (input listener prefix) |
+| `role="alert"` on callout | Task 4 (HTML) |
+| `--hc-danger` red color | Task 2 (CSS) |
+| Autofill suppression attrs | Task 4 (HTML) |
+| Math-challenge step out of scope | Task 7 step 11 (regression check) |
+| Patch bump to 1.1.1 via `npm run release` | Task 10 |
+| Manual test on Chrome and Firefox | Task 7 |
+| Security review before PR | Task 9 |
+| Open PR, do not merge | Task 11 |
+
+No gaps.
+
+**Placeholder scan:** None of "TBD", "TODO", "appropriate error handling", "similar to Task N" appear. Every code step shows actual code; every command step shows the actual command and expected output.
+
+**Type consistency:** `triggerCheatCallout` defined once (Task 5) and called from three listeners in the same task. `pickCheatLine` defined once (Task 3) and called once (Task 5). `CHEAT_CALLOUT_LINES` defined once (Task 3) and consumed by `pickCheatLine` only. No naming drift.

--- a/docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md
+++ b/docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md
@@ -1,0 +1,113 @@
+# Type-to-Confirm Paste Bypass — Design Spec
+
+**Issue:** [#49 — Friction dialog that makes me type should not allow me to copy/paste](https://github.com/Ktulue/HypeControl/issues/49)
+**Date:** 2026-04-27
+**Status:** Approved, ready for plan
+
+## Problem
+
+The "Type to confirm" friction step asks the user to type the phrase `I want to buy this` before the Confirm button enables. The check is purely value-based — it accepts any value that matches the phrase, regardless of how it got into the input. As reported on issue #49, users can paste the phrase to defeat the friction in one keystroke. The reporter also called out the "drag/select" path and assumed it was OS-level; it isn't — the extension's own CSS makes the displayed phrase one-click selectable, which actively assists the bypass.
+
+## Root Cause
+
+Two contributing factors in the existing implementation (`src/content/interceptor.ts:1106-1203` and `src/content/styles.css:718-730`):
+
+1. **No paste-vector blocking on the input.** `showTypeToConfirmStep()` registers an `input` listener that checks the value against the phrase, but it does not listen for `paste`, `drop`, or `beforeinput` events. Any path that lands matching text in the value (clipboard paste, drag-drop, browser autofill, programmatic `execCommand`) flips the Confirm button to enabled.
+2. **The displayed phrase is one-click selectable.** `.hc-confirm-phrase` has `user-select: all`, which means a single click selects the entire prompt text, making it trivial to copy or drag into the input. This was a UX choice for readability that turned out to enable the bypass.
+
+## Mental Model
+
+The friction in this step is the act of typing — the muscle memory pause and the keystrokes themselves. The input value matching the phrase is a *proxy* for "the user typed it." Any path that produces the matching value without typing defeats the friction. The fix is to:
+
+- **Block non-typing inputs.** Anything from the clipboard, a drop event, autofill, or `beforeinput` with a paste-flavored `inputType` is rejected.
+- **Make the source un-grabbable.** The displayed phrase is the obvious thing to copy; it should not select on click.
+- **Call out the cheat in brand voice.** Per the project's "Friction is the feature" principle, a paste attempt is a beat in the friction experience, not just a silently-blocked event. A short Newman-flavored ("Ah ah ah…") callout flashes inline, the input clears, and the user is back at zero.
+
+## Scope Decisions
+
+- **Type-to-confirm step only.** The math-challenge step (`showMathChallengeStep`, same file) is *not* hardened. The math problem is generated freshly on each open and the answer is 2–3 digits; pasting "42" defeats nothing meaningful, because the friction there is solving the problem, not typing it.
+- **No new settings, no storage, no migrations, no type changes.** The fix is pure UI/event hardening.
+- **Right-click contextmenu is NOT blocked.** The `paste` event already fires on context-menu paste, so blocking is redundant and removing the menu would also remove "Inspect Element" for power users — heavy-handed for no marginal gain.
+- **Telemetry-only logging.** A blocked paste attempt is logged via the existing `log()` helper at the same severity as the existing "Type-to-confirm step shown" log. No new event types, no new storage.
+- **No copy rotation state.** The cheeky callout line is picked at random from a fixed pool on each attempt; we do not track "which line was shown last" — randomness is fine and avoids state.
+
+## Changes by File
+
+### 1. `src/content/interceptor.ts`
+
+Inside `showTypeToConfirmStep()` (~line 1113):
+
+- Add a module-scoped `CHEAT_CALLOUT_LINES: readonly string[]` array near `TYPE_TO_CONFIRM_PHRASE` with five Newman-flavored lines:
+  - `"Ah ah ah. You didn't type the magic phrase."`
+  - `"Ah ah ah — pasting isn't typing."`
+  - `"You didn't say the magic word."`
+  - `"The friction is the feature. Hands on keyboard."`
+  - `"Nice try. Hands on keyboard."`
+- Add a small helper `pickCheatLine()` that returns a random entry from the pool.
+- In the rendered HTML, add three attributes to the input to discourage password managers and autofill:
+  - `name="hc-no-autofill"`
+  - `data-1p-ignore` (1Password)
+  - `data-lpignore="true"` (LastPass)
+- After the input element in the rendered HTML, add a hidden inline callout element:
+  ```html
+  <p class="hc-cheat-callout" id="hc-cheat-callout" role="alert" style="display: none;"></p>
+  ```
+- Inside the existing `Promise` body, after the `inputEl` and `proceedBtn` references are obtained, add a `calloutEl` reference and a `triggerCheatCallout()` helper that:
+  1. Clears `inputEl.value`.
+  2. Re-disables the Confirm button (mirrors the existing disabled-state styling).
+  3. Sets the callout's `textContent` to a freshly picked line and unhides it. **Use `textContent`, never `innerHTML`** — per the project's stored XSS feedback memory, all user-facing dynamic strings are written via `textContent`.
+  4. Refocuses the input.
+  5. Calls `log('Type-to-confirm: paste/drop bypass attempt blocked')`.
+- Wire three event listeners on the input, all routing to `triggerCheatCallout()` after `preventDefault()`:
+  - `paste`
+  - `drop`
+  - `beforeinput` — only when `inputType` is one of `'insertFromPaste'`, `'insertFromDrop'`, or `'insertReplacementText'` (defense-in-depth for `execCommand` and exotic IME paths).
+- In the existing `input` listener, hide the callout on every legitimate keystroke: `if (calloutEl) calloutEl.style.display = 'none';` before the existing match-checking logic.
+
+### 2. `src/content/styles.css`
+
+- `.hc-confirm-phrase` (line 718): change `user-select: all;` to `user-select: none;` and add `-webkit-user-select: none;`. The phrase remains visually present and screen-reader-readable; only mouse-selection is suppressed.
+- Add a new `.hc-cheat-callout` rule positioned below the input:
+  ```css
+  .hc-cheat-callout {
+    margin-top: 8px;
+    font-family: var(--hc-font);
+    font-size: 13px;
+    color: var(--hc-danger);
+    font-weight: 600;
+    text-align: center;
+  }
+  ```
+  Color uses the existing `--hc-danger` token (red) — the universal "stop, you're caught" semantic, consistent with the design system's red-for-warning rule.
+
+## Out of Scope
+
+- Hardening the math-challenge step.
+- Hardening the whitelist channel-name input or any other text input in the extension.
+- Per-attempt copy rotation tracking (random pick is sufficient).
+- Disabling browser-level keyboard shortcuts other than via `paste` event preventDefault (which already covers Ctrl/Cmd+V).
+- Devtools-driven attacks (programmatic `inputEl.value = '...'` from console). A determined adversary with devtools is not the target user; HypeControl is opt-in friction for the user themself.
+
+## Accessibility
+
+- The displayed phrase remains in the DOM with the same text and the same accessible name. `user-select: none` affects pointer/keyboard selection only, not screen-reader rendering.
+- The callout element uses `role="alert"` so screen readers announce it when it becomes visible.
+- The input remains fully keyboard-typable, which is the only path screen-reader users would take. Paste-via-keyboard for AT users is a legitimate concern in general but is exactly the workflow this feature is designed to disrupt — friction is the point.
+
+## Testing Plan
+
+1. **Keyboard paste blocked.** Open the type-to-confirm step. Copy `I want to buy this` to the clipboard. Press Ctrl/Cmd+V in the input. **Expected:** input stays empty, Confirm stays disabled, callout flashes a Newman line.
+2. **Right-click paste blocked.** Same as above, via right-click → Paste menu. **Expected:** identical behavior.
+3. **Drag-and-drop the prompt phrase blocked.** Try to select the displayed phrase with the mouse. **Expected:** selection does not occur (CSS).
+4. **Drag-and-drop external text blocked.** Select arbitrary text on the page (e.g., from the description) and drag it into the input. **Expected:** drop event prevented, callout flashes.
+5. **`beforeinput` defense-in-depth.** Verifies the listener — not a user-facing scenario. With the input focused, run `document.execCommand('insertText', false, 'I want to buy this')` from devtools. **Expected:** input stays empty, callout flashes. (`beforeinput` with `inputType === 'insertReplacementText'` catches this.) Note: this test exercises the safety net; an adversary with devtools can always bypass via direct `inputEl.value` assignment, which is intentionally out of scope.
+6. **Autofill / password manager.** With 1Password (or any installed manager) active, open the modal. **Expected:** the field is not auto-filled (or, if a manager is sufficiently aggressive to ignore the hints, the `paste` / `beforeinput` listeners catch the fill).
+7. **Legitimate typing still works.** Type the phrase character by character. **Expected:** Confirm enables when the value matches; pressing Enter or clicking Confirm resolves with `'proceed'`.
+8. **Callout hides on resumed typing.** Trigger a paste (callout visible), then type one character. **Expected:** callout hides immediately on first keystroke.
+9. **Rapid repeated paste attempts.** Paste five times in a row. **Expected:** input stays empty each time; callout text rotates randomly across attempts; no duplicate-listener leaks; modal stays responsive.
+10. **Cancel still works.** Trigger a paste, then click Cancel (or press Escape). **Expected:** modal closes, decision resolves to `'cancel'`.
+11. **No regression in math challenge.** Open the math challenge step in a separate intercept. **Expected:** unchanged behavior — paste still works there (intentional, out of scope).
+
+## Version Bump
+
+Current version is 1.1.0 (per `manifest.json` and `package.json`). Bump patch to **1.1.1** at the end of implementation per the project's lockstep release process documented in `docs/dev/RELEASE-PROCESS.md`. Use `npm run release` — do not bump manifests by hand.

--- a/docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md
+++ b/docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md
@@ -37,10 +37,9 @@ The friction in this step is the act of typing — the muscle memory pause and t
 
 Inside `showTypeToConfirmStep()` (~line 1113):
 
-- Add a module-scoped `CHEAT_CALLOUT_LINES: readonly string[]` array near `TYPE_TO_CONFIRM_PHRASE` with five Newman-flavored lines:
+- Add a module-scoped `CHEAT_CALLOUT_LINES: readonly string[]` array near `TYPE_TO_CONFIRM_PHRASE` with four Newman-flavored lines:
   - `"Ah ah ah. You didn't type the magic phrase."`
   - `"Ah ah ah — pasting isn't typing."`
-  - `"You didn't say the magic word."`
   - `"The friction is the feature. Hands on keyboard."`
   - `"Nice try. Hands on keyboard."`
 - Add a small helper `pickCheatLine()` that returns a random entry from the pool.

--- a/docs/release-notes/v1.1.1.md
+++ b/docs/release-notes/v1.1.1.md
@@ -1,0 +1,7 @@
+# v1.1.1 — April 28, 2026
+
+**Ah ah ah. You didn't type the magic phrase.** Closed the copy-paste bypass on the type-to-confirm friction step — pasting, dragging, and autofilling the confirmation phrase no longer enables the Confirm button. Try to cheat your way past it and you'll get a Newman-flavored callout for your trouble. Friction is the feature. Hands on keyboard.
+
+- **Fixed:** type-to-confirm step now blocks paste, drop, drag-and-drop, and password-manager autofill — the only path through is typing the phrase out, the way it was always meant to work (#49).
+
+_Platforms: Chrome · Firefox_

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "browser_specific_settings": {
     "gecko": {
@@ -25,13 +25,21 @@
     "https://www.twitch.tv/*"
   ],
   "background": {
-    "scripts": ["serviceWorker.js"]
+    "scripts": [
+      "serviceWorker.js"
+    ]
   },
   "content_scripts": [
     {
-      "matches": ["https://www.twitch.tv/*"],
-      "js": ["content.js"],
-      "css": ["content.css"],
+      "matches": [
+        "https://www.twitch.tv/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "content.css"
+      ],
       "run_at": "document_idle"
     }
   ],
@@ -44,7 +52,9 @@
         "assets/fonts/SpaceGrotesk-SemiBold.woff2",
         "assets/fonts/SpaceGrotesk-Bold.woff2"
       ],
-      "matches": ["https://www.twitch.tv/*"]
+      "matches": [
+        "https://www.twitch.tv/*"
+      ]
     }
   ],
   "action": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",
@@ -21,9 +21,15 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.twitch.tv/*"],
-      "js": ["content.js"],
-      "css": ["content.css"],
+      "matches": [
+        "https://www.twitch.tv/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "content.css"
+      ],
       "run_at": "document_idle"
     }
   ],
@@ -36,7 +42,9 @@
         "assets/fonts/SpaceGrotesk-SemiBold.woff2",
         "assets/fonts/SpaceGrotesk-Bold.woff2"
       ],
-      "matches": ["https://www.twitch.tv/*"]
+      "matches": [
+        "https://www.twitch.tv/*"
+      ]
     }
   ],
   "action": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1162,6 +1162,24 @@ async function showTypeToConfirmStep(
     const previousFocus = document.activeElement as HTMLElement | null;
     const inputEl = overlay.querySelector('#hc-confirm-input') as HTMLInputElement | null;
     const proceedBtn = overlay.querySelector('[data-action="proceed"]') as HTMLButtonElement | null;
+    const calloutEl = overlay.querySelector('#hc-cheat-callout') as HTMLElement | null;
+
+    const triggerCheatCallout = () => {
+      if (!inputEl) return;
+      inputEl.value = '';
+      if (proceedBtn) {
+        proceedBtn.disabled = true;
+        proceedBtn.setAttribute('aria-disabled', 'true');
+        proceedBtn.style.opacity = '0.4';
+        proceedBtn.style.cursor = 'not-allowed';
+      }
+      if (calloutEl) {
+        calloutEl.textContent = pickCheatLine();
+        calloutEl.style.display = '';
+      }
+      inputEl.focus();
+      log('Type-to-confirm: paste/drop bypass attempt blocked');
+    };
 
     const finish = (decision: 'cancel' | 'proceed') => {
       if (resolved) return;
@@ -1173,12 +1191,35 @@ async function showTypeToConfirmStep(
 
     // Real-time validation: enable Confirm only when input matches phrase (case-insensitive)
     inputEl?.addEventListener('input', () => {
+      if (calloutEl) calloutEl.style.display = 'none';
       const matches = (inputEl.value.trim().toLowerCase() === TYPE_TO_CONFIRM_PHRASE.toLowerCase());
       if (proceedBtn) {
         proceedBtn.disabled = !matches;
         proceedBtn.setAttribute('aria-disabled', String(!matches));
         proceedBtn.style.opacity = matches ? '' : '0.4';
         proceedBtn.style.cursor = matches ? '' : 'not-allowed';
+      }
+    });
+
+    inputEl?.addEventListener('paste', (e) => {
+      e.preventDefault();
+      triggerCheatCallout();
+    });
+
+    inputEl?.addEventListener('drop', (e) => {
+      e.preventDefault();
+      triggerCheatCallout();
+    });
+
+    inputEl?.addEventListener('beforeinput', (e) => {
+      const ev = e as InputEvent;
+      if (
+        ev.inputType === 'insertFromPaste' ||
+        ev.inputType === 'insertFromDrop' ||
+        ev.inputType === 'insertReplacementText'
+      ) {
+        e.preventDefault();
+        triggerCheatCallout();
       }
     });
 

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1174,8 +1174,11 @@ async function showTypeToConfirmStep(
         proceedBtn.style.cursor = 'not-allowed';
       }
       if (calloutEl) {
-        calloutEl.textContent = pickCheatLine();
+        // Flip display before setting textContent so role="alert" announces
+        // reliably — Chrome+NVDA only fires the live-region announcement when
+        // content changes while the element is already visible.
         calloutEl.style.display = '';
+        calloutEl.textContent = pickCheatLine();
       }
       inputEl.focus();
       log('Type-to-confirm: paste/drop bypass attempt blocked');

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1140,7 +1140,11 @@ async function showTypeToConfirmStep(
           placeholder="Type the phrase above..."
           autocomplete="off"
           spellcheck="false"
+          name="hc-no-autofill"
+          data-1p-ignore
+          data-lpignore="true"
         />
+        <p class="hc-cheat-callout" id="hc-cheat-callout" role="alert" style="display: none;"></p>
       </div>
       <div class="hc-actions">
         <button class="hc-btn hc-btn-cancel" data-action="cancel">Cancel</button>

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1105,6 +1105,17 @@ async function showFrictionCooldownStep(
 
 const TYPE_TO_CONFIRM_PHRASE = 'I want to buy this';
 
+const CHEAT_CALLOUT_LINES: readonly string[] = [
+  "Ah ah ah. You didn't type the magic phrase.",
+  "Ah ah ah — pasting isn't typing.",
+  'The friction is the feature. Hands on keyboard.',
+  'Nice try. Hands on keyboard.',
+];
+
+function pickCheatLine(): string {
+  return CHEAT_CALLOUT_LINES[Math.floor(Math.random() * CHEAT_CALLOUT_LINES.length)];
+}
+
 /**
  * Friction step that requires the user to type a specific phrase before
  * the Confirm button becomes enabled. Cancel/Escape/backdrop all resolve

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -726,7 +726,8 @@
   border-radius: 4px;
   padding: 6px 14px;
   margin: 12px 0 16px;
-  user-select: all;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .hc-confirm-input {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -754,6 +754,15 @@
   opacity: 0.7;
 }
 
+.hc-cheat-callout {
+  margin-top: 8px;
+  font-family: var(--hc-font);
+  font-size: 13px;
+  color: var(--hc-danger);
+  font-weight: 600;
+  text-align: center;
+}
+
 /* Math challenge step */
 .hc-math-question {
   font-size: 40px;


### PR DESCRIPTION
## Summary

- Closes #49 — copy/paste bypass on the type-to-confirm friction step
- Blocks `paste`, `drop`, and paste-flavored `beforeinput` events on the input
- Flips `.hc-confirm-phrase` to `user-select: none` so the prompt itself can't be dragged into the input
- Adds three autofill-suppression attributes (`name="hc-no-autofill"`, `data-1p-ignore`, `data-lpignore="true"`) to discourage password managers
- Flashes a Newman-flavored cheeky callout from a 4-line random pool when a cheat attempt is caught
- ARIA correctness: `role="alert"` element flips visible *before* `textContent` is set, so Chrome+NVDA reliably announces it
- Lockstep patch bump 1.1.0 → 1.1.1 across `manifest.json`, `manifest.firefox.json`, `package.json`; tag `v1.1.1` cut locally; dual-platform zips built (`releases/hype-control-{chrome,firefox}-v1.1.1.zip`)

## Test plan

- [x] Keyboard paste (Ctrl/Cmd+V) blocked, callout flashes, input stays empty — Chrome + Firefox
- [x] Right-click paste blocked
- [x] Displayed phrase cannot be selected by mouse
- [x] Drag-and-drop external text into input blocked
- [x] `execCommand('insertText', ...)` from devtools is caught by the `beforeinput` listener
- [x] Password manager (1Password / LastPass / Bitwarden) does not auto-fill
- [x] Legitimate typing still enables Confirm
- [x] Callout hides as soon as the user resumes typing
- [x] Repeated pastes rotate copy randomly
- [x] Cancel and Escape still work
- [x] Math-challenge step unchanged (intentionally out of scope)
- [x] Jest regression — 101/101, 8/8 suites
- [x] `npm run build` and `npm run build:firefox` clean
- [x] Manual cross-browser verification on Chrome + Firefox passed
- [x] Pre-PR `/security-review` clean — no findings

## Spec & Plan

- Spec: `docs/dev/superpowers/specs/2026-04-27-type-to-confirm-paste-bypass-design.md`
- Plan: `docs/dev/superpowers/plans/2026-04-27-type-to-confirm-paste-bypass.md`

## Lockstep checklist

- [x] `manifest.json` → 1.1.1
- [x] `manifest.firefox.json` → 1.1.1
- [x] `package.json` → 1.1.1
- [x] `CHANGELOG.md` 1.1.1 entry filled in
- [x] `docs/release-notes/v1.1.1.md` filled in
- [x] Tag `v1.1.1` exists locally (push after merge per release process)