### PR TITLE
feat: limits progress bars in popup Limits section

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,6 +1,6 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-04-28
+**Updated:** 2026-04-29
 **Current Version:** 1.1.2
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
@@ -232,6 +232,7 @@ The original design called for a guided overlay on the Twitch page highlighting 
 
 ### Recently Completed
 
+- [x] **Limits Progress Bars in Popup (2026-04-29)** — Replaced plain-text spending tracker rows in the popup Limits section with the same colored progress-bar widget the friction overlay renders. Bars only render when their cap is enabled; cap-disabled rows fall back to existing text behavior. Cap-amount edits live-update bars via the existing `onCapChange` callback. Extracted `getCapColorClass` + `buildCapProgressBar` into shared `src/shared/capBar.ts` (reused by overlay and popup). Adds `capAmount <= 0` guard as a defensive improvement to the overlay too. Spec: `docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md`. Plan: `docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md`.
 - [x] **Dual-platform 1.1.0 release cut (2026-04-24)** — Lockstep version bump across `manifest.json`, `manifest.firefox.json`, `package.json` to 1.1.0. Firefox caught up from 1.0.2 (drift from the AMO port). Both Chrome and Firefox builds verified. Ready for Chrome Web Store + AMO submissions.
 - [x] **Fix stream override storage mismatch (#32) — v1.0.4** — Override now short-circuits `shouldBypassFriction` globally (any channel), popup writes `streamingOverride` to `chrome.storage.sync` so the content script actually reads it. Purchases during bypass logged as `outcome: 'streaming'`. Replaced per-purchase toast with persistent `hc-streaming-badge` showing live countdown / live-on-channel / grace-period state.
 - [x] **Firefox AMO Port (2026-04-02)** — v1.0.2. Dual-manifest build (`manifest.firefox.json`), webpack target flag, build-time icon directory constant. AMO submission pending.

--- a/docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md
+++ b/docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md
@@ -1,0 +1,1055 @@
+# Limits Progress Bars in Popup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the popup Limits section's plain-text spending tracker rows with the same visual progress bars the friction overlay already renders. Bars only show when their cap is enabled; cap-disabled rows fall back to existing behavior.
+
+**Architecture:** Extract `getCapColorClass` and `buildCapProgressBar` from `src/content/interceptor.ts` into a new shared module `src/shared/capBar.ts`. The friction overlay continues to import from there; the popup's `limits.ts` imports the same widget and renders bars into new sibling slots in `popup.html`. Cap-amount changes in the popup trigger a live bar repaint via the existing `onCapChange` callback chain. CSS variables and `.hc-cap-bar*` rules are added to `popup.css`.
+
+**Tech Stack:** TypeScript, Chrome Extension MV3, webpack, Jest + ts-jest (node env), `chrome.storage.sync` (settings) / `chrome.storage.local` (tracker).
+
+**Spec:** `docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md`
+
+**Branch:** `feat/limits-progress-bars-in-popup` (already created)
+
+**Versioning note for executors:** Do NOT bump versions during this plan. The release process is separate per `docs/dev/RELEASE-PROCESS.md`.
+
+---
+
+## File Map
+
+| Path | Status | Responsibility |
+|------|--------|----------------|
+| `src/shared/capBar.ts` | NEW | Pure functions: tier classification + bar HTML construction. Single source of truth for the bar widget. |
+| `tests/shared/capBar.test.ts` | NEW | Unit tests for `getCapColorClass` and `buildCapProgressBar`, including the new amount guard. |
+| `src/content/interceptor.ts` | MODIFY | Remove local copies of bar functions; import from shared module. No behavior change. |
+| `src/popup/popup.html` | MODIFY | Add `id="tracker-daily-text"` to Daily row; add three sibling `<div class="hc-cap-bar-host">` slots. |
+| `src/popup/popup.css` | MODIFY | Add `--hc-*` variables to `:root` + `[data-theme="light"]`; add `.hc-cap-bar*` and tier rules; add `.hc-cap-bar-host`. |
+| `src/popup/sections/limits.ts` | MODIFY | Render bars in `refreshTracker()`; switch cap-value source to `getPending()`; toggle bar/text visibility per cap state. |
+| `src/popup/popup.ts` | MODIFY | Extend `onCapChange` callback in `initLimits` call to also invoke `limits.refreshTracker()` so cap edits live-update bars. |
+| `docs/dev/HypeControl-TODO.md` | MODIFY | Mark feature complete after manual test pass. |
+
+---
+
+## Task 1: Create shared `capBar.ts` module with tests
+
+**Files:**
+- Create: `src/shared/capBar.ts`
+- Create: `tests/shared/capBar.test.ts`
+
+This task introduces the new shared module via TDD. The functions are extracted from `interceptor.ts:318-356`, with one new behavior: when `capAmount <= 0`, `buildCapProgressBar` returns `''` (empty string) so callers can skip rendering instead of producing a divide-by-zero bar.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/shared/capBar.test.ts` with the following content:
+
+```typescript
+import { getCapColorClass, buildCapProgressBar } from '../../src/shared/capBar';
+
+describe('getCapColorClass', () => {
+  test('returns hc-cap-green when percentage is 0', () => {
+    expect(getCapColorClass(0)).toBe('hc-cap-green');
+  });
+
+  test('returns hc-cap-green when percentage is 59', () => {
+    expect(getCapColorClass(59)).toBe('hc-cap-green');
+  });
+
+  test('returns hc-cap-yellow at exactly 60', () => {
+    expect(getCapColorClass(60)).toBe('hc-cap-yellow');
+  });
+
+  test('returns hc-cap-yellow when percentage is 79', () => {
+    expect(getCapColorClass(79)).toBe('hc-cap-yellow');
+  });
+
+  test('returns hc-cap-orange at exactly 80', () => {
+    expect(getCapColorClass(80)).toBe('hc-cap-orange');
+  });
+
+  test('returns hc-cap-orange when percentage is 99', () => {
+    expect(getCapColorClass(99)).toBe('hc-cap-orange');
+  });
+
+  test('returns hc-cap-red at exactly 100', () => {
+    expect(getCapColorClass(100)).toBe('hc-cap-red');
+  });
+
+  test('returns hc-cap-red when percentage exceeds 100', () => {
+    expect(getCapColorClass(150)).toBe('hc-cap-red');
+  });
+});
+
+describe('buildCapProgressBar', () => {
+  test('returns empty string when capAmount is 0', () => {
+    expect(buildCapProgressBar('Daily', 10, 0, 0)).toBe('');
+  });
+
+  test('returns empty string when capAmount is negative', () => {
+    expect(buildCapProgressBar('Daily', 10, 0, -5)).toBe('');
+  });
+
+  test('renders a bar with 0% green when current and delta are 0', () => {
+    const html = buildCapProgressBar('Daily', 0, 0, 100);
+    expect(html).toContain('hc-cap-green');
+    expect(html).toContain('Daily');
+    expect(html).toContain('$0.00 / $100.00');
+    expect(html).toContain('(0%)');
+    expect(html).toContain('width: 0%');
+  });
+
+  test('renders 50% green bar when current is 50 of 100', () => {
+    const html = buildCapProgressBar('Daily', 50, 0, 100);
+    expect(html).toContain('hc-cap-green');
+    expect(html).toContain('$50.00 / $100.00');
+    expect(html).toContain('(50%)');
+    expect(html).toContain('width: 50%');
+  });
+
+  test('renders 60% yellow bar at the green/yellow boundary', () => {
+    const html = buildCapProgressBar('Weekly', 60, 0, 100);
+    expect(html).toContain('hc-cap-yellow');
+    expect(html).toContain('Weekly');
+    expect(html).toContain('(60%)');
+  });
+
+  test('renders 85% orange bar', () => {
+    const html = buildCapProgressBar('Monthly', 85, 0, 100);
+    expect(html).toContain('hc-cap-orange');
+    expect(html).toContain('Monthly');
+    expect(html).toContain('(85%)');
+  });
+
+  test('renders 100% red bar with OVER BUDGET when newTotal exactly equals capAmount', () => {
+    // Boundary: newTotal == capAmount is treated as 100% (red), not over-budget.
+    const html = buildCapProgressBar('Daily', 100, 0, 100);
+    expect(html).toContain('hc-cap-red');
+    expect(html).toContain('(100%)');
+    expect(html).not.toContain('OVER BUDGET');
+  });
+
+  test('renders OVER BUDGET when newTotal exceeds capAmount', () => {
+    const html = buildCapProgressBar('Daily', 120, 0, 100);
+    expect(html).toContain('hc-cap-red');
+    expect(html).toContain('$120.00 / $100.00');
+    expect(html).toContain('OVER BUDGET');
+    expect(html).not.toContain('(120%)');
+  });
+
+  test('caps fill width at 100% when over budget', () => {
+    const html = buildCapProgressBar('Daily', 200, 0, 100);
+    expect(html).toContain('width: 100%');
+    expect(html).not.toContain('width: 200%');
+  });
+
+  test('adds purchaseAmount to currentTotal for the bar value', () => {
+    // Friction-overlay use case: current $40, in-flight $20, cap $100 → 60% yellow
+    const html = buildCapProgressBar('Daily', 40, 20, 100);
+    expect(html).toContain('hc-cap-yellow');
+    expect(html).toContain('$60.00 / $100.00');
+    expect(html).toContain('(60%)');
+  });
+
+  test('rounds the displayed total to 2 decimals', () => {
+    const html = buildCapProgressBar('Daily', 10.005, 0, 100);
+    // Math.round((10.005 + 0) * 100) / 100 = 10.01
+    expect(html).toContain('$10.01');
+  });
+
+  test('emits all four required structural classes', () => {
+    const html = buildCapProgressBar('Daily', 50, 0, 100);
+    expect(html).toContain('class="hc-cap-bar hc-cap-green"');
+    expect(html).toContain('class="hc-cap-bar__header"');
+    expect(html).toContain('class="hc-cap-bar__label"');
+    expect(html).toContain('class="hc-cap-bar__value"');
+    expect(html).toContain('class="hc-cap-bar__track"');
+    expect(html).toContain('class="hc-cap-bar__fill"');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+npx jest tests/shared/capBar.test.ts
+```
+
+Expected: ALL tests fail with `Cannot find module '../../src/shared/capBar'` or equivalent. The module does not exist yet.
+
+- [ ] **Step 3: Implement the shared module**
+
+Create `src/shared/capBar.ts` with the following content:
+
+```typescript
+/**
+ * Determine the color tier for a cap progress bar.
+ * Green < 60%, Yellow 60–79%, Orange 80–99%, Red 100%+
+ */
+export function getCapColorClass(percentage: number): string {
+  if (percentage >= 100) return 'hc-cap-red';
+  if (percentage >= 80) return 'hc-cap-orange';
+  if (percentage >= 60) return 'hc-cap-yellow';
+  return 'hc-cap-green';
+}
+
+/**
+ * Build a single cap progress bar HTML string.
+ *
+ * Label is constrained to known static values — never user-controlled.
+ * Numeric values are computed internally. innerHTML of this string is safe.
+ *
+ * Returns '' (empty string) when `capAmount <= 0`. Callers must treat empty
+ * output as "no bar to render" and skip emitting it. This guards against
+ * divide-by-zero displays when a cap is enabled but its amount has not been
+ * set, and is used by both the friction overlay and the popup Limits section.
+ *
+ * @param label Hardcoded period label: 'Daily' | 'Weekly' | 'Monthly'.
+ * @param currentTotal Already-spent amount for the period.
+ * @param purchaseAmount Additional amount being attempted (overlay) or 0 (popup).
+ * @param capAmount Configured cap for the period.
+ */
+export function buildCapProgressBar(
+  label: 'Daily' | 'Weekly' | 'Monthly',
+  currentTotal: number,
+  purchaseAmount: number,
+  capAmount: number,
+): string {
+  if (capAmount <= 0) return '';
+
+  const newTotal = Math.round((currentTotal + purchaseAmount) * 100) / 100;
+  const percentage = Math.round((newTotal / capAmount) * 100);
+  const barWidth = Math.min(percentage, 100);
+  const colorClass = getCapColorClass(percentage);
+  const overBudget = newTotal > capAmount;
+
+  return `
+    <div class="hc-cap-bar ${colorClass}">
+      <div class="hc-cap-bar__header">
+        <span class="hc-cap-bar__label">${label}</span>
+        <span class="hc-cap-bar__value">$${newTotal.toFixed(2)} / $${capAmount.toFixed(2)}${overBudget ? ' — OVER BUDGET' : ` (${percentage}%)`}</span>
+      </div>
+      <div class="hc-cap-bar__track">
+        <div class="hc-cap-bar__fill" style="width: ${barWidth}%"></div>
+      </div>
+    </div>
+  `;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+npx jest tests/shared/capBar.test.ts
+```
+
+Expected: ALL tests pass (15 tests across the two `describe` blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/capBar.ts tests/shared/capBar.test.ts
+git commit -m "feat: extract cap bar widget into shared module
+
+New src/shared/capBar.ts exposes getCapColorClass and buildCapProgressBar
+as pure functions, ready to be reused by the popup Limits section.
+
+Adds capAmount<=0 guard: returns '' instead of dividing by zero. Callers
+must skip rendering when output is empty.
+
+Tests cover all four tier boundaries, OVER BUDGET formatting, fill-width
+clamping, and the new guard."
+```
+
+---
+
+## Task 2: Migrate `interceptor.ts` to use the shared module
+
+**Files:**
+- Modify: `src/content/interceptor.ts:318-357` (remove local function definitions, add import)
+
+This is a verbatim swap — the friction overlay's behavior must not change. Tests pass = local copy was redundant.
+
+- [ ] **Step 1: Add the import to `interceptor.ts`**
+
+Find the existing imports near the top of `src/content/interceptor.ts` (look for the block of `import` statements). Add this line, sorted near the other `../shared/*` imports:
+
+```typescript
+import { buildCapProgressBar } from '../shared/capBar';
+```
+
+Note: We do NOT need to import `getCapColorClass` because it's only called internally by `buildCapProgressBar`, and the local interceptor code never called `getCapColorClass` directly outside of `buildCapProgressBar`.
+
+- [ ] **Step 2: Delete the local function definitions**
+
+Delete lines 318–357 of `src/content/interceptor.ts` — the entire block from the `/**` comment of `getCapColorClass` through the closing brace of `buildCapProgressBar` (inclusive). The exact block to remove:
+
+```typescript
+/**
+ * Determine the color tier for a cap progress bar.
+ * Green < 60%, Yellow 60–79%, Orange 80–99%, Red 100%+
+ */
+function getCapColorClass(percentage: number): string {
+  if (percentage >= 100) return 'hc-cap-red';
+  if (percentage >= 80) return 'hc-cap-orange';
+  if (percentage >= 60) return 'hc-cap-yellow';
+  return 'hc-cap-green';
+}
+
+/**
+ * Build a single cap progress bar HTML string.
+ * Label is constrained to known static values — never user-controlled.
+ * Numeric values are computed internally. innerHTML is safe here.
+ */
+function buildCapProgressBar(
+  label: 'Daily' | 'Weekly' | 'Monthly',
+  currentTotal: number,
+  purchaseAmount: number,
+  capAmount: number,
+): string {
+  const newTotal = Math.round((currentTotal + purchaseAmount) * 100) / 100;
+  const percentage = Math.round((newTotal / capAmount) * 100);
+  const barWidth = Math.min(percentage, 100);
+  const colorClass = getCapColorClass(percentage);
+  const overBudget = newTotal > capAmount;
+
+  return `
+    <div class="hc-cap-bar ${colorClass}">
+      <div class="hc-cap-bar__header">
+        <span class="hc-cap-bar__label">${label}</span>
+        <span class="hc-cap-bar__value">$${newTotal.toFixed(2)} / $${capAmount.toFixed(2)}${overBudget ? ' — OVER BUDGET' : ` (${percentage}%)`}</span>
+      </div>
+      <div class="hc-cap-bar__track">
+        <div class="hc-cap-bar__fill" style="width: ${barWidth}%"></div>
+      </div>
+    </div>
+  `;
+}
+```
+
+The `buildCostBreakdown` function below (which calls `buildCapProgressBar`) stays unchanged — it now resolves the call to the imported function.
+
+**Note on the new `capAmount <= 0` guard:** `buildCostBreakdown` already wraps each call in `if (settings.dailyCap.enabled)` etc., but does NOT check the amount. After this migration, the shared function returns `''` for amount=0, and the existing `if (capBars)` check at line 381 will produce an empty `<div class="hc-cap-bars">` if all caps return empty. Add a defensive check in `buildCostBreakdown` to skip the wrapper when `capBars === ''`:
+
+```typescript
+const capSection = capBars.trim() ? `<div class="hc-cap-bars">${capBars}</div>` : '';
+```
+
+(The original used a truthiness check on `capBars` which is `''` for empty — already correct. The `.trim()` adds safety against whitespace-only template output. Verify by reading the current line 381 and only adjust if the existing check is loose enough to render empty wrappers.)
+
+- [ ] **Step 3: Run the existing test suite to verify nothing broke**
+
+Run:
+```bash
+npx jest
+```
+
+Expected: all existing tests pass plus the 15 new `capBar.test.ts` tests. Total test count goes up by 15 from before Task 1. No failures.
+
+- [ ] **Step 4: Build the extension to verify the migration compiles**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: build succeeds with no errors. `dist/` contains the rebuilt extension.
+
+- [ ] **Step 5: Manual smoke test of the friction overlay**
+
+Load the unpacked extension from `dist/` in Chrome (chrome://extensions → Developer mode → Load unpacked → select `dist/`).
+
+1. In settings (popup), enable a daily cap of $50.
+2. Click Save.
+3. Visit a Twitch channel and attempt a Bits purchase (or use the test panel if available — see `src/content/tourPanel.ts`).
+4. Confirm the friction overlay still renders the daily cap progress bar exactly as before — same color, same `$X.XX / $50.00 (NN%)` formatting, same fill width.
+
+If the bar is missing or visually different from the v1.1.2 baseline, the migration broke something. Investigate before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "refactor: interceptor reuses shared capBar module
+
+Delete local getCapColorClass and buildCapProgressBar; import from
+src/shared/capBar instead. No behavior change for the friction overlay;
+manual smoke-tested against a real Twitch purchase attempt."
+```
+
+---
+
+## Task 3: Add CSS variables and bar styles to `popup.css`
+
+**Files:**
+- Modify: `src/popup/popup.css` (variables and rules added; line numbers will shift, so the steps below describe targets by selector, not by line number)
+
+- [ ] **Step 1: Add `--hc-*` variables to `:root` block**
+
+Find the `:root { ... }` block in `src/popup/popup.css` (currently around lines 27–46). At the end of the existing variable list (after `--accent-text: #bf94ff;`), add:
+
+```css
+  /* Bar widget tokens (mirror src/content/styles.css for the shared .hc-cap-bar* rules) */
+  --hc-success: #22C55E;
+  --hc-success-rgb: 34, 197, 94;
+  --hc-danger: #e91916;
+  --hc-danger-rgb: 233, 25, 22;
+  --hc-warning: #F97316;
+  --hc-warning-rgb: 249, 115, 22;
+  --hc-caution: #EAB308;
+  --hc-caution-rgb: 234, 179, 8;
+  --hc-progress-bg: #2a2a2e;
+```
+
+- [ ] **Step 2: Add light-mode overrides to `[data-theme="light"]`**
+
+Find the `[data-theme="light"] { ... }` block (currently around lines 49–63). Append at the end of the block, before the closing `}`:
+
+```css
+  /* Bar widget light-mode overrides */
+  --hc-success: #16A34A;
+  --hc-warning: #EA580C;
+  --hc-caution: #CA8A04;
+  --hc-caution-rgb: 202, 138, 4;
+```
+
+`--hc-danger` and `--hc-danger-rgb` are not overridden in light mode (the danger red stays the same per `src/content/styles.css`).
+
+- [ ] **Step 3: Append the bar widget rules**
+
+Append the following block to the end of `src/popup/popup.css`. Pick a location after all existing rules but before any final `@media` blocks if present.
+
+```css
+/* ─── Cap progress bars (shared widget — mirrors src/content/styles.css) ─── */
+
+.hc-cap-bar-host {
+  /* Match the vertical rhythm of sibling .hc-row elements inside .hc-group */
+  margin-top: 8px;
+}
+
+.hc-cap-bar {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+}
+
+.hc-cap-bar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.hc-cap-bar__label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hc-cap-bar__track {
+  height: 4px;
+  background: var(--hc-progress-bg, #2a2a2e);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.hc-cap-bar__fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+/* Color tiers */
+.hc-cap-green {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.2);
+  color: var(--hc-success);
+}
+.hc-cap-green .hc-cap-bar__fill {
+  background: var(--hc-success);
+}
+
+.hc-cap-yellow {
+  background: rgba(var(--hc-caution-rgb), 0.1);
+  border-color: rgba(var(--hc-caution-rgb), 0.2);
+  color: var(--hc-caution);
+}
+.hc-cap-yellow .hc-cap-bar__fill {
+  background: var(--hc-caution);
+}
+
+.hc-cap-orange {
+  background: rgba(var(--hc-warning-rgb), 0.1);
+  border-color: rgba(var(--hc-warning-rgb), 0.2);
+  color: var(--hc-warning);
+}
+.hc-cap-orange .hc-cap-bar__fill {
+  background: var(--hc-warning);
+}
+
+.hc-cap-red {
+  background: rgba(var(--hc-danger-rgb), 0.1);
+  border-color: rgba(var(--hc-danger-rgb), 0.2);
+  color: var(--hc-danger);
+}
+.hc-cap-red .hc-cap-bar__fill {
+  background: var(--hc-danger);
+}
+```
+
+- [ ] **Step 4: Build the extension**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Reload the unpacked extension and verify no visual regressions**
+
+Reload the extension at chrome://extensions. Open the popup. The Limits section should still look identical to before — no bars yet because the HTML and rendering haven't been updated. Verify nothing else is broken by the new CSS rules (they're scoped to `.hc-cap-bar*` so should not bleed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/popup/popup.css
+git commit -m "feat(popup): add cap bar CSS variables and tier styles
+
+Adds the --hc-* color tokens that the shared .hc-cap-bar* rules expect,
+plus the bar widget styles themselves. Light-mode overrides match the
+friction overlay. .hc-cap-bar-host spacer aligns bars with the existing
+.hc-row rhythm in .hc-group."
+```
+
+---
+
+## Task 4: Add bar host slots and IDs to `popup.html`
+
+**Files:**
+- Modify: `src/popup/popup.html` around the Limits section (currently lines 308–335) — specifically the `.hc-group` block containing the tracker rows.
+
+- [ ] **Step 1: Add `id="tracker-daily-text"` to the Daily row**
+
+Find this block (around line 309–312):
+
+```html
+<div class="hc-row">
+  <span class="hc-label">Daily total</span>
+  <span class="tracker-value" id="tracker-daily">—</span>
+</div>
+```
+
+Change it to:
+
+```html
+<div class="hc-row" id="tracker-daily-text">
+  <span class="hc-label">Daily total</span>
+  <span class="tracker-value" id="tracker-daily">—</span>
+</div>
+```
+
+- [ ] **Step 2: Add bar host slots after each tracker text row**
+
+Insert a `<div class="hc-cap-bar-host" ...>` element immediately after each of the three tracker rows. Final structure for the daily/weekly/monthly block:
+
+```html
+<div class="hc-row" id="tracker-daily-text">
+  <span class="hc-label">Daily total</span>
+  <span class="tracker-value" id="tracker-daily">—</span>
+</div>
+<div class="hc-cap-bar-host" id="tracker-daily-bar" hidden></div>
+<div class="hc-row" id="tracker-weekly-row" hidden>
+  <span class="hc-label">Weekly total</span>
+  <span class="tracker-value" id="tracker-weekly">—</span>
+</div>
+<div class="hc-cap-bar-host" id="tracker-weekly-bar" hidden></div>
+<div class="hc-row" id="tracker-monthly-row" hidden>
+  <span class="hc-label">Monthly total</span>
+  <span class="tracker-value" id="tracker-monthly">—</span>
+</div>
+<div class="hc-cap-bar-host" id="tracker-monthly-bar" hidden></div>
+```
+
+Note that the savings calendar row, calendar container, and reset row that follow this block stay exactly where they are — no changes there.
+
+- [ ] **Step 3: Build the extension**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: build succeeds. (Webpack will copy `popup.html` to `dist/popup.html`.)
+
+- [ ] **Step 4: Reload and verify popup still works**
+
+Reload the unpacked extension. Open the popup. The Limits section should look identical to before — the new bar host slots are all `hidden`, so visually nothing changes. Verify the tracker text rows still display dollar amounts. Verify Reset Tracker still works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/popup/popup.html
+git commit -m "feat(popup): add cap bar host slots in Limits section
+
+Adds three hidden <div class='hc-cap-bar-host'> siblings, one per
+tracker row, ready to host the bar widget. Daily row gains
+id='tracker-daily-text' so it can be toggled. No visual change yet —
+slots stay hidden until limits.ts wires up the rendering."
+```
+
+---
+
+## Task 5: Render bars in `limits.ts`
+
+**Files:**
+- Modify: `src/popup/sections/limits.ts` (entire `refreshTracker` function plus surrounding element refs and imports)
+
+This is the core wiring change. The function picks bar-vs-text per row based on the cap-enabled state, reads cap values from `getPending()` (the popup's live in-memory state, not saved settings) so cap-input edits update bars immediately, and uses tracker totals from `chrome.storage.local`.
+
+- [ ] **Step 1: Add the import**
+
+Open `src/popup/sections/limits.ts`. Find the existing imports at the top of the file. Add:
+
+```typescript
+import { buildCapProgressBar } from '../../shared/capBar';
+```
+
+- [ ] **Step 2: Acquire references to the new DOM elements**
+
+Inside `initLimits`, find the block of `el.querySelector<...>(...)` declarations (currently lines 16–34). Add the following references at the end of that block, before the event-listener wiring begins:
+
+```typescript
+  // Tracker rows + bar host slots (one pair per period)
+  const trackerDailyTextEl = el.querySelector<HTMLElement>('#tracker-daily-text')!;
+  const trackerDailyBarEl = el.querySelector<HTMLElement>('#tracker-daily-bar')!;
+  const trackerWeeklyBarEl = el.querySelector<HTMLElement>('#tracker-weekly-bar')!;
+  const trackerMonthlyBarEl = el.querySelector<HTMLElement>('#tracker-monthly-bar')!;
+```
+
+The existing `trackerDailyEl`, `trackerWeeklyEl`, `trackerMonthlyEl` (the value spans inside the text rows) and `trackerWeeklyRowEl`, `trackerMonthlyRowEl` (the row containers for weekly/monthly) stay as-is.
+
+- [ ] **Step 3: Replace the body of `refreshTracker()` with bar-aware rendering**
+
+Find the existing `refreshTracker()` function (currently lines 160–174):
+
+```typescript
+async function refreshTracker(): Promise<void> {
+  const settingsResult = await chrome.storage.sync.get('hcSettings');
+  const userSettings = migrateSettings(settingsResult['hcSettings'] || {});
+  const tracker = await loadSpendingTracker(userSettings);
+
+  trackerDailyEl.textContent = `$${(tracker.dailyTotal ?? 0).toFixed(2)}`;
+
+  trackerWeeklyEl.textContent = `$${(tracker.weeklyTotal ?? 0).toFixed(2)}`;
+  trackerMonthlyEl.textContent = `$${(tracker.monthlyTotal ?? 0).toFixed(2)}`;
+
+  const weeklyEnabled = userSettings.weeklyCap?.enabled ?? false;
+  const monthlyEnabled = userSettings.monthlyCap?.enabled ?? false;
+  trackerWeeklyRowEl.hidden = !weeklyEnabled;
+  trackerMonthlyRowEl.hidden = !monthlyEnabled;
+}
+```
+
+Replace it with:
+
+```typescript
+async function refreshTracker(): Promise<void> {
+  // Cap config comes from pending state so live edits to cap inputs
+  // update the bars before the user clicks Save.
+  const pending = getPending();
+  // Tracker totals come from chrome.storage.local (read-only here — popup
+  // never mutates the tracker). loadSpendingTracker handles auto-resets.
+  const settingsForTracker = await (async () => {
+    const stored = await chrome.storage.sync.get('hcSettings');
+    return migrateSettings(stored['hcSettings'] || {});
+  })();
+  const tracker = await loadSpendingTracker(settingsForTracker);
+
+  const dailyTotal = tracker.dailyTotal ?? 0;
+  const weeklyTotal = tracker.weeklyTotal ?? 0;
+  const monthlyTotal = tracker.monthlyTotal ?? 0;
+
+  // Always set the text-value spans — they're the fallback when no bar renders.
+  trackerDailyEl.textContent = `$${dailyTotal.toFixed(2)}`;
+  trackerWeeklyEl.textContent = `$${weeklyTotal.toFixed(2)}`;
+  trackerMonthlyEl.textContent = `$${monthlyTotal.toFixed(2)}`;
+
+  // Daily: cap on → bar; cap off → text row (always visible per current behavior).
+  renderCapRow(
+    'Daily',
+    dailyTotal,
+    pending.dailyCap,
+    trackerDailyTextEl,
+    trackerDailyBarEl,
+    /* showTextWhenCapOff */ true,
+  );
+
+  // Weekly/Monthly: cap on → bar; cap off → entire row hidden (current behavior).
+  renderCapRow(
+    'Weekly',
+    weeklyTotal,
+    pending.weeklyCap,
+    trackerWeeklyRowEl,
+    trackerWeeklyBarEl,
+    /* showTextWhenCapOff */ false,
+  );
+  renderCapRow(
+    'Monthly',
+    monthlyTotal,
+    pending.monthlyCap,
+    trackerMonthlyRowEl,
+    trackerMonthlyBarEl,
+    /* showTextWhenCapOff */ false,
+  );
+}
+```
+
+- [ ] **Step 4: Add the `renderCapRow` helper above `refreshTracker`**
+
+Add this helper function to `src/popup/sections/limits.ts`, immediately above the `refreshTracker` function (still inside the `initLimits` closure, so it has access to nothing it shouldn't):
+
+```typescript
+/**
+ * Render one tracker row as either a progress bar (cap enabled with non-zero
+ * amount) or as a plain text row / hidden state (cap disabled or amount=0).
+ *
+ * @param textRowEl The .hc-row element holding the label + value spans.
+ * @param barHostEl The sibling .hc-cap-bar-host slot.
+ * @param showTextWhenCapOff true for daily (always visible), false for
+ *   weekly/monthly (hidden until their cap is enabled).
+ */
+function renderCapRow(
+  label: 'Daily' | 'Weekly' | 'Monthly',
+  total: number,
+  cap: { enabled: boolean; amount: number },
+  textRowEl: HTMLElement,
+  barHostEl: HTMLElement,
+  showTextWhenCapOff: boolean,
+): void {
+  const barHtml = cap.enabled
+    ? buildCapProgressBar(label, total, 0, cap.amount)
+    : '';
+
+  if (barHtml) {
+    barHostEl.innerHTML = barHtml;
+    barHostEl.hidden = false;
+    textRowEl.hidden = true;
+  } else {
+    barHostEl.innerHTML = '';
+    barHostEl.hidden = true;
+    textRowEl.hidden = !showTextWhenCapOff;
+  }
+}
+```
+
+- [ ] **Step 5: Run the existing test suite**
+
+Run:
+```bash
+npx jest
+```
+
+Expected: all tests pass. There are no DOM-rendering tests for `limits.ts`, but the existing tests (escalation, spendingTracker, types, etc.) should be unaffected.
+
+- [ ] **Step 6: Build the extension**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7: Manual smoke test of bar rendering**
+
+Reload the unpacked extension. Open the popup.
+
+1. Confirm no caps enabled: the Limits section shows plain `Daily total $X.XX` only (weekly/monthly hidden). Same as today.
+2. Enable Daily cap, set amount to $50, click Save Settings, reopen popup. Confirm the Daily row now shows a green bar `DAILY $0.00 / $50.00 (0%)` (or whatever the current daily total is). The plain text row is hidden.
+3. Enable Weekly + Monthly caps with non-zero amounts, click Save, reopen. Confirm both render as bars.
+4. Disable Daily cap, click Save, reopen. Confirm the green bar disappears and the plain text row reappears.
+
+Live updates from cap-input edits don't work yet — that comes in Task 6.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/popup/sections/limits.ts
+git commit -m "feat(popup): render cap progress bars in Limits section
+
+refreshTracker() now picks per-row between bar (cap enabled) and text
+(cap disabled). Cap config sourced from pending state so future cap
+input edits can repaint bars without saving first. Tracker totals
+still read from chrome.storage.local."
+```
+
+---
+
+## Task 6: Wire `refreshTracker` into the `onCapChange` callback
+
+**Files:**
+- Modify: `src/popup/popup.ts:244` (the `initLimits` call inside `main()`)
+
+Today, the `onCapChange` callback only triggers escalation recomputation. We need it to also repaint the bars so cap toggles and amount edits update visually before Save.
+
+- [ ] **Step 1: Update the `onCapChange` callback**
+
+Find the existing line in `src/popup/popup.ts` (around line 244):
+
+```typescript
+const limits = initLimits(limitsEl, { onCapChange: () => updateEscalation() });
+```
+
+Replace it with:
+
+```typescript
+const limits = initLimits(limitsEl, {
+  onCapChange: () => {
+    updateEscalation();
+    // Repaint cap progress bars on cap toggle/amount edits.
+    // limits is in the closure scope; resolved at call-time, not init-time
+    // (same pattern updateEscalation uses to reach `friction`).
+    limits.refreshTracker();
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors. The `limits` reference inside the callback resolves at runtime via closure, the same pattern `updateEscalation()` already uses to reach `friction`.
+
+If TypeScript complains about "Block-scoped variable 'limits' used before its declaration," investigate — `updateEscalation`'s reference to `friction` works because TS allows the use inside function/arrow bodies as long as actual invocation happens later. If somehow this is rejected here, fall back to:
+
+```typescript
+let limitsRef: ReturnType<typeof initLimits> | null = null;
+const limits = initLimits(limitsEl, {
+  onCapChange: () => {
+    updateEscalation();
+    limitsRef?.refreshTracker();
+  },
+});
+limitsRef = limits;
+```
+
+- [ ] **Step 3: Run the test suite**
+
+Run:
+```bash
+npx jest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Manual smoke test of live updates**
+
+Reload the unpacked extension. Open the popup.
+
+1. Enable Daily cap, set amount to $50. As you edit the amount input (don't click Save), the bar percentage should update live with each keystroke.
+2. Toggle Daily cap off — bar disappears immediately, text row reappears.
+3. Toggle Daily cap on — bar reappears immediately.
+4. Click Save Settings. Close and reopen popup. Confirm the bar persists with the saved cap amount.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/popup/popup.ts
+git commit -m "feat(popup): live-update cap bars on toggle/amount edits
+
+Extends the Limits onCapChange callback to also call refreshTracker()
+so the bars repaint as the user toggles caps or edits cap amount inputs
+— no Save click required for visual feedback."
+```
+
+---
+
+## Task 7: Run the full manual test plan from the spec
+
+**Files:** none (verification task)
+
+This task executes test cases #1–12 from `docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md` "Manual Test Plan" section. No code changes; if any case fails, return to the responsible task and fix.
+
+- [ ] **Step 1: Reload the unpacked extension fresh**
+
+At chrome://extensions, click "Reload" on the Hype Control extension. Then close any open popups.
+
+- [ ] **Step 2: Execute test case #1 — fresh / no caps**
+
+Disable all three caps (daily, weekly, monthly), click Save, reopen popup. Expected: Daily row shows plain `Daily total $X.XX`; weekly/monthly rows hidden. No bars visible. Pass/fail: ___.
+
+- [ ] **Step 3: Execute test case #2 — enable daily cap**
+
+Enable Daily cap, set $50, click Save, reopen. Expected: Daily row is now a green bar with `DAILY` on the left and `$X.XX / $50.00 (NN%)` on the right. Pass/fail: ___.
+
+- [ ] **Step 4: Execute test case #3 — bar after a $10 intercepted purchase**
+
+On a Twitch channel, attempt a $10 purchase via the Bits panel and complete the friction (let it through). Reopen popup. Expected: bar shows current-total / $50.00 (NN%) in green. Pass/fail: ___.
+
+- [ ] **Step 5: Execute test case #4 — over budget**
+
+Push the daily tracker over $50 by completing additional purchases (or temporarily set the daily cap to $5 if the tracker is already at $10+, then revert). Reopen popup. Expected: bar shows `$X.XX / $50.00 — OVER BUDGET` in red, fill at full width. Pass/fail: ___.
+
+- [ ] **Step 6: Execute test case #5 — disable daily cap**
+
+Toggle Daily cap off, click Save, reopen. Expected: bar disappears, plain text row reappears with current dollar value. Pass/fail: ___.
+
+- [ ] **Step 7: Execute test case #6 — enable weekly + monthly**
+
+Enable Weekly cap ($200) and Monthly cap ($800), click Save, reopen. Expected: both rows render as bars. Pass/fail: ___.
+
+- [ ] **Step 8: Execute test case #7 — disable weekly cap**
+
+Toggle Weekly cap off, click Save, reopen. Expected: weekly bar AND text row both hidden. Pass/fail: ___.
+
+- [ ] **Step 9: Execute test case #8 — live edit of daily amount**
+
+With Daily cap enabled at $50, click into the daily cap amount input, change to `20`. As you type, the bar's percentage and tier should update live (e.g., $10 spent / $20 cap = 50% green; $25 spent / $20 = OVER BUDGET red). Click Save. Reopen and confirm persists. Pass/fail: ___.
+
+- [ ] **Step 10: Execute test case #9 — theme switch**
+
+In Settings section, switch theme dark → light → auto. Bars should re-render with the appropriate light-mode hex values. Confirm green/yellow/orange/red all look correct in light mode (slightly darker shades than dark mode). Pass/fail: ___.
+
+- [ ] **Step 11: Execute test case #10 — friction overlay regression**
+
+On a Twitch channel, trigger a real friction event (Bits attempt, Sub attempt, or `/gift` command). Confirm the overlay's existing cap progress bars still render correctly — same color tier, same `$X.XX / $Y.YY (NN%)` formatting, same fill widths. Pass/fail: ___.
+
+- [ ] **Step 12: Execute test case #11 — cap enabled with amount = 0**
+
+Enable Daily cap, set amount to `0`, click Save. Reopen popup. Expected: no bar rendered for daily; plain text row visible (because the empty-string guard in `buildCapProgressBar` returned `''` and `renderCapRow` falls back to text-with-`showTextWhenCapOff=true`). Pass/fail: ___.
+
+- [ ] **Step 13: Execute test case #12 — Reset Tracker**
+
+With caps enabled and tracker > $0, click Reset Tracker, confirm with "Wipe it". Expected: all bars instantly re-render at 0% green. Pass/fail: ___.
+
+- [ ] **Step 14: If any test case failed, return to the responsible task**
+
+Match failures back to the implementing task:
+- #1, #5, #7, #11 → likely Task 5 (limits.ts rendering logic)
+- #2, #3, #6, #13 → likely Task 5 or Task 4 (markup / refresh)
+- #4 → Task 1 (over-budget logic in capBar.ts)
+- #8 → Task 6 (live update wiring)
+- #9 → Task 3 (light-mode CSS variables)
+- #10 → Task 2 (interceptor migration regression)
+- #12 → Task 1 (capAmount<=0 guard)
+
+If all pass, proceed to Task 8.
+
+---
+
+## Task 8: Update `HypeControl-TODO.md`
+
+**Files:**
+- Modify: `docs/dev/HypeControl-TODO.md`
+
+- [ ] **Step 1: Read the current state of the TODO**
+
+Run:
+```bash
+head -60 docs/dev/HypeControl-TODO.md
+```
+
+Note the format used for completed items, the `Updated` date, and `Current Version` fields.
+
+- [ ] **Step 2: Add the completion entry**
+
+In the appropriate section (likely an "Add-ons" or "v1.1.x" or similar block — match existing structure), add a checked entry along the lines of:
+
+```markdown
+- [x] **Limits Progress Bars in Popup** — Replaced plain text trackers in the popup Limits section with the same colored progress bar widget the friction overlay uses. Bars only render when their cap is enabled; cap-disabled rows fall back to current text behavior. Live updates on cap-input edits via the existing onCapChange callback. Spec: `docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md`. Plan: `docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md`.
+```
+
+Also update the `Updated:` date in the header (set to today's date — 2026-04-29 unless executing later) and the footer timestamp if one exists.
+
+Do NOT update `Current Version` in the header — versioning is handled separately by `npm run release` per `docs/dev/RELEASE-PROCESS.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/HypeControl-TODO.md
+git commit -m "docs: mark limits progress bars feature complete in TODO"
+```
+
+---
+
+## Task 9: Push branch and open PR (NOT merge)
+
+**Files:** none
+
+- [ ] **Step 1: Run security review on the branch BEFORE pushing**
+
+Per the user's standing feedback (`feedback_security_review_before_pr.md`), `/security-review` must run on the branch before opening the PR — treated as a non-negotiable pre-push gate.
+
+In the Claude Code session, run:
+```
+/security-review
+```
+
+Expected: clean report. The new code is a CSS-and-DOM addition with no user-controlled data flowing into innerHTML (label is hardcoded constants, values are numeric). The shared module's amount guard is a defensive improvement.
+
+If `/security-review` flags anything, address it before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/limits-progress-bars-in-popup
+```
+
+- [ ] **Step 3: Open the PR (do NOT merge)**
+
+Per the user's standing rule: open the PR and stop. Never run `gh pr merge` without explicit user approval.
+
+```bash
+gh pr create --title "feat: limits progress bars in popup Limits section" --body "$(cat <<'EOF'
+## Summary
+
+- Extracted `getCapColorClass` + `buildCapProgressBar` from `interceptor.ts` into new shared module `src/shared/capBar.ts`
+- Popup Limits section now renders the same colored progress bars the friction overlay uses, when caps are enabled
+- Cap-disabled rows fall back to existing text behavior (no UX change for users without caps)
+- Cap-amount edits live-update bars via the existing `onCapChange` callback
+- Added `capAmount <= 0` guard in the shared widget — fixes a latent edge case in the friction overlay too
+
+Spec: `docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md`
+Plan: `docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md`
+
+## Test plan
+
+- [x] New unit tests for `capBar.ts` (15 tests, all four tier boundaries + over-budget + amount guard)
+- [x] Existing test suite green
+- [x] Manual: fresh install, no caps → unchanged
+- [x] Manual: enable daily cap → green bar replaces text row
+- [x] Manual: push tracker over budget → red bar with `OVER BUDGET`
+- [x] Manual: cap enabled with amount=0 → text fallback (guard works)
+- [x] Manual: live update on cap input edits
+- [x] Manual: theme switch dark/light/auto
+- [x] Manual: friction overlay still renders bars (regression check)
+EOF
+)"
+```
+
+Stop here. Report the PR URL to the user and wait for explicit approval before any merge.
+
+---
+
+## Self-Review Checklist (already performed; documented for executors)
+
+- **Spec coverage:** All seven file changes listed in the spec map to tasks (capBar.ts → T1, interceptor.ts → T2, popup.css → T3, popup.html → T4, limits.ts → T5, popup.ts → T6, HypeControl-TODO.md → T8). All 12 manual test cases have explicit steps in T7.
+- **Placeholder scan:** No TBDs, TODOs, or "implement later" stubs. Every code step has complete code.
+- **Type consistency:** `buildCapProgressBar` signature is identical across the shared module, `interceptor.ts` callers (Task 2 leaves them untouched), and the new `limits.ts` callers (Task 5 calls with `purchaseAmount = 0`). `LimitsCallbacks.onCapChange` signature unchanged. `LimitsController` exposes `refreshTracker` already (used in Task 6).
+- **Ambiguity check:** TypeScript closure-over-`limits` pattern in Task 6 includes a fallback in case TS is stricter than expected. CSS placement in Task 3 is described by selector + targeting (after existing rules), not by line number, since prior tasks shift line numbers.

--- a/docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md
+++ b/docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md
@@ -1,0 +1,178 @@
+# Limits Progress Bars in Popup — Design
+
+**Status:** Spec
+**Date:** 2026-04-29
+**Branch:** `feat/limits-progress-bars-in-popup`
+
+## Goal
+
+Replace the plain-text spending tracker rows in the popup's Limits section with the same visual progress-bar widget the friction overlay already shows during intercepts. Bars only render when the corresponding cap is enabled; cap-disabled rows fall back to the existing text behavior. No new settings, no toggle, no new UI chrome.
+
+## Why
+
+Today, a user with daily/weekly/monthly caps enabled has to trigger a purchase to see where they stand against those caps — the popup only shows raw dollar totals. Surfacing the same colored bars in the popup turns the Limits section into an at-a-glance status view, reinforces the "Green means saved" brand principle, and reuses a widget that already exists rather than inventing a parallel one.
+
+## Scope
+
+**In scope:**
+- In-place visual upgrade of the daily/weekly/monthly tracker rows in the popup's Limits section
+- Extracting the bar-rendering logic into a shared module
+- Adding the necessary CSS variables and rules to `popup.css`
+- Live updates so bars react to cap-amount edits before Save
+
+**Out of scope:**
+- Any change to the friction overlay's appearance or rendering behavior
+- New settings, display toggles, or user preferences
+- Section-level highlighting or "celebrate winning" success treatment
+- Restructuring popup section layout, navigation, or other rows
+
+## Architecture
+
+New shared module **`src/shared/capBar.ts`** exposes two pure functions, extracted verbatim from `src/content/interceptor.ts:318-356`:
+
+```typescript
+export function getCapColorClass(percentage: number): string;
+export function buildCapProgressBar(
+  label: string,
+  currentTotal: number,
+  priceDelta: number,
+  capAmount: number,
+): string;
+```
+
+- The friction overlay calls `buildCapProgressBar('Daily', tracker.dailyTotal, priceWithTax, settings.dailyCap.amount)`.
+- The popup calls `buildCapProgressBar('Daily', tracker.dailyTotal, 0, settings.dailyCap.amount)`.
+
+Same signature; the popup just passes `0` for `priceDelta` because there's no in-flight purchase.
+
+**Defensive guard added during extraction:** when `capAmount <= 0`, `buildCapProgressBar` returns an empty string. Callers must treat empty-string output as "no bar" and skip emitting it. This also prevents a 100% red bar appearing in the friction overlay when a user enables a cap but hasn't set an amount — a small positive side effect.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/shared/capBar.ts` | **NEW** — extracted `getCapColorClass` and `buildCapProgressBar`; adds `capAmount <= 0` guard |
+| `src/content/interceptor.ts` | Remove local copies of both functions (lines 318-356); add `import { buildCapProgressBar } from '../shared/capBar';` |
+| `src/popup/sections/limits.ts` | Import `buildCapProgressBar` from shared module; render bars in `refreshTracker()`; switch cap-value source from `chrome.storage.sync` to `getPending()`; expose `refreshTracker()` so popup can call it from the existing `onCapChange` callback alongside `updateEscalation()` |
+| `src/popup/popup.html` | Add `id="tracker-daily-text"` to the Daily row in `.hc-group` (currently has no row-level id); add three sibling slots: `<div class="hc-cap-bar-host" id="tracker-{daily,weekly,monthly}-bar" hidden></div>` |
+| `src/popup/popup.css` | Add `--hc-*` CSS variables to `:root` and `[data-theme="light"]`; add `.hc-cap-bar*` and tier rules; add `.hc-cap-bar-host` for row rhythm |
+
+No changes to `types.ts`, no migration logic, no new settings, no version bump (release timing handled separately per `docs/dev/RELEASE-PROCESS.md`).
+
+## Behavior
+
+### Visibility per row
+
+| Period | Cap enabled | Cap disabled |
+|--------|-------------|--------------|
+| Daily | Bar visible, text row hidden | Text row visible (current behavior) |
+| Weekly | Bar visible, text row hidden | Both hidden (current behavior) |
+| Monthly | Bar visible, text row hidden | Both hidden (current behavior) |
+
+For users with no caps enabled, the popup looks identical to today.
+
+### Bar values
+
+- **Label:** hardcoded constant — `'Daily'`, `'Weekly'`, or `'Monthly'`. Uppercased by CSS (`text-transform: uppercase`).
+- **Header right-side text:** `$<currentTotal> / $<capAmount> (<percentage>%)`, or `$<currentTotal> / $<capAmount> — OVER BUDGET` when `currentTotal > capAmount`.
+- **Color tier (existing 4-tier scale):**
+  - `hc-cap-green` — < 60%
+  - `hc-cap-yellow` — 60–79%
+  - `hc-cap-orange` — 80–99%
+  - `hc-cap-red` — ≥ 100%
+
+### Live updates
+
+`refreshTracker()` switches its cap-value source from `chrome.storage.sync.get('hcSettings')` to `getPending()` (the popup's in-memory pending state, already kept in sync with every input keystroke). Tracker totals (`dailyTotal`, `weeklyTotal`, `monthlyTotal`) still come from `chrome.storage.local` (read-only here — popup never mutates the tracker).
+
+`refreshTracker()` is called in three places:
+1. On popup load (already wired in `popup.ts:269`)
+2. From `popup.ts:244` — the `onCapChange` callback for the Limits controller is extended to call both `updateEscalation()` (existing) and `limits.refreshTracker()` (new), so toggling a cap or editing its amount triggers a bar repaint
+3. After "Wipe it" (Reset Tracker) — already wired in `limits.ts:144`
+
+## CSS
+
+### Variables
+
+Added to `src/popup/popup.css` `:root` block (defaults — match overlay's dark-mode values from `styles.css:36-58`):
+
+```css
+--hc-success: #22C55E;
+--hc-success-rgb: 34, 197, 94;
+--hc-danger: #e91916;
+--hc-danger-rgb: 233, 25, 22;
+--hc-warning: #F97316;
+--hc-warning-rgb: 249, 115, 22;
+--hc-caution: #EAB308;
+--hc-caution-rgb: 234, 179, 8;
+--hc-progress-bg: #2a2a2e;
+```
+
+Added to `[data-theme="light"]` block (overrides — match overlay's light-mode values from `styles.css:74-77`):
+
+```css
+--hc-success: #16A34A;
+--hc-warning: #EA580C;
+--hc-caution: #CA8A04;
+--hc-caution-rgb: 202, 138, 4;
+```
+
+These duplicate the values of existing `--success` / `--danger` tokens in popup. The duplication is intentional: the shared bar CSS uses `--hc-*` names, so adding them to popup keeps a single canonical bar stylesheet across both surfaces. Normalizing the popup's variable namespace is out of scope.
+
+### Rules
+
+Copied verbatim from `src/content/styles.css:269-337` into `popup.css` (the `.hc-cap-bars` wrapper at lines 262-267 is **not** copied — bars in the popup are interleaved with other rows, not stacked as a single block):
+
+- `.hc-cap-bar`
+- `.hc-cap-bar__header`, `.hc-cap-bar__label`
+- `.hc-cap-bar__track`, `.hc-cap-bar__fill`
+- `.hc-cap-green`, `.hc-cap-yellow`, `.hc-cap-orange`, `.hc-cap-red` (and their `.hc-cap-{tier} .hc-cap-bar__fill` companions)
+
+There is no `.hc-cap-bar__value` rule in the source; the value span uses inherited typography.
+
+Plus one new rule for the host slot:
+
+```css
+.hc-cap-bar-host {
+  /* Vertical rhythm matching other .hc-row elements in .hc-group */
+}
+```
+
+Exact margin/padding values matched to the existing row gap at implementation time.
+
+## Edge Cases
+
+1. **Cap enabled, amount = 0.** Guard in `capBar.ts` returns empty string. Popup treats it as "no bar" and falls back to the text row (daily) or hidden state (weekly/monthly). Friction overlay also benefits from this guard.
+2. **Tracker totals at $0.** Bar renders at 0%, green tier. No special handling.
+3. **`currentTotal > capAmount`.** Fill width capped at 100% (existing logic in `buildCapProgressBar`); header shows `— OVER BUDGET` in place of `(NN%)`. Tier is red.
+4. **Theme switch mid-session.** `applyTheme()` flips `[data-theme="light"]` on `documentElement`; CSS variable cascade re-resolves bar colors automatically. No JS recomputation.
+5. **User-controlled data in bar markup.** None. Label is a string constant; values are numeric. The existing safety comment in `buildCapProgressBar` ("innerHTML is safe here") remains valid in the popup context.
+6. **Cap amount edited but not yet saved.** Bar reflects the in-memory pending state immediately. If user closes popup without saving, next open shows the saved-state bar — same as every other pending field today.
+
+## Manual Test Plan
+
+| # | Action | Expected |
+|---|--------|----------|
+| 1 | Fresh install, no caps enabled | Plain text "Daily total $0.00"; weekly/monthly rows hidden — *unchanged from today* |
+| 2 | Enable daily cap, set $50, click Save, reopen popup | Daily row is a green bar with `DAILY` on the left and `$0.00 / $50.00 (0%)` on the right |
+| 3 | Complete an intercepted $10 purchase, reopen popup | Bar shows `$10.00 / $50.00 (20%)`, green tier |
+| 4 | Push tracker over $50 (multiple completed purchases) | Bar shows `$X.XX / $50.00 — OVER BUDGET`, red tier, fill at 100% width |
+| 5 | Toggle daily cap off | Bar disappears, plain text row reappears with current $ value |
+| 6 | Enable weekly + monthly caps with non-zero amounts | Both rows render as bars in their appropriate tier |
+| 7 | Disable weekly cap | Weekly bar AND text row both hidden (current behavior preserved) |
+| 8 | Edit daily cap amount input from $50 → $20 (don't save) | Bar percentage and tier update live as user types; on Save, persists |
+| 9 | Switch popup theme: dark → light → auto | Bars use the light-mode hex values; transitions smoothly |
+| 10 | Trigger a real friction event on Twitch (regression) | Friction overlay bars still render correctly — shared module extraction did not break the source surface |
+| 11 | Enable daily cap with amount = 0 | Treated as disabled — text row shown for daily, bar suppressed |
+| 12 | Reset Tracker via "Wipe it" | All bars instantly re-render at 0% green |
+
+## Risks
+
+1. **Shared-module extraction breaks the friction overlay.** Function signature is unchanged; only the source file moves. Test case #10 is the regression check.
+2. **CSS variable namespace duplication in popup.** `--success` and `--hc-success` will both exist with the same value. Long-term debt; could be normalized in a future maintenance pass. Acceptable for this feature.
+3. **Bar host row spacing visually inconsistent with surrounding rows.** Visual-only, caught by inspection at implementation time.
+4. **Live updates on input might cause flicker on rapid keystrokes.** Each keystroke triggers `refreshTracker` → `loadSpendingTracker` → bar re-render. The async `loadSpendingTracker` could race if input is faster than storage round-trip. Mitigation: tracker totals don't change while editing cap inputs, so we can cache the tracker fetch and only re-read it on tracker-affecting events. *Decision deferred to implementation* — try the naive approach first, optimize if visible flicker occurs.
+
+## Follow-ups
+
+None. Scope was deliberately kept tight. If future signal arrives for any of the rejected design directions (display toggle, section-level winning highlight, co-located bars next to cap toggles), each would be a separate spec.

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -17,6 +17,7 @@ import { log, debug } from '../shared/logger';
 import { writeInterceptEvent } from '../shared/interceptLogger';
 import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
 import { loadSpendingTracker, recordPurchase } from '../shared/spendingTracker';
+import { buildCapProgressBar } from '../shared/capBar';
 
 // ── Zero Trust no-price overlay messages ────────────────────────────────
 // Two tonal buckets: matter-of-fact and cheeky. Selection alternates buckets
@@ -313,47 +314,6 @@ function formatComparisonDisplay(item: ComparisonItem, purchaseAmount: number, t
     labelText: `of a ${item.name}`,
     sentence: `That ${taxPrice} is only ~${percent}% of a ${item.name}`,
   };
-}
-
-/**
- * Determine the color tier for a cap progress bar.
- * Green < 60%, Yellow 60–79%, Orange 80–99%, Red 100%+
- */
-function getCapColorClass(percentage: number): string {
-  if (percentage >= 100) return 'hc-cap-red';
-  if (percentage >= 80) return 'hc-cap-orange';
-  if (percentage >= 60) return 'hc-cap-yellow';
-  return 'hc-cap-green';
-}
-
-/**
- * Build a single cap progress bar HTML string.
- * Label is constrained to known static values — never user-controlled.
- * Numeric values are computed internally. innerHTML is safe here.
- */
-function buildCapProgressBar(
-  label: 'Daily' | 'Weekly' | 'Monthly',
-  currentTotal: number,
-  purchaseAmount: number,
-  capAmount: number,
-): string {
-  const newTotal = Math.round((currentTotal + purchaseAmount) * 100) / 100;
-  const percentage = Math.round((newTotal / capAmount) * 100);
-  const barWidth = Math.min(percentage, 100);
-  const colorClass = getCapColorClass(percentage);
-  const overBudget = newTotal > capAmount;
-
-  return `
-    <div class="hc-cap-bar ${colorClass}">
-      <div class="hc-cap-bar__header">
-        <span class="hc-cap-bar__label">${label}</span>
-        <span class="hc-cap-bar__value">$${newTotal.toFixed(2)} / $${capAmount.toFixed(2)}${overBudget ? ' — OVER BUDGET' : ` (${percentage}%)`}</span>
-      </div>
-      <div class="hc-cap-bar__track">
-        <div class="hc-cap-bar__fill" style="width: ${barWidth}%"></div>
-      </div>
-    </div>
-  `;
 }
 
 /**

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -43,6 +43,16 @@
   --radius: 6px;
   --font: 'Space Grotesk', sans-serif;
   --accent-text: #bf94ff;
+  /* Bar widget tokens (mirror src/content/styles.css for the shared .hc-cap-bar* rules) */
+  --hc-success: #22C55E;
+  --hc-success-rgb: 34, 197, 94;
+  --hc-danger: #e91916;
+  --hc-danger-rgb: 233, 25, 22;
+  --hc-warning: #F97316;
+  --hc-warning-rgb: 249, 115, 22;
+  --hc-caution: #EAB308;
+  --hc-caution-rgb: 234, 179, 8;
+  --hc-progress-bg: #2a2a2e;
 }
 
 /* ─── Light mode overrides ───────────────────────────────── */
@@ -60,6 +70,11 @@
   --success: #16A34A;
   --accent-rgb: 124, 58, 237;
   --success-rgb: 22, 163, 74;
+  /* Bar widget light-mode overrides */
+  --hc-success: #16A34A;
+  --hc-warning: #EA580C;
+  --hc-caution: #CA8A04;
+  --hc-caution-rgb: 202, 138, 4;
 }
 
 [data-theme="light"] .calendar-cell.tier-grass {
@@ -1078,3 +1093,80 @@ body {
    It is used in overlay HTML rendered by interceptor.ts (content script),
    which loads src/content/styles.css — not popup.css.
    The badge style is defined in Task 9 (styles.css). */
+
+/* ─── Cap progress bars (shared widget — mirrors src/content/styles.css) ─── */
+
+.hc-cap-bar-host {
+  /* Match the vertical rhythm of sibling .hc-row elements inside .hc-group */
+  margin-top: 8px;
+}
+
+.hc-cap-bar {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+}
+
+.hc-cap-bar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.hc-cap-bar__label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hc-cap-bar__track {
+  height: 4px;
+  background: var(--hc-progress-bg, #2a2a2e);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.hc-cap-bar__fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+/* Color tiers */
+.hc-cap-green {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.2);
+  color: var(--hc-success);
+}
+.hc-cap-green .hc-cap-bar__fill {
+  background: var(--hc-success);
+}
+
+.hc-cap-yellow {
+  background: rgba(var(--hc-caution-rgb), 0.1);
+  border-color: rgba(var(--hc-caution-rgb), 0.2);
+  color: var(--hc-caution);
+}
+.hc-cap-yellow .hc-cap-bar__fill {
+  background: var(--hc-caution);
+}
+
+.hc-cap-orange {
+  background: rgba(var(--hc-warning-rgb), 0.1);
+  border-color: rgba(var(--hc-warning-rgb), 0.2);
+  color: var(--hc-warning);
+}
+.hc-cap-orange .hc-cap-bar__fill {
+  background: var(--hc-warning);
+}
+
+.hc-cap-red {
+  background: rgba(var(--hc-danger-rgb), 0.1);
+  border-color: rgba(var(--hc-danger-rgb), 0.2);
+  color: var(--hc-danger);
+}
+.hc-cap-red .hc-cap-bar__fill {
+  background: var(--hc-danger);
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -306,18 +306,21 @@
           </select>
         </div>
         <div class="hc-group">
-          <div class="hc-row">
+          <div class="hc-row" id="tracker-daily-text">
             <span class="hc-label">Daily total</span>
             <span class="tracker-value" id="tracker-daily">—</span>
           </div>
+          <div class="hc-cap-bar-host" id="tracker-daily-bar" hidden></div>
           <div class="hc-row" id="tracker-weekly-row" hidden>
             <span class="hc-label">Weekly total</span>
             <span class="tracker-value" id="tracker-weekly">—</span>
           </div>
+          <div class="hc-cap-bar-host" id="tracker-weekly-bar" hidden></div>
           <div class="hc-row" id="tracker-monthly-row" hidden>
             <span class="hc-label">Monthly total</span>
             <span class="tracker-value" id="tracker-monthly">—</span>
           </div>
+          <div class="hc-cap-bar-host" id="tracker-monthly-bar" hidden></div>
           <div class="hc-row">
             <span class="hc-label">Savings calendar</span>
             <button class="btn-icon" id="btn-calendar" aria-label="Toggle savings calendar" title="View savings calendar">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -241,7 +241,15 @@ async function main(): Promise<void> {
     onLockChange: () => updateEscalation(),
   });
 
-  const limits = initLimits(limitsEl, { onCapChange: () => updateEscalation() });
+  const limits = initLimits(limitsEl, {
+    onCapChange: () => {
+      updateEscalation();
+      // Repaint cap progress bars on cap toggle/amount edits.
+      // limits is in the closure scope; resolved at call-time, not init-time
+      // (same pattern updateEscalation uses to reach `friction`).
+      limits.refreshTracker();
+    },
+  });
 
   const stats = initStats(statsEl);
 

--- a/src/popup/sections/limits.ts
+++ b/src/popup/sections/limits.ts
@@ -2,6 +2,7 @@ import { UserSettings, DEFAULT_SPENDING_TRACKER, migrateSettings } from '../../s
 import { loadSpendingTracker, SPENDING_KEY } from '../../shared/spendingTracker';
 import { initCalendar } from './calendar';
 import { getPending, setPendingField } from '../pendingState';
+import { buildCapProgressBar } from '../../shared/capBar';
 
 export interface LimitsController {
   render(settings: UserSettings): void;
@@ -32,6 +33,12 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
   const trackerWeeklyRowEl = el.querySelector<HTMLElement>('#tracker-weekly-row')!;
   const trackerMonthlyEl = el.querySelector<HTMLElement>('#tracker-monthly')!;
   const trackerMonthlyRowEl = el.querySelector<HTMLElement>('#tracker-monthly-row')!;
+
+  // Tracker rows + bar host slots (one pair per period)
+  const trackerDailyTextEl = el.querySelector<HTMLElement>('#tracker-daily-text')!;
+  const trackerDailyBarEl = el.querySelector<HTMLElement>('#tracker-daily-bar')!;
+  const trackerWeeklyBarEl = el.querySelector<HTMLElement>('#tracker-weekly-bar')!;
+  const trackerMonthlyBarEl = el.querySelector<HTMLElement>('#tracker-monthly-bar')!;
 
   // Daily cap
   dailyCapEnabledEl.addEventListener('change', () => {
@@ -157,20 +164,86 @@ export function initLimits(el: HTMLElement, callbacks: LimitsCallbacks = {}): Li
     calendar.toggle();
   });
 
+  /**
+   * Render one tracker row as either a progress bar (cap enabled with non-zero
+   * amount) or as a plain text row / hidden state (cap disabled or amount=0).
+   *
+   * @param textRowEl The .hc-row element holding the label + value spans.
+   * @param barHostEl The sibling .hc-cap-bar-host slot.
+   * @param showTextWhenCapOff true for daily (always visible), false for
+   *   weekly/monthly (hidden until their cap is enabled).
+   */
+  function renderCapRow(
+    label: 'Daily' | 'Weekly' | 'Monthly',
+    total: number,
+    cap: { enabled: boolean; amount: number },
+    textRowEl: HTMLElement,
+    barHostEl: HTMLElement,
+    showTextWhenCapOff: boolean,
+  ): void {
+    const barHtml = cap.enabled
+      ? buildCapProgressBar(label, total, 0, cap.amount)
+      : '';
+
+    if (barHtml) {
+      barHostEl.innerHTML = barHtml;
+      barHostEl.hidden = false;
+      textRowEl.hidden = true;
+    } else {
+      barHostEl.innerHTML = '';
+      barHostEl.hidden = true;
+      textRowEl.hidden = !showTextWhenCapOff;
+    }
+  }
+
   async function refreshTracker(): Promise<void> {
-    const settingsResult = await chrome.storage.sync.get('hcSettings');
-    const userSettings = migrateSettings(settingsResult['hcSettings'] || {});
-    const tracker = await loadSpendingTracker(userSettings);
+    // Cap config comes from pending state so live edits to cap inputs
+    // update the bars before the user clicks Save.
+    const pending = getPending();
+    // Tracker totals come from chrome.storage.local (read-only here — popup
+    // never mutates the tracker). loadSpendingTracker handles auto-resets.
+    const settingsForTracker = await (async () => {
+      const stored = await chrome.storage.sync.get('hcSettings');
+      return migrateSettings(stored['hcSettings'] || {});
+    })();
+    const tracker = await loadSpendingTracker(settingsForTracker);
 
-    trackerDailyEl.textContent = `$${(tracker.dailyTotal ?? 0).toFixed(2)}`;
+    const dailyTotal = tracker.dailyTotal ?? 0;
+    const weeklyTotal = tracker.weeklyTotal ?? 0;
+    const monthlyTotal = tracker.monthlyTotal ?? 0;
 
-    trackerWeeklyEl.textContent = `$${(tracker.weeklyTotal ?? 0).toFixed(2)}`;
-    trackerMonthlyEl.textContent = `$${(tracker.monthlyTotal ?? 0).toFixed(2)}`;
+    // Always set the text-value spans — they're the fallback when no bar renders.
+    trackerDailyEl.textContent = `$${dailyTotal.toFixed(2)}`;
+    trackerWeeklyEl.textContent = `$${weeklyTotal.toFixed(2)}`;
+    trackerMonthlyEl.textContent = `$${monthlyTotal.toFixed(2)}`;
 
-    const weeklyEnabled = userSettings.weeklyCap?.enabled ?? false;
-    const monthlyEnabled = userSettings.monthlyCap?.enabled ?? false;
-    trackerWeeklyRowEl.hidden = !weeklyEnabled;
-    trackerMonthlyRowEl.hidden = !monthlyEnabled;
+    // Daily: cap on → bar; cap off → text row (always visible per current behavior).
+    renderCapRow(
+      'Daily',
+      dailyTotal,
+      pending.dailyCap,
+      trackerDailyTextEl,
+      trackerDailyBarEl,
+      /* showTextWhenCapOff */ true,
+    );
+
+    // Weekly/Monthly: cap on → bar; cap off → entire row hidden (current behavior).
+    renderCapRow(
+      'Weekly',
+      weeklyTotal,
+      pending.weeklyCap,
+      trackerWeeklyRowEl,
+      trackerWeeklyBarEl,
+      /* showTextWhenCapOff */ false,
+    );
+    renderCapRow(
+      'Monthly',
+      monthlyTotal,
+      pending.monthlyCap,
+      trackerMonthlyRowEl,
+      trackerMonthlyBarEl,
+      /* showTextWhenCapOff */ false,
+    );
   }
 
   function render(settings: UserSettings): void {

--- a/src/shared/capBar.ts
+++ b/src/shared/capBar.ts
@@ -1,0 +1,53 @@
+/**
+ * Determine the color tier for a cap progress bar.
+ * Green < 60%, Yellow 60–79%, Orange 80–99%, Red 100%+
+ */
+export function getCapColorClass(percentage: number): string {
+  if (percentage >= 100) return 'hc-cap-red';
+  if (percentage >= 80) return 'hc-cap-orange';
+  if (percentage >= 60) return 'hc-cap-yellow';
+  return 'hc-cap-green';
+}
+
+/**
+ * Build a single cap progress bar HTML string.
+ *
+ * Label is constrained to known static values — never user-controlled.
+ * Numeric values are computed internally. innerHTML of this string is safe.
+ *
+ * Returns '' (empty string) when `capAmount <= 0`. Callers must treat empty
+ * output as "no bar to render" and skip emitting it. This guards against
+ * divide-by-zero displays when a cap is enabled but its amount has not been
+ * set, and is used by both the friction overlay and the popup Limits section.
+ *
+ * @param label Hardcoded period label: 'Daily' | 'Weekly' | 'Monthly'.
+ * @param currentTotal Already-spent amount for the period.
+ * @param purchaseAmount Additional amount being attempted (overlay) or 0 (popup).
+ * @param capAmount Configured cap for the period.
+ */
+export function buildCapProgressBar(
+  label: 'Daily' | 'Weekly' | 'Monthly',
+  currentTotal: number,
+  purchaseAmount: number,
+  capAmount: number,
+): string {
+  if (capAmount <= 0) return '';
+
+  const newTotal = Math.round((currentTotal + purchaseAmount) * 100) / 100;
+  const percentage = Math.round((newTotal / capAmount) * 100);
+  const barWidth = Math.min(percentage, 100);
+  const colorClass = getCapColorClass(percentage);
+  const overBudget = newTotal > capAmount;
+
+  return `
+    <div class="hc-cap-bar ${colorClass}">
+      <div class="hc-cap-bar__header">
+        <span class="hc-cap-bar__label">${label}</span>
+        <span class="hc-cap-bar__value">$${newTotal.toFixed(2)} / $${capAmount.toFixed(2)}${overBudget ? ' — OVER BUDGET' : ` (${percentage}%)`}</span>
+      </div>
+      <div class="hc-cap-bar__track">
+        <div class="hc-cap-bar__fill" style="width: ${barWidth}%"></div>
+      </div>
+    </div>
+  `;
+}

--- a/tests/shared/capBar.test.ts
+++ b/tests/shared/capBar.test.ts
@@ -1,0 +1,122 @@
+import { getCapColorClass, buildCapProgressBar } from '../../src/shared/capBar';
+
+describe('getCapColorClass', () => {
+  test('returns hc-cap-green when percentage is 0', () => {
+    expect(getCapColorClass(0)).toBe('hc-cap-green');
+  });
+
+  test('returns hc-cap-green when percentage is 59', () => {
+    expect(getCapColorClass(59)).toBe('hc-cap-green');
+  });
+
+  test('returns hc-cap-yellow at exactly 60', () => {
+    expect(getCapColorClass(60)).toBe('hc-cap-yellow');
+  });
+
+  test('returns hc-cap-yellow when percentage is 79', () => {
+    expect(getCapColorClass(79)).toBe('hc-cap-yellow');
+  });
+
+  test('returns hc-cap-orange at exactly 80', () => {
+    expect(getCapColorClass(80)).toBe('hc-cap-orange');
+  });
+
+  test('returns hc-cap-orange when percentage is 99', () => {
+    expect(getCapColorClass(99)).toBe('hc-cap-orange');
+  });
+
+  test('returns hc-cap-red at exactly 100', () => {
+    expect(getCapColorClass(100)).toBe('hc-cap-red');
+  });
+
+  test('returns hc-cap-red when percentage exceeds 100', () => {
+    expect(getCapColorClass(150)).toBe('hc-cap-red');
+  });
+});
+
+describe('buildCapProgressBar', () => {
+  test('returns empty string when capAmount is 0', () => {
+    expect(buildCapProgressBar('Daily', 10, 0, 0)).toBe('');
+  });
+
+  test('returns empty string when capAmount is negative', () => {
+    expect(buildCapProgressBar('Daily', 10, 0, -5)).toBe('');
+  });
+
+  test('renders a bar with 0% green when current and delta are 0', () => {
+    const html = buildCapProgressBar('Daily', 0, 0, 100);
+    expect(html).toContain('hc-cap-green');
+    expect(html).toContain('Daily');
+    expect(html).toContain('$0.00 / $100.00');
+    expect(html).toContain('(0%)');
+    expect(html).toContain('width: 0%');
+  });
+
+  test('renders 50% green bar when current is 50 of 100', () => {
+    const html = buildCapProgressBar('Daily', 50, 0, 100);
+    expect(html).toContain('hc-cap-green');
+    expect(html).toContain('$50.00 / $100.00');
+    expect(html).toContain('(50%)');
+    expect(html).toContain('width: 50%');
+  });
+
+  test('renders 60% yellow bar at the green/yellow boundary', () => {
+    const html = buildCapProgressBar('Weekly', 60, 0, 100);
+    expect(html).toContain('hc-cap-yellow');
+    expect(html).toContain('Weekly');
+    expect(html).toContain('(60%)');
+  });
+
+  test('renders 85% orange bar', () => {
+    const html = buildCapProgressBar('Monthly', 85, 0, 100);
+    expect(html).toContain('hc-cap-orange');
+    expect(html).toContain('Monthly');
+    expect(html).toContain('(85%)');
+  });
+
+  test('renders 100% red bar with OVER BUDGET when newTotal exactly equals capAmount', () => {
+    // Boundary: newTotal == capAmount is treated as 100% (red), not over-budget.
+    const html = buildCapProgressBar('Daily', 100, 0, 100);
+    expect(html).toContain('hc-cap-red');
+    expect(html).toContain('(100%)');
+    expect(html).not.toContain('OVER BUDGET');
+  });
+
+  test('renders OVER BUDGET when newTotal exceeds capAmount', () => {
+    const html = buildCapProgressBar('Daily', 120, 0, 100);
+    expect(html).toContain('hc-cap-red');
+    expect(html).toContain('$120.00 / $100.00');
+    expect(html).toContain('OVER BUDGET');
+    expect(html).not.toContain('(120%)');
+  });
+
+  test('caps fill width at 100% when over budget', () => {
+    const html = buildCapProgressBar('Daily', 200, 0, 100);
+    expect(html).toContain('width: 100%');
+    expect(html).not.toContain('width: 200%');
+  });
+
+  test('adds purchaseAmount to currentTotal for the bar value', () => {
+    // Friction-overlay use case: current $40, in-flight $20, cap $100 → 60% yellow
+    const html = buildCapProgressBar('Daily', 40, 20, 100);
+    expect(html).toContain('hc-cap-yellow');
+    expect(html).toContain('$60.00 / $100.00');
+    expect(html).toContain('(60%)');
+  });
+
+  test('rounds the displayed total to 2 decimals', () => {
+    const html = buildCapProgressBar('Daily', 10.005, 0, 100);
+    // Math.round((10.005 + 0) * 100) / 100 = 10.01
+    expect(html).toContain('$10.01');
+  });
+
+  test('emits all four required structural classes', () => {
+    const html = buildCapProgressBar('Daily', 50, 0, 100);
+    expect(html).toContain('class="hc-cap-bar hc-cap-green"');
+    expect(html).toContain('class="hc-cap-bar__header"');
+    expect(html).toContain('class="hc-cap-bar__label"');
+    expect(html).toContain('class="hc-cap-bar__value"');
+    expect(html).toContain('class="hc-cap-bar__track"');
+    expect(html).toContain('class="hc-cap-bar__fill"');
+  });
+});

--- a/tests/shared/capBar.test.ts
+++ b/tests/shared/capBar.test.ts
@@ -74,7 +74,7 @@ describe('buildCapProgressBar', () => {
     expect(html).toContain('(85%)');
   });
 
-  test('renders 100% red bar with OVER BUDGET when newTotal exactly equals capAmount', () => {
+  test('renders 100% red bar at exactly the cap amount, with no OVER BUDGET label', () => {
     // Boundary: newTotal == capAmount is treated as 100% (red), not over-budget.
     const html = buildCapProgressBar('Daily', 100, 0, 100);
     expect(html).toContain('hc-cap-red');


### PR DESCRIPTION
## Summary

- Extracted `getCapColorClass` + `buildCapProgressBar` from `src/content/interceptor.ts` into a new shared module `src/shared/capBar.ts` so both the friction overlay and the popup can render the same widget
- Popup Limits section now renders the colored progress bars (4 tiers: green/yellow/orange/red) the friction overlay has always used
- Cap-disabled rows fall back to existing text behavior — no UX change for users without caps enabled
- Cap-amount edits live-update bars via the existing `onCapChange` callback (no Save click required for visual feedback)
- Added `capAmount <= 0` guard inside the shared widget that returns `''` instead of dividing by zero — fixes a latent edge case in the friction overlay too

Spec: [`docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md`](docs/dev/superpowers/specs/2026-04-29-limits-progress-bars-design.md)
Plan: [`docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md`](docs/dev/superpowers/plans/2026-04-29-limits-progress-bars.md)

## Test plan

- [x] New unit tests for `capBar.ts` — 20 tests covering all four tier boundaries, OVER BUDGET formatting, fill-width clamping, decimal rounding, and the new amount=0 guard
- [x] Full Jest suite green (128 tests across 9 suites)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Manual: fresh install, no caps → unchanged
- [x] Manual: enable daily cap → green bar replaces text row
- [x] Manual: push tracker over budget → red bar with `OVER BUDGET`
- [x] Manual: cap enabled with amount=0 → text fallback (guard works)
- [x] Manual: live update on cap input edits
- [x] Manual: theme switch dark/light/auto
- [x] Manual: friction overlay still renders bars (regression check)
- [x] `/security-review` clean — no high-confidence vulnerabilities, project XSS rule satisfied (numeric `.toFixed(2)` output + compile-time-constrained label)