### PR TITLE
fix: correct cancelledAtStep recording in spending history

### DIFF
--- a/docs/dev/HypeControl-TODO.md
+++ b/docs/dev/HypeControl-TODO.md
@@ -1,6 +1,6 @@
 # Hype Control - What's Left To Do
 
-**Updated:** 2026-04-29
+**Updated:** 2026-04-30
 **Current Version:** 1.1.2
 **Based On:** HC-Project-Document.md vs. actual codebase audit (MTS was the original project codename)
 
@@ -362,4 +362,17 @@ Added a form-control short-circuit in `isPurchaseButton()` so tier-picker, combo
 
 ---
 
-_Last updated 2026-04-28 against the v1.1.2 codebase. Sub tier dropdown re-trigger fix closed (#48)._
+## CANCEL-STEP TRACKING FIX (v1.1.2)
+
+- [x] **Cancel-step tracking fix (`fix/cancel-step-tracking`)** — `InterceptEvent.cancelledAtStep` now reflects the actual step where the user cancelled. Replaced hardcoded step numbers in `runFrictionFlow`'s intensity-gated branches with a running counter, and added recording on two cancel paths that previously dropped the field entirely (delay-timer cancel, cap-exceedance cancel). Spec: `docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md`.
+
+---
+
+## FOLLOW-UPS
+
+- [ ] **Chat-command cap-exceedance step recording** — `chatCommandInterceptor.ts` cap-exceedance cancel handler does not record `cancelledAtStep`. Same class of bug as the one fixed for the button-click path; deferred so the button-path fix could ship first. Should record `frictionResult.lastStep + 1` similar to the fix in `interceptor.ts`.
+- [ ] **"Top Cancel Step" tile tie-breaker (`history.ts:223`)** — Tie-breaker currently favors the lowest step number; tile may still skew to Step 1 even after recording is fixed. Revisit once real corrected data accumulates; possibly switch to highest-step-wins or show all tied steps.
+
+---
+
+_Last updated 2026-04-30 against the v1.1.2 codebase. Cancel-step tracking fix completed._

--- a/docs/superpowers/plans/2026-04-30-cancel-step-tracking.md
+++ b/docs/superpowers/plans/2026-04-30-cancel-step-tracking.md
@@ -1,0 +1,585 @@
+# Cancel-Step Tracking Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Do NOT bump versions.** Version bumps are out of scope for this plan and are handled by the user via `npm run release`. Subagents must not edit `manifest.json`, `manifest.firefox.json`, or `package.json` version fields.
+
+**Goal:** Fix `InterceptEvent.cancelledAtStep` so it reflects the actual step where the user cancelled, regardless of friction intensity, comparison-item count, or whether a price was detected.
+
+**Architecture:** Replace hardcoded step numbers in `runFrictionFlow` with a running counter (`currentStep`). Precompute total steps once via a pure helper based on price availability, comparison count, intensity, and delay-timer enablement. Surface the final step reached on `FrictionResult.lastStep` so the caller can chain the cap-exceedance step (which lives outside `runFrictionFlow`) as the next step number.
+
+**Tech Stack:** TypeScript, Jest + ts-jest, webpack. Project root at `F:\GDriveClone\Claude_Code\HypeControl`. Branch: `fix/cancel-step-tracking`.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md`
+
+---
+
+## File Plan
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `src/shared/frictionStepCount.ts` | Create | Pure helper `computeTotalSteps`. No DOM dependency — lives in shared so it can be unit-tested without jsdom. |
+| `tests/shared/frictionStepCount.test.ts` | Create | Unit tests covering all conditional branches of `computeTotalSteps`. |
+| `src/content/interceptor.ts` | Modify | Add `lastStep` to `FrictionResult`; refactor `runFrictionFlow` to counter-based; fix delay-timer cancel; update cap-exceedance handler in caller. |
+| `docs/dev/HypeControl-TODO.md` | Modify | Per CLAUDE.md post-work updates: add bug-fix entry, update header date. |
+
+`HC-Project-Document.md` does **not** need updating — this is a bug fix; no feature status changes.
+
+`chatCommandInterceptor.ts` does **not** need updating — it already reads `frictionResult.cancelledAtStep` and writes it through (line 306). The fix propagates automatically.
+
+---
+
+## Task 1: Add `computeTotalSteps` helper (TDD)
+
+**Files:**
+- Create: `src/shared/frictionStepCount.ts`
+- Create: `tests/shared/frictionStepCount.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/shared/frictionStepCount.test.ts` with this exact content:
+
+```typescript
+import { computeTotalSteps } from '../../src/shared/frictionStepCount';
+
+describe('computeTotalSteps', () => {
+  test('low intensity, no price, no delay timer → 1 (main only)', () => {
+    expect(computeTotalSteps(null, 0, 'low', false)).toBe(1);
+  });
+
+  test('low intensity, with price, 3 comparisons, no delay timer → 4', () => {
+    expect(computeTotalSteps(5.99, 3, 'low', false)).toBe(4);
+  });
+
+  test('low intensity, no price, with delay timer → 2 (main + delay)', () => {
+    expect(computeTotalSteps(null, 0, 'low', true)).toBe(2);
+  });
+
+  test('medium intensity, no price, no delay timer → 2 (main + reason)', () => {
+    expect(computeTotalSteps(null, 0, 'medium', false)).toBe(2);
+  });
+
+  test('medium intensity, with price, 1 comparison, no delay timer → 3', () => {
+    expect(computeTotalSteps(5.99, 1, 'medium', false)).toBe(3);
+  });
+
+  test('high intensity, no price, no delay timer → 4 (main + reason + cooldown + type)', () => {
+    expect(computeTotalSteps(null, 0, 'high', false)).toBe(4);
+  });
+
+  test('high intensity, with price, 2 comparisons, with delay timer → 7', () => {
+    // 1 main + 2 comparisons + 3 intensity (reason + cooldown + type) + 1 delay = 7
+    expect(computeTotalSteps(5.99, 2, 'high', true)).toBe(7);
+  });
+
+  test('extreme intensity, with price, 3 comparisons, with delay timer → 9', () => {
+    // 1 main + 3 comparisons + 1 reason + 1 cooldown + 1 math + 1 type + 1 delay = 9
+    expect(computeTotalSteps(5.99, 3, 'extreme', true)).toBe(9);
+  });
+
+  test('extreme intensity, no price, no delay timer → 5 (main + reason + cooldown + math + type)', () => {
+    expect(computeTotalSteps(null, 0, 'extreme', false)).toBe(5);
+  });
+
+  test('comparison count is ignored when price is null', () => {
+    // Even with 5 items configured, no price means no comparison steps.
+    expect(computeTotalSteps(null, 5, 'low', false)).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+npm test -- frictionStepCount
+```
+
+Expected: FAIL — module `../../src/shared/frictionStepCount` not found.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/shared/frictionStepCount.ts` with this exact content:
+
+```typescript
+import { FrictionIntensity } from './types';
+
+/**
+ * Total number of friction windows the user will see for a given configuration.
+ *
+ * The friction flow consists of:
+ * - 1 main overlay (always)
+ * - N comparison-item overlays (only when a price was detected)
+ * - intensity-gated overlays:
+ *     - medium: reason selection (1 step)
+ *     - high: reason + cooldown + type-to-confirm (3 steps)
+ *     - extreme: reason + cooldown + math + type-to-confirm (4 steps)
+ * - 1 delay-timer overlay (only when delayTimer.enabled)
+ */
+export function computeTotalSteps(
+  priceWithTax: number | null,
+  comparisonItemCount: number,
+  intensity: FrictionIntensity,
+  delayTimerEnabled: boolean,
+): number {
+  let total = 1; // main overlay
+  if (priceWithTax !== null) total += comparisonItemCount;
+  if (intensity !== 'low')     total += 1; // reason
+  if (intensity === 'high')    total += 2; // cooldown + type-to-confirm
+  if (intensity === 'extreme') total += 3; // cooldown + math + type-to-confirm
+  if (delayTimerEnabled)       total += 1; // delay timer
+  return total;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm test -- frictionStepCount
+```
+
+Expected: PASS — all 10 test cases pass.
+
+- [ ] **Step 5: Run full test suite to ensure nothing else broke**
+
+```bash
+npm test
+```
+
+Expected: PASS — all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/frictionStepCount.ts tests/shared/frictionStepCount.test.ts
+git commit -m "feat(shared): add computeTotalSteps helper for friction step accounting
+
+Pure helper that computes the total number of friction overlays a user
+will see for a given configuration (price availability, comparison count,
+intensity, delay timer). Used in the next commit to fix step-number
+recording in runFrictionFlow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Refactor `runFrictionFlow` to use the counter
+
+**Files:**
+- Modify: `src/content/interceptor.ts`
+  - `FrictionResult` interface (lines 68-73)
+  - `runFrictionFlow` body (lines 1596-1773)
+
+This task makes coordinated changes that must land together to keep TypeScript happy. Each step is a single targeted edit.
+
+- [ ] **Step 1: Add the import for `computeTotalSteps`**
+
+In `src/content/interceptor.ts`, find the existing imports near the top of the file. Add this import alongside the existing `../shared/...` imports:
+
+```typescript
+import { computeTotalSteps } from '../shared/frictionStepCount';
+```
+
+- [ ] **Step 2: Add `lastStep` field to `FrictionResult` interface**
+
+In `src/content/interceptor.ts`, find this block (around line 68-73):
+
+```typescript
+/** Result returned by runFrictionFlow */
+export interface FrictionResult {
+  decision: OverlayDecision;
+  cancelledAtStep?: number;
+  purchaseReason?: string;
+}
+```
+
+Replace with:
+
+```typescript
+/** Result returned by runFrictionFlow */
+export interface FrictionResult {
+  decision: OverlayDecision;
+  cancelledAtStep?: number;
+  purchaseReason?: string;
+  /** Final step number reached. Populated on both proceed and cancel. On cancel, equals cancelledAtStep. */
+  lastStep: number;
+}
+```
+
+After this edit, TypeScript will report errors at every `runFrictionFlow` return site. We'll fix them in Step 3.
+
+- [ ] **Step 3: Replace the entire `runFrictionFlow` body**
+
+In `src/content/interceptor.ts`, find the function definition starting at line 1596. Replace the entire function body (the function itself, from `async function runFrictionFlow(` through its closing `}` — currently lines 1596-1773) with this exact code:
+
+```typescript
+async function runFrictionFlow(
+  attempt: PurchaseAttempt,
+  settings: UserSettings,
+  tracker: SpendingTracker,
+  maxComparisons?: number,
+  whitelistNote?: string,
+  onWhitelistAdd?: (behavior: WhitelistBehavior) => Promise<void>,
+): Promise<FrictionResult> {
+  let purchaseReason: string | undefined;
+  let currentStep = 1;
+
+  // Step 1: Main overlay
+  const mainDecision = await showMainOverlay(attempt, settings, tracker, whitelistNote, onWhitelistAdd);
+  if (mainDecision === 'cancel') {
+    log('Friction flow: cancelled at Step 1 (main overlay)');
+    return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+  }
+
+  // Compute priceWithTax (null when no price was detected)
+  const priceWithTax = (attempt.priceValue && attempt.priceValue > 0)
+    ? Math.round(attempt.priceValue * (1 + settings.taxRate / 100) * 100) / 100
+    : null;
+
+  if (priceWithTax === null) {
+    log('Friction flow: no price detected, skipping comparison steps');
+  }
+
+  // Compute item pool. Empty when priceWithTax is null (comparison loop will be skipped).
+  const itemPool: ComparisonItem[] = priceWithTax === null
+    ? []
+    : maxComparisons !== undefined
+      ? settings.comparisonItems
+          .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'full')
+          .slice(0, maxComparisons)
+      : settings.comparisonItems
+          .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'nudge');
+
+  // Compute escalated intensity (hoisted from below — pure, no side effects)
+  const maxPercent = computeMaxCapPercent(settings, tracker);
+  const intensity = computeEscalatedIntensity(
+    settings.frictionIntensity ?? 'low',
+    maxPercent,
+    settings.intensityLocked ?? false,
+  );
+
+  // Compute total steps once based on actual conditions.
+  const totalSteps = computeTotalSteps(
+    priceWithTax,
+    itemPool.length,
+    intensity,
+    settings.delayTimer?.enabled ?? false,
+  );
+
+  // Steps 2..(1+itemPool.length): comparison items (only when price detected)
+  if (priceWithTax !== null) {
+    const taxPrice = `$${priceWithTax.toFixed(2)}`;
+    const comparisonSteps: { item: ComparisonItem; display: ComparisonDisplay }[] = [];
+
+    for (const item of itemPool) {
+      const display = formatComparisonDisplay(item, priceWithTax, taxPrice);
+      comparisonSteps.push({ item, display });
+    }
+
+    log(`Friction flow: ${comparisonSteps.length} comparison step(s) (${maxComparisons !== undefined ? 'nudge/enabled only' : 'full/all items'}), priceWithTax=${taxPrice}`);
+
+    for (let i = 0; i < comparisonSteps.length; i++) {
+      const { item, display } = comparisonSteps[i];
+      currentStep++;
+      const decision = await showComparisonStep(item, display, currentStep, totalSteps, attempt);
+      if (decision === 'cancel') {
+        log(`Friction flow: cancelled at Step ${currentStep} (${item.name})`, {
+          stepsCompleted: currentStep - 1,
+          totalSteps,
+        });
+        return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+      }
+    }
+
+    log('Friction flow: completed all comparison steps', {
+      totalSteps,
+      channel: attempt.channel,
+      rawPrice: attempt.rawPrice,
+    });
+  }
+
+  // ── Intensity-gated steps ─────────────────────────────────────────────
+  // For intensity steps we reuse a shared overlay element that each step re-populates.
+  // Note: showReasonSelectionStep appends and removes the overlay itself.
+  // The subsequent steps (cooldown, type-to-confirm, math) expect the overlay to
+  // already be in the DOM (they only set innerHTML and apply theme).
+  // So after reason selection proceeds we must re-append before the next step.
+  let intensityOverlay: HTMLElement | null = null;
+
+  if (intensity === 'medium' || intensity === 'high' || intensity === 'extreme') {
+    intensityOverlay = document.createElement('div');
+    intensityOverlay.id = 'hc-overlay';
+    intensityOverlay.className = 'hc-overlay';
+    intensityOverlay.setAttribute('role', 'dialog');
+    intensityOverlay.setAttribute('aria-modal', 'true');
+    intensityOverlay.setAttribute('aria-labelledby', 'hc-overlay-heading');
+    intensityOverlay.setAttribute('aria-describedby', 'hc-overlay-desc');
+
+    currentStep++;
+    log(`Friction flow: starting reason selection step (step ${currentStep})`);
+    const reasonResult = await showReasonSelectionStep(intensityOverlay);
+    if (reasonResult.decision === 'cancel') {
+      // Overlay was already removed by showReasonSelectionStep; nothing to clean up.
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+    }
+    purchaseReason = reasonResult.reason;
+  }
+
+  if (intensity === 'high' || intensity === 'extreme') {
+    // showReasonSelectionStep removed the overlay from DOM after resolving.
+    // Re-append so cooldown step can operate on it.
+    overlayVisible = true;
+    document.body.appendChild(intensityOverlay!);
+
+    currentStep++;
+    const cooldownSecs = intensity === 'extreme' ? 30 : 10;
+    log(`Friction flow: starting friction cooldown step (${cooldownSecs}s, step ${currentStep})`);
+    const cooldownResult = await showFrictionCooldownStep(intensityOverlay!, cooldownSecs);
+    if (cooldownResult === 'cancel') {
+      removeOverlay(intensityOverlay!);
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+    }
+  }
+
+  if (intensity === 'high') {
+    currentStep++;
+    log(`Friction flow: starting type-to-confirm step (step ${currentStep})`);
+    const typeResult = await showTypeToConfirmStep(intensityOverlay!);
+    if (typeResult === 'cancel') {
+      removeOverlay(intensityOverlay!);
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+    }
+    // All intensity steps done for 'high' — clean up overlay.
+    removeOverlay(intensityOverlay!);
+  }
+
+  if (intensity === 'extreme') {
+    currentStep++;
+    log(`Friction flow: starting math challenge step (step ${currentStep})`);
+    const mathResult = await showMathChallengeStep(intensityOverlay!);
+    if (mathResult === 'cancel') {
+      removeOverlay(intensityOverlay!);
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+    }
+    currentStep++;
+    log(`Friction flow: starting type-to-confirm step (step ${currentStep})`);
+    const typeResult = await showTypeToConfirmStep(intensityOverlay!);
+    if (typeResult === 'cancel') {
+      removeOverlay(intensityOverlay!);
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+    }
+    // All intensity steps done for 'extreme' — clean up overlay.
+    removeOverlay(intensityOverlay!);
+  }
+
+  // ── Standalone Delay Timer (final step) ──────────────────────────────
+  if (settings.delayTimer?.enabled) {
+    currentStep++;
+    log(`Delay timer step starting (${settings.delayTimer.seconds}s, step ${currentStep})`);
+    const delayDecision = await showDelayTimerStep(
+      settings.delayTimer.seconds,
+      attempt,
+    );
+    if (delayDecision === 'cancel') {
+      log('Friction flow: cancelled at delay timer step');
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
+    }
+  }
+
+  return { decision: 'proceed', purchaseReason, lastStep: currentStep };
+}
+```
+
+Key changes embedded in this replacement:
+- New `let currentStep = 1;` counter at top.
+- `priceWithTax`, `itemPool`, `intensity`, and `totalSteps` all computed up front so `totalSteps` is accurate.
+- Comparison loop uses `currentStep++` before each iteration and passes `currentStep`/`totalSteps` to `showComparisonStep`.
+- Every cancel return uses `cancelledAtStep: currentStep` instead of a hardcoded number.
+- Delay-timer cancel now records `cancelledAtStep: currentStep` (was missing).
+- Every return includes `lastStep: currentStep` (required by the new interface).
+- Proceed return at the bottom includes `lastStep: currentStep`.
+
+- [ ] **Step 4: Update the caller's cap-exceedance handler**
+
+In `src/content/interceptor.ts`, find this block (around lines 2006-2019 — inside the function that handles a `frictionResult.decision === 'proceed'` case before the cap-exceedance check):
+
+```typescript
+      if (escalatedDecision === 'cancel') {
+        log('User cancelled at cap exceedance step');
+        await writeInterceptEvent({
+          channel: attempt.channel,
+          purchaseType: attempt.type,
+          rawPrice: attempt.rawPrice,
+          priceWithTax,
+          outcome: 'cancelled',
+          savedAmount: priceWithTax ?? 0,
+          purchaseReason: frictionResult.purchaseReason,
+        });
+        pendingPurchase = null;
+        return;
+      }
+```
+
+Replace with:
+
+```typescript
+      if (escalatedDecision === 'cancel') {
+        log('User cancelled at cap exceedance step');
+        await writeInterceptEvent({
+          channel: attempt.channel,
+          purchaseType: attempt.type,
+          rawPrice: attempt.rawPrice,
+          priceWithTax,
+          outcome: 'cancelled',
+          cancelledAtStep: frictionResult.lastStep + 1,
+          savedAmount: priceWithTax ?? 0,
+          purchaseReason: frictionResult.purchaseReason,
+        });
+        pendingPurchase = null;
+        return;
+      }
+```
+
+The only change is the added `cancelledAtStep: frictionResult.lastStep + 1` line. Cap-exceedance is the step *after* the last friction window the user passed.
+
+- [ ] **Step 5: Run the full test suite to confirm types compile and nothing regressed**
+
+```bash
+npm test
+```
+
+Expected: PASS — all tests still pass (no test was added for the integration; type-checking is performed by ts-jest).
+
+- [ ] **Step 6: Run a production build to confirm webpack accepts the changes**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no TypeScript errors.
+
+If the build fails for non-TypeScript reasons (e.g., environment, file lock), do **not** retry — surface the failure to the user per CLAUDE.md.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/content/interceptor.ts
+git commit -m "fix(interceptor): correct cancelledAtStep recording with running counter
+
+Replaces hardcoded step numbers in runFrictionFlow's intensity-gated
+branches with a single running counter (currentStep) that increments
+before each window. Also fixes two cancel paths that previously did not
+record cancelledAtStep at all:
+
+- Delay-timer cancel (was returning {decision: 'cancel'} with no step)
+- Cap-exceedance cancel (was writing the InterceptEvent without the field)
+
+Adds FrictionResult.lastStep so the cap-exceedance handler — which runs
+in the caller after runFrictionFlow returns proceed — can record the
+correct step number (lastStep + 1).
+
+Spec: docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Manual smoke test verification
+
+This task is performed by the user in a real Chrome browser running the unpacked extension. No code changes happen here — but the plan must explicitly capture the verification before we ship.
+
+The implementing engineer/agent should:
+
+- [ ] **Step 1: Build the extension for development**
+
+```bash
+npm run build
+```
+
+Then load the `dist/` directory as an unpacked extension in Chrome (or refresh it if already loaded).
+
+- [ ] **Step 2: Walk through the verification matrix**
+
+For each scenario, configure settings via the options page, trigger the friction flow on a Twitch page (or via the demo overlay button), cancel at the indicated step, then open the spending history (`chrome-extension://<extension-id>/history.html`), expand the row, and confirm the displayed step number.
+
+| # | Configuration | Cancel at | Expected `Cancelled at Step` |
+| --- | --- | --- | --- |
+| 1 | Any | Main overlay | `Step 1` |
+| 2 | Low intensity, price detected, full friction with 3 enabled comparison items | Comparison item #2 | `Step 3` |
+| 3 | Medium intensity, **zero-trust** mode, click a no-price button | Reason selection | `Step 2` |
+| 4 | High intensity, price detected, full friction with 3 comparison items | Cooldown timer | `Step 6` |
+| 5 | Extreme intensity, price detected, full friction with 3 comparison items | Math challenge | `Step 7` |
+| 6 | Low intensity, no comparisons enabled, delay timer enabled | Delay timer | `Step 2` |
+| 7 | Any intensity, daily cap configured to be exceeded by the test purchase, complete all friction | Cap-exceedance step | `Step (lastStep + 1)` (varies) |
+
+For scenarios 6 and 7, before this fix the row would have **no** "Cancelled at Step" field in the detail panel. After this fix the field must appear with the expected number.
+
+- [ ] **Step 3: Document any deviations**
+
+If any scenario produces an unexpected number, capture:
+- Settings used (intensity, comparison items enabled, delay timer state).
+- Channel and purchase type.
+- Where you cancelled.
+- The number shown.
+
+Surface to the user before proceeding to Task 4.
+
+---
+
+## Task 4: Update the project TODO
+
+**File:**
+- Modify: `docs/dev/HypeControl-TODO.md`
+
+- [ ] **Step 1: Read the current file to find the right section**
+
+```bash
+head -40 docs/dev/HypeControl-TODO.md
+```
+
+Locate the header (which contains `Updated:` and `Current Version:` fields) and any "Bug Fixes" or recent-fixes section. If no bug-fixes section exists, add the entry under the most recently completed feature group with a clear "Bug Fixes" heading.
+
+- [ ] **Step 2: Update the header date**
+
+Set `Updated:` to `2026-04-30`. Do **not** change `Current Version:` — version bumps are out of scope.
+
+- [ ] **Step 3: Add the bug-fix entry**
+
+Add a new bullet under the appropriate bug-fixes section:
+
+```markdown
+- [x] **Cancel-step tracking fix (`fix/cancel-step-tracking`)** — `InterceptEvent.cancelledAtStep` now reflects the actual step where the user cancelled. Replaced hardcoded step numbers in `runFrictionFlow`'s intensity-gated branches with a running counter, and added recording on two cancel paths that previously dropped the field entirely (delay-timer cancel, cap-exceedance cancel). Spec: `docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md`.
+```
+
+- [ ] **Step 4: Update footer timestamp if present**
+
+If the file ends with a timestamp like `_Last updated: YYYY-MM-DD_`, update it to `2026-04-30`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/dev/HypeControl-TODO.md
+git commit -m "docs(todo): record cancel-step tracking fix
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist (for the implementer)
+
+After all four tasks, verify:
+
+- [ ] `npm test` passes with all new and existing tests green.
+- [ ] `npm run build` succeeds without TypeScript errors.
+- [ ] All seven manual smoke-test scenarios in Task 3 produce the expected step numbers.
+- [ ] No version fields in `manifest.json`, `manifest.firefox.json`, or `package.json` were edited.
+- [ ] Branch is `fix/cancel-step-tracking`. PR is opened against `main` but **not merged** without explicit user approval (per CLAUDE.md global rule).
+
+## Out of scope (do not implement here)
+
+- "Top Cancel Step" tile tie-breaker on `history.ts:223` — deferred to a follow-up PR pending observation of corrected data.
+- "Step X of Y" headers on intensity-gated modals — those modals do not currently render a step counter; not adding new UI.
+- Any change to `chatCommandInterceptor.ts` — it already reads `frictionResult.cancelledAtStep` correctly and benefits from the fix automatically.
+- Version bumps and release builds — handled by the user via `npm run release` after the PR merges.

--- a/docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md
@@ -1,0 +1,141 @@
+# Cancel-Step Tracking Fix — Design
+
+**Date:** 2026-04-30
+**Branch:** `fix/cancel-step-tracking`
+**Scope:** Bug fix — `InterceptEvent.cancelledAtStep` recording in the spending history.
+
+## Problem
+
+The spending history view (`history.html`) shows incorrect or missing "Cancelled at Step" values for cancelled events. Per-row detail panels report wrong step numbers, and some cancel paths produce events with no step recorded at all.
+
+The user-visible symptom: cancel-step values do not reflect where the user actually cancelled. The "Top Cancel Step" summary tile is dominated by Step 1 because data at later steps is either mislabeled or missing.
+
+## Root cause
+
+Three independent issues in `runFrictionFlow` (`src/content/interceptor.ts`) and its caller:
+
+### 1. Hardcoded step numbers in intensity-gated branches
+
+Lines 1706, 1722, 1732, 1744, 1751 return hardcoded step numbers (`3`, `4`, `5`, `5`, `6`) on cancel. These were correct under one assumption: `1 main + 1 comparison + intensity steps`. That assumption holds only when `softNudgeSteps === 1` and a price was detected — which is the minority case.
+
+Examples of breakage:
+- Zero-trust mode + no detected price → comparison loop is skipped → reason step is actually step 2, not step 3.
+- Full friction with 3 comparison items → reason step is actually step 5, not step 3 (and step 3 collides with comparison item #2's number).
+- Full friction with 3 comparison items + high intensity → cooldown is actually step 6, not step 4.
+
+### 2. Two cancel paths don't record `cancelledAtStep` at all
+
+- **Delay-timer cancel** (`interceptor.ts:1768`) returns `{ decision: 'cancel' }` with no step.
+- **Cap-exceedance cancel** (`interceptor.ts:2008-2016`) writes the InterceptEvent without `cancelledAtStep`.
+
+Both result in `cancelledAtStep === undefined`, which causes `history.ts:291` to silently omit the "Cancelled at Step" detail field for those rows.
+
+### 3. (Out of scope) "Top Cancel Step" tile tie-breaker
+
+`history.ts:223` favors the lowest step number on ties. Once recording is fixed, this may or may not still be a problem. Deferred per design decision — revisit after observing real corrected data.
+
+## Approach
+
+Replace hardcoded step numbers with a single running counter inside `runFrictionFlow`. Precompute `totalSteps` once. Every cancel returns the counter's current value. The function returns the final step it reached so the caller can chain the cap-exceedance step as the next number.
+
+This mirrors the natural mental model of the flow ("which window am I on?") and removes the assumption-based numbering that caused Issue #1. It also makes the "Step X of Y" display on comparison modals correct without changing the modal-rendering code itself — `Y` becomes accurate because we compute it from the same set of conditions that drive the flow.
+
+## Changes
+
+### 1. `runFrictionFlow` (`src/content/interceptor.ts:1596`)
+
+- Declare `let currentStep = 1;` at the top (the main overlay is always step 1).
+- Compute total steps upfront with a new helper:
+  ```ts
+  const totalSteps = computeTotalSteps(
+    priceWithTax,
+    itemPool.length,
+    intensity,
+    settings.delayTimer.enabled,
+  );
+  ```
+- Increment `currentStep` immediately before each subsequent window:
+  - Each iteration of the comparison loop.
+  - Reason step.
+  - Cooldown step.
+  - Type-to-confirm step (high intensity).
+  - Math challenge step (extreme intensity).
+  - Type-to-confirm step (after math, extreme intensity).
+  - Delay timer step.
+- Replace every `cancelledAtStep: <hardcoded>` return with `cancelledAtStep: currentStep`.
+- Fix the delay-timer cancel path to include `cancelledAtStep: currentStep`.
+- Pass the corrected `totalSteps` to `showComparisonStep` (replaces the local `totalSteps = 1 + comparisonSteps.length` calculation, which understates `Y` when intensity steps also run).
+
+### 2. New helper: `computeTotalSteps`
+
+```ts
+function computeTotalSteps(
+  priceWithTax: number | null,
+  comparisonItemCount: number,
+  intensity: FrictionIntensity,
+  delayTimerEnabled: boolean,
+): number {
+  let total = 1; // main overlay
+  if (priceWithTax !== null) total += comparisonItemCount;
+  if (intensity !== 'low')     total += 1; // reason
+  if (intensity === 'high')    total += 2; // cooldown + type-to-confirm
+  if (intensity === 'extreme') total += 3; // cooldown + math + type-to-confirm
+  if (delayTimerEnabled)       total += 1; // delay timer
+  return total;
+}
+```
+
+Lives in `interceptor.ts` near `runFrictionFlow`. Pure function, no side effects.
+
+### 3. `FrictionResult` interface (`src/content/interceptor.ts:68-73`)
+
+Add a new field:
+
+```ts
+export interface FrictionResult {
+  decision: OverlayDecision;
+  cancelledAtStep?: number;
+  purchaseReason?: string;
+  lastStep: number; // final step number reached, populated on both proceed and cancel
+}
+```
+
+`lastStep` is populated unconditionally so the caller can use it to compute the next step number (for cap-exceedance). On cancel, `lastStep === cancelledAtStep`.
+
+### 4. Caller's cap-exceedance handler (`src/content/interceptor.ts:2008-2016`)
+
+When the user cancels at the cap-exceedance step (which runs *after* `runFrictionFlow` returns proceed), record:
+
+```ts
+cancelledAtStep: frictionResult.lastStep + 1,
+```
+
+This positions cap-exceedance correctly as the step immediately after the last friction window the user passed.
+
+## Out of scope
+
+- **"Top Cancel Step" tile tie-breaker** (`history.ts:223`). Deferred — revisit after observing post-fix data. Tracked as a future PR if still problematic.
+- **"Step X of Y" headers on intensity-gated modals.** These modals do not currently render a step counter in their UI. We are not adding one.
+- **`chatCommandInterceptor.ts`.** Already reads `frictionResult.cancelledAtStep` and writes it through (line 306). The fix propagates automatically; no changes required in this file.
+
+## Testing
+
+Manual smoke testing covers each fix scenario. Trigger via real Twitch purchase buttons or the demo-overlay action.
+
+| Scenario | Expected `cancelledAtStep` | Pre-fix bug |
+| --- | --- | --- |
+| Cancel at main overlay | `1` | (correct already) |
+| Cancel at comparison item index `i` (0-based) | `i + 2` | (correct already) |
+| Zero-trust + no detected price + medium intensity, cancel at reason | `2` | Hardcoded `3` |
+| Full friction with 3 enabled comparison items, high intensity, cancel at cooldown | `6` | Hardcoded `4` |
+| Full friction with 3 enabled comparison items, extreme intensity, cancel at math | `7` | Hardcoded `5` |
+| Delay timer enabled, low intensity, no comparisons (price null), cancel at delay timer | `2` | Missing entirely (`undefined`) |
+| All friction passed, cancel at cap-exceedance | `lastStep + 1` (varies) | Missing entirely (`undefined`) |
+
+After the fix:
+- Per-row detail panels in `history.html` show the correct step number for every cancelled event.
+- "Step X of Y" headers on comparison modals show correct `Y` when intensity steps also run.
+
+## Follow-ups
+
+- Observe whether the "Top Cancel Step" summary tile still skews to Step 1 once real data accumulates with corrected recording. If so, open a follow-up PR to revisit the tie-breaker (`history.ts:223`).

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hype Control",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "icons": {
     "16": "assets/icons/ChromeWebStore/HC_icon_16px.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hype-control",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Friction between your wallet and the hype train. Spending caps, cooldown timers, and reality checks before Twitch purchases.",
   "scripts": {
     "build": "webpack --mode production",

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -1621,6 +1621,7 @@ async function runFrictionFlow(
 
   if (priceWithTax === null) {
     log('Friction flow: no price detected, skipping comparison steps');
+    // Zero Trust mode can reach here — intensity steps still run without a price.
   }
 
   // Compute item pool. Empty when priceWithTax is null (comparison loop will be skipped).

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -18,6 +18,7 @@ import { writeInterceptEvent } from '../shared/interceptLogger';
 import { computeEscalatedIntensity, computeMaxCapPercent } from '../shared/escalation';
 import { loadSpendingTracker, recordPurchase } from '../shared/spendingTracker';
 import { buildCapProgressBar } from '../shared/capBar';
+import { computeTotalSteps } from '../shared/frictionStepCount';
 
 // ── Zero Trust no-price overlay messages ────────────────────────────────
 // Two tonal buckets: matter-of-fact and cheeky. Selection alternates buckets
@@ -70,6 +71,8 @@ export interface FrictionResult {
   decision: OverlayDecision;
   cancelledAtStep?: number;
   purchaseReason?: string;
+  /** Final step number reached. Populated on both proceed and cancel. On cancel, equals cancelledAtStep. */
+  lastStep: number;
 }
 
 /** Storage keys */
@@ -1602,35 +1605,52 @@ async function runFrictionFlow(
   onWhitelistAdd?: (behavior: WhitelistBehavior) => Promise<void>,
 ): Promise<FrictionResult> {
   let purchaseReason: string | undefined;
+  let currentStep = 1;
 
   // Step 1: Main overlay
   const mainDecision = await showMainOverlay(attempt, settings, tracker, whitelistNote, onWhitelistAdd);
   if (mainDecision === 'cancel') {
     log('Friction flow: cancelled at Step 1 (main overlay)');
-    return { decision: 'cancel', cancelledAtStep: 1 };
+    return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
   }
 
-  // Build comparison steps — only when price is detected
+  // Compute priceWithTax (null when no price was detected)
   const priceWithTax = (attempt.priceValue && attempt.priceValue > 0)
     ? Math.round(attempt.priceValue * (1 + settings.taxRate / 100) * 100) / 100
     : null;
 
   if (priceWithTax === null) {
     log('Friction flow: no price detected, skipping comparison steps');
-    // Price Guard would never reach here (determineFrictionLevel returns 'none').
-    // Zero Trust continues to intensity steps below — fall through.
   }
 
-  if (priceWithTax !== null) {
-    // nudge: enabled items where scope is 'nudge' or 'both', limited to softNudgeSteps
-    // full: enabled items where scope is 'full' or 'both' (scope replaces the old "all items" behavior)
-    const itemPool = maxComparisons !== undefined
+  // Compute item pool. Empty when priceWithTax is null (comparison loop will be skipped).
+  const itemPool: ComparisonItem[] = priceWithTax === null
+    ? []
+    : maxComparisons !== undefined
       ? settings.comparisonItems
           .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'full')
           .slice(0, maxComparisons)
       : settings.comparisonItems
           .filter(i => i.enabled && (i.frictionScope ?? 'both') !== 'nudge');
 
+  // Compute escalated intensity (hoisted from below — pure, no side effects)
+  const maxPercent = computeMaxCapPercent(settings, tracker);
+  const intensity = computeEscalatedIntensity(
+    settings.frictionIntensity ?? 'low',
+    maxPercent,
+    settings.intensityLocked ?? false,
+  );
+
+  // Compute total steps once based on actual conditions.
+  const totalSteps = computeTotalSteps(
+    priceWithTax,
+    itemPool.length,
+    intensity,
+    settings.delayTimer?.enabled ?? false,
+  );
+
+  // Steps 2..(1+itemPool.length): comparison items (only when price detected)
+  if (priceWithTax !== null) {
     const taxPrice = `$${priceWithTax.toFixed(2)}`;
     const comparisonSteps: { item: ComparisonItem; display: ComparisonDisplay }[] = [];
 
@@ -1639,30 +1659,18 @@ async function runFrictionFlow(
       comparisonSteps.push({ item, display });
     }
 
-    // Total steps = 1 (main) + N (comparisons)
-    const totalSteps = 1 + comparisonSteps.length;
-
     log(`Friction flow: ${comparisonSteps.length} comparison step(s) (${maxComparisons !== undefined ? 'nudge/enabled only' : 'full/all items'}), priceWithTax=${taxPrice}`);
-
-    // Steps 2+: Each comparison item
-    // We need a reference to the last overlay shown so we can pass it to subsequent steps.
-    // Comparison steps each create their own overlay element; after the loop we need
-    // the most-recently-created overlay for the intensity steps below.
-    // showComparisonStep creates its own overlay internally, so we capture it via a
-    // wrapper that returns it. For now, we create a placeholder overlay to reuse for
-    // the intensity steps (it will be re-populated by each step function).
 
     for (let i = 0; i < comparisonSteps.length; i++) {
       const { item, display } = comparisonSteps[i];
-      const stepNumber = i + 2; // Step 1 was the main overlay
-
-      const decision = await showComparisonStep(item, display, stepNumber, totalSteps, attempt);
+      currentStep++;
+      const decision = await showComparisonStep(item, display, currentStep, totalSteps, attempt);
       if (decision === 'cancel') {
-        log(`Friction flow: cancelled at Step ${stepNumber} (${item.name})`, {
-          stepsCompleted: stepNumber - 1,
+        log(`Friction flow: cancelled at Step ${currentStep} (${item.name})`, {
+          stepsCompleted: currentStep - 1,
           totalSteps,
         });
-        return { decision: 'cancel', cancelledAtStep: stepNumber };
+        return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
       }
     }
 
@@ -1674,21 +1682,14 @@ async function runFrictionFlow(
   }
 
   // ── Intensity-gated steps ─────────────────────────────────────────────
-  // For steps 3+, we reuse a shared overlay element that each step re-populates.
+  // For intensity steps we reuse a shared overlay element that each step re-populates.
   // Note: showReasonSelectionStep appends and removes the overlay itself.
   // The subsequent steps (cooldown, type-to-confirm, math) expect the overlay to
   // already be in the DOM (they only set innerHTML and apply theme).
   // So after reason selection proceeds we must re-append before the next step.
   let intensityOverlay: HTMLElement | null = null;
-  const maxPercent = computeMaxCapPercent(settings, tracker);
-  const intensity = computeEscalatedIntensity(
-    settings.frictionIntensity ?? 'low',
-    maxPercent,
-    settings.intensityLocked ?? false,
-  );
 
   if (intensity === 'medium' || intensity === 'high' || intensity === 'extreme') {
-    // Create the shared overlay element for intensity steps
     intensityOverlay = document.createElement('div');
     intensityOverlay.id = 'hc-overlay';
     intensityOverlay.className = 'hc-overlay';
@@ -1697,13 +1698,12 @@ async function runFrictionFlow(
     intensityOverlay.setAttribute('aria-labelledby', 'hc-overlay-heading');
     intensityOverlay.setAttribute('aria-describedby', 'hc-overlay-desc');
 
-    // Step 3: Reason selection
-    // showReasonSelectionStep manages its own append/remove lifecycle.
-    log('Friction flow: starting reason selection step (step 3)');
+    currentStep++;
+    log(`Friction flow: starting reason selection step (step ${currentStep})`);
     const reasonResult = await showReasonSelectionStep(intensityOverlay);
     if (reasonResult.decision === 'cancel') {
       // Overlay was already removed by showReasonSelectionStep; nothing to clean up.
-      return { decision: 'cancel', cancelledAtStep: 3 };
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
     }
     purchaseReason = reasonResult.reason;
   }
@@ -1714,62 +1714,62 @@ async function runFrictionFlow(
     overlayVisible = true;
     document.body.appendChild(intensityOverlay!);
 
+    currentStep++;
     const cooldownSecs = intensity === 'extreme' ? 30 : 10;
-    log(`Friction flow: starting friction cooldown step (${cooldownSecs}s, step 4)`);
+    log(`Friction flow: starting friction cooldown step (${cooldownSecs}s, step ${currentStep})`);
     const cooldownResult = await showFrictionCooldownStep(intensityOverlay!, cooldownSecs);
     if (cooldownResult === 'cancel') {
       removeOverlay(intensityOverlay!);
-      return { decision: 'cancel', cancelledAtStep: 4 };
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
     }
   }
 
   if (intensity === 'high') {
-    // intensityOverlay is still in the DOM (cooldown step didn't remove it).
-    log('Friction flow: starting type-to-confirm step (step 5)');
+    currentStep++;
+    log(`Friction flow: starting type-to-confirm step (step ${currentStep})`);
     const typeResult = await showTypeToConfirmStep(intensityOverlay!);
     if (typeResult === 'cancel') {
       removeOverlay(intensityOverlay!);
-      return { decision: 'cancel', cancelledAtStep: 5 };
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
     }
     // All intensity steps done for 'high' — clean up overlay.
     removeOverlay(intensityOverlay!);
   }
 
   if (intensity === 'extreme') {
-    // intensityOverlay is still in the DOM (cooldown step didn't remove it).
-    log('Friction flow: starting math challenge step (step 5)');
+    currentStep++;
+    log(`Friction flow: starting math challenge step (step ${currentStep})`);
     const mathResult = await showMathChallengeStep(intensityOverlay!);
     if (mathResult === 'cancel') {
       removeOverlay(intensityOverlay!);
-      return { decision: 'cancel', cancelledAtStep: 5 };
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
     }
-    // Math passed — proceed to type-to-confirm (step 6). Overlay stays in DOM.
-    log('Friction flow: starting type-to-confirm step (step 6)');
+    currentStep++;
+    log(`Friction flow: starting type-to-confirm step (step ${currentStep})`);
     const typeResult = await showTypeToConfirmStep(intensityOverlay!);
     if (typeResult === 'cancel') {
       removeOverlay(intensityOverlay!);
-      return { decision: 'cancel', cancelledAtStep: 6 };
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
     }
     // All intensity steps done for 'extreme' — clean up overlay.
     removeOverlay(intensityOverlay!);
   }
 
-  // For 'medium' intensity: reason step removed overlay itself; no extra cleanup needed.
-
   // ── Standalone Delay Timer (final step) ──────────────────────────────
   if (settings.delayTimer?.enabled) {
-    log(`Delay timer step starting (${settings.delayTimer.seconds}s)`);
+    currentStep++;
+    log(`Delay timer step starting (${settings.delayTimer.seconds}s, step ${currentStep})`);
     const delayDecision = await showDelayTimerStep(
       settings.delayTimer.seconds,
       attempt,
     );
     if (delayDecision === 'cancel') {
       log('Friction flow: cancelled at delay timer step');
-      return { decision: 'cancel' };
+      return { decision: 'cancel', cancelledAtStep: currentStep, lastStep: currentStep };
     }
   }
 
-  return { decision: 'proceed', purchaseReason };
+  return { decision: 'proceed', purchaseReason, lastStep: currentStep };
 }
 
 export function showBudgetToast(
@@ -2011,6 +2011,7 @@ async function handleClick(event: MouseEvent): Promise<void> {
           rawPrice: attempt.rawPrice,
           priceWithTax,
           outcome: 'cancelled',
+          cancelledAtStep: frictionResult.lastStep + 1,
           savedAmount: priceWithTax ?? 0,
           purchaseReason: frictionResult.purchaseReason,
         });

--- a/src/shared/frictionStepCount.ts
+++ b/src/shared/frictionStepCount.ts
@@ -1,0 +1,28 @@
+import { FrictionIntensity } from './types';
+
+/**
+ * Total number of friction windows the user will see for a given configuration.
+ *
+ * The friction flow consists of:
+ * - 1 main overlay (always)
+ * - N comparison-item overlays (only when a price was detected)
+ * - intensity-gated overlays:
+ *     - medium: reason selection (1 step)
+ *     - high: reason + cooldown + type-to-confirm (3 steps)
+ *     - extreme: reason + cooldown + math + type-to-confirm (4 steps)
+ * - 1 delay-timer overlay (only when delayTimer.enabled)
+ */
+export function computeTotalSteps(
+  priceWithTax: number | null,
+  comparisonItemCount: number,
+  intensity: FrictionIntensity,
+  delayTimerEnabled: boolean,
+): number {
+  let total = 1; // main overlay
+  if (priceWithTax !== null) total += comparisonItemCount;
+  if (intensity !== 'low')     total += 1; // reason
+  if (intensity === 'high')    total += 2; // cooldown + type-to-confirm
+  if (intensity === 'extreme') total += 3; // cooldown + math + type-to-confirm
+  if (delayTimerEnabled)       total += 1; // delay timer
+  return total;
+}

--- a/tests/shared/frictionStepCount.test.ts
+++ b/tests/shared/frictionStepCount.test.ts
@@ -1,0 +1,46 @@
+import { computeTotalSteps } from '../../src/shared/frictionStepCount';
+
+describe('computeTotalSteps', () => {
+  test('low intensity, no price, no delay timer → 1 (main only)', () => {
+    expect(computeTotalSteps(null, 0, 'low', false)).toBe(1);
+  });
+
+  test('low intensity, with price, 3 comparisons, no delay timer → 4', () => {
+    expect(computeTotalSteps(5.99, 3, 'low', false)).toBe(4);
+  });
+
+  test('low intensity, no price, with delay timer → 2 (main + delay)', () => {
+    expect(computeTotalSteps(null, 0, 'low', true)).toBe(2);
+  });
+
+  test('medium intensity, no price, no delay timer → 2 (main + reason)', () => {
+    expect(computeTotalSteps(null, 0, 'medium', false)).toBe(2);
+  });
+
+  test('medium intensity, with price, 1 comparison, no delay timer → 3', () => {
+    expect(computeTotalSteps(5.99, 1, 'medium', false)).toBe(3);
+  });
+
+  test('high intensity, no price, no delay timer → 4 (main + reason + cooldown + type)', () => {
+    expect(computeTotalSteps(null, 0, 'high', false)).toBe(4);
+  });
+
+  test('high intensity, with price, 2 comparisons, with delay timer → 7', () => {
+    // 1 main + 2 comparisons + 3 intensity (reason + cooldown + type) + 1 delay = 7
+    expect(computeTotalSteps(5.99, 2, 'high', true)).toBe(7);
+  });
+
+  test('extreme intensity, with price, 3 comparisons, with delay timer → 9', () => {
+    // 1 main + 3 comparisons + 1 reason + 1 cooldown + 1 math + 1 type + 1 delay = 9
+    expect(computeTotalSteps(5.99, 3, 'extreme', true)).toBe(9);
+  });
+
+  test('extreme intensity, no price, no delay timer → 5 (main + reason + cooldown + math + type)', () => {
+    expect(computeTotalSteps(null, 0, 'extreme', false)).toBe(5);
+  });
+
+  test('comparison count is ignored when price is null', () => {
+    // Even with 5 items configured, no price means no comparison steps.
+    expect(computeTotalSteps(null, 5, 'low', false)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded step numbers in `runFrictionFlow`'s intensity-gated branches with a running counter (`currentStep`) that increments before each window.
- Fix two cancel paths that were dropping `cancelledAtStep` entirely: the delay-timer cancel return and the cap-exceedance cancel handler in the caller.
- Add `FrictionResult.lastStep` so the cap-exceedance handler (which runs outside `runFrictionFlow`) can record the correct step number as `lastStep + 1`.
- Compute `totalSteps` up front via a new `computeTotalSteps` helper so "Step X of Y" on comparison modals stays correct when intensity steps also run.

The user-visible bug: every cancelled row in the spending history view either showed the wrong step number (hardcoded numbers assumed `1 main + 1 comparison + intensity`, wrong for almost any other config) or had no "Cancelled at Step" field at all (delay-timer + cap-exceedance paths).

## Documents

- Spec: [`docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md`](../blob/fix/cancel-step-tracking/docs/superpowers/specs/2026-04-30-cancel-step-tracking-design.md)
- Plan: [`docs/superpowers/plans/2026-04-30-cancel-step-tracking.md`](../blob/fix/cancel-step-tracking/docs/superpowers/plans/2026-04-30-cancel-step-tracking.md)

## Out of scope (tracked as follow-ups in `HypeControl-TODO.md`)

- Same class of bug in `chatCommandInterceptor.ts` cap-exceedance handler — deferred so this fix could ship first.
- "Top Cancel Step" tile tie-breaker on `history.ts:223` — wait for real corrected data before deciding lowest-wins vs highest-wins.

## Test plan

- [x] `npm test` — 138 tests pass (10 new for `computeTotalSteps`).
- [x] `npm run build` — clean Chrome build, no TS errors.
- [x] Manual smoke test in Chrome:
  - [x] Cancel at main overlay → Step 1
  - [x] Cancel at comparison item #2 (full friction, 3 items) → Step 3
  - [x] Cancel at reason step (medium intensity, zero-trust, no price) → Step 2 (was hardcoded 3)
  - [x] Cancel at cooldown (high intensity, 3 comparisons) → Step 6 (was hardcoded 4)
  - [x] Cancel at math challenge (extreme intensity, 3 comparisons) → Step 7 (was hardcoded 5)
  - [x] Cancel at delay timer (low intensity, no comparisons, delay enabled) → Step 2 (was missing)
  - [x] Cancel at cap-exceedance after passing all friction → `lastStep + 1` (was missing)
- [x] `/security-review` — no findings.